### PR TITLE
Add ORCID support; make social links optional

### DIFF
--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,11 +1,12 @@
 <div class="social">
   <span class="contacticon center">
-    <a href="mailto:{{ site.email | encode_email }}"><i class="fas fa-envelope"></i></a>
-    <a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}" target="_blank" title="Google Scholar"><i class="ai ai-google-scholar"></i></a>
-    <a href="https://github.com/{{ site.github_username }}" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>
-    <a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>
-    <a href="https://twitter.com/{{ site.twitter_username }}" target="_blank" title="Twitter"><i class="fab fa-twitter"></i></a>
-    <a href="https://www.strava.com/athletes/{{ site.strava_userid }}" target="_blank" title="Strava"><i class="fab fa-strava"></i></a>
+    {%- if site.email -%}<a href="mailto:{{ site.email | encode_email }}"><i class="fas fa-envelope"></i></a>{%- endif -%}
+    {%- if site.orcid_id -%}<a href="https://orcid.org/{{ site.orcid_id }}" target="_blank" title="ORCID"><i class="ai ai-orcid"></i></a>{%- endif -%}
+    {%- if site.scholar_userid -%}<a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}" target="_blank" title="Google Scholar"><i class="ai ai-google-scholar"></i></a>{%- endif -%}
+    {%- if site.github_username -%}<a href="https://github.com/{{ site.github_username }}" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>{%- endif -%}
+    {%- if site.linkedin_username -%}<a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank" title="LinkedIn"><i class="fab fa-linkedin"></i></a>{%- endif -%}
+    {%- if site.twitter_username -%}<a href="https://twitter.com/{{ site.twitter_username }}" target="_blank" title="Twitter"><i class="fab fa-twitter"></i></a>{%- endif -%}
+    {%- if site.strava_userid -%}<a href="https://www.strava.com/athletes/{{ site.strava_userid }}" target="_blank" title="Strava"><i class="fab fa-strava"></i></a>{%- endif -%}
   </span>
 
   <div class="col three caption">


### PR DESCRIPTION
This adds ORCID to the social profiles allowed by default, and only shows links if they are included in the site configuration.