### PR TITLE
Do not delete CNAME file 

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -81,7 +81,7 @@ git checkout -b $DEPLOY_BRANCH
 bundle exec jekyll build
 
 # Delete and move files
-find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name '.gitignore' -exec rm -rf {} \;
+find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name 'CNAME' ! -name '.gitignore' -exec rm -rf {} \;
 mv _site/* .
 rm -R _site/
 


### PR DESCRIPTION
The step in the deploy script that deletes almost all files except for _site/ was causing issues if you have a custom domain name. GitHub pages requires a CNAME, so I added this to the list of files not to delete.