### PR TITLE
Fixed webkit text scaling `bug`

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -3,6 +3,7 @@
 html, body {
   height: auto;
   min-height: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
 img {


### PR DESCRIPTION
Modified _base.scss in order to tell webkit not to automatically scale font sizes. I noticed that if I browsed my page on my iPhone, the font size of the footer would start at 12pt, then get scaled up (to ~20pt) as I rotated my phone to landscape, and not scale back to 12pt when I rotated back to landscape. A similar thing was happening on some p-tags, though with different sizes. It turns out that there is a text-size-adjust css property which is used to automatically scale up fonts on mobile devices, ignoring the css (the idea being to improve usability on older sites which didn't design for mobile). As the site is designed for mobile, we don't want any automated scaling to be applied, so I set -webkit-text-size-adjust: 100% in order to prevent the scaling from occurring. This fixes what I was observing on my phone, though it may be that a similar fix is required for other browsers.