### PR TITLE
Alignfix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Maruan Al-Shedivat.
+Copyright (c) 2018 Maruan Al-Shedivat.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ By default, the script uses the `master` branch for the source code and deploys 
 The optional flag `--user` tells it to deploy to `master` and use `source` for the source code instead.
 Using `master` for deployment is a convention for [user and organization pages](https://help.github.com/articles/user-organization-and-project-pages/).
 
-**Note:** when deploying your user or organization page, make the `_config.yml` has `url` and `baseurl` fields as follows.
+**Note:** when deploying your user or organization page, make sure the `_config.yml` has `url` and `baseurl` fields as follows.
 
 ```
 url: # should be empty
 baseurl:  # should be empty
 ```
+
+### Usage ###
+
+Note that `_pages/about.md` is built to index.html in the published site. There is therefore no need to have a separate index page for the project. If an index page does exist in the root directory then this will prevent `_pages/about.md` from being added to the built site.
 
 ## Features
 
@@ -100,4 +104,4 @@ Style improvements and bug fixes are especially welcome.
 
 ## License
 
-MIT
+The theme is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ url: # should be empty
 baseurl:  # should be empty
 ```
 
-### Usage ###
+### Usage
 
 Note that `_pages/about.md` is built to index.html in the published site. There is therefore no need to have a separate index page for the project. If an index page does exist in the root directory then this will prevent `_pages/about.md` from being added to the built site.
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ footer_text: >
   Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
 
 url:  # the base hostname & protocol for your site
-baseurl: /al-folio # the subpath of your site, e.g. /blog/
+baseurl: # the subpath of your site, e.g. /blog/
 last_updated: # leave blank if you don't want to display last updated
 
 # -----------------------------------------------------------------------------

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ footer_text: >
   Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
 
 url:  # the base hostname & protocol for your site
-baseurl: # the subpath of your site, e.g. /blog/
+baseurl: /al-folio # the subpath of your site, e.g. /blog/
 last_updated: # leave blank if you don't want to display last updated
 
 # -----------------------------------------------------------------------------

--- a/_projects/1_project.markdown
+++ b/_projects/1_project.markdown
@@ -18,15 +18,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -36,8 +36,8 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
@@ -50,6 +50,6 @@ You can also put regular text between your rows of images. Say you wanted to wri
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>

--- a/_projects/2_project.markdown
+++ b/_projects/2_project.markdown
@@ -18,15 +18,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -36,20 +36,20 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
 </div>
 
 
-<br/><br/><br/>
+<br/><br/>
 
 
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>

--- a/_projects/3_project.markdown
+++ b/_projects/3_project.markdown
@@ -19,15 +19,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -37,20 +37,21 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
 </div>
 
 
-<br/><br/><br/>
+<br/><br/>
 
 
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>
+

--- a/_projects/4_project.markdown
+++ b/_projects/4_project.markdown
@@ -18,15 +18,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -36,20 +36,21 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
 </div>
 
 
-<br/><br/><br/>
+<br/><br/>
 
 
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>
+

--- a/_projects/5_project.markdown
+++ b/_projects/5_project.markdown
@@ -18,15 +18,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -36,20 +36,21 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
 </div>
 
 
-<br/><br/><br/>
+<br/><br/>
 
 
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>
+

--- a/_projects/6_project.markdown
+++ b/_projects/6_project.markdown
@@ -18,15 +18,15 @@ To give your project a background in the portfolio page, just add the img tag to
 
 
 <div class="img_row">
-    <img class="col one" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/1.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/2.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/3.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     Caption photos easily. On the left, a road goes through a tunnel. Middle, leaves artistically fall in a hipster photoshoot. Right, in another hipster photoshoot, a lumberjack grasps a handful of pine needles.
 </div>
 <div class="img_row">
-    <img class="col three" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
+    <img class="col three left" src="{{ site.baseurl }}/assets/img/5.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     This image can also have a caption. It's like magic.
@@ -36,17 +36,20 @@ You can also put regular text between your rows of images. Say you wanted to wri
 
 
 <div class="img_row">
-    <img class="col two" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
-    <img class="col one" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
+    <img class="col two left" src="{{ site.baseurl }}/assets/img/6.jpg" alt="" title="example image"/>
+    <img class="col one left" src="{{ site.baseurl }}/assets/img/11.jpg" alt="" title="example image"/>
 </div>
 <div class="col three caption">
     You can also have artistically styled 2/3 + 1/3 images, like these.
 </div>
 
 
+<br/><br/>
+
+
 The code is simple. Just add a col class to your image, and another class specifying the width: one, two, or three columns wide. Here's the code for the last row of images above:
 
     <div class="img_row">
-      <img class="col two" src="/img/6.jpg"/>
-      <img class="col one" src="/img/11.jpg"/>
+      <img class="col two left" src="/img/6.jpg"/>
+      <img class="col one left" src="/img/11.jpg"/>
     </div>

--- a/_sass/_gallery.scss
+++ b/_sass/_gallery.scss
@@ -19,7 +19,6 @@ figcaption {
 .col {
     width: 100%;
     height: 100%;
-    float: left;
     object-fit: cover;
     box-sizing:border-box;
     padding: $img-spacing;

--- a/_sass/_profile.scss
+++ b/_sass/_profile.scss
@@ -1,5 +1,5 @@
 .profile {
-    float: right !important;
+    float: right;
     img {
         box-shadow: 0 0 5px $grey-color;
         width: 100%;

--- a/_sass/_profile.scss
+++ b/_sass/_profile.scss
@@ -1,5 +1,4 @@
 .profile {
-    float: right;
     img {
         box-shadow: 0 0 5px $grey-color;
         width: 100%;


### PR DESCRIPTION
There's a bug in the `_pages/_about.md` file, in that there's a `profile: align:` property defined in the front matter, but changing it doesn't do anything. I realised it's because there's an `align: right !important;` line in the `_sass/_profile.scss` file, which shouldn't be there. The `_layout/about.html` file creates a div for the profile image with a class given by the `profile: align:` property of the about.md page, and these classes are defined in `_sass/_positions.scss` simply to set the alignment, so the alignment should be set from this class, rather than separately in the profile class. If one changes the `profile: align:` property to left instead of right as it is in the template file, then nothing happens, as the `important` property of profile overrides the left class. If one just removes the alignment from the profile class, then there's still an error, as the col class in `_sass/_gallery.scss` is also defined to be left aligned, and as the profile image is also set to have the col class, then there is still a conflict. My fix is therefore to also remove the left align property from the col class seeing as a left/right class exists which makes all alignment explicit. Finally, this requires the project pages to have the images also have the left class in order to get the nice 2/1 or 1/1/1 images. I also updated the code snippet in the projects to match the changed classes.