### PR TITLE
Fixes bug when generating publications from single authors.

### DIFF
--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -15,37 +15,37 @@
   {% else %}
     <span class="title">{{entry.title}}</span>
     <span class="author">
-        {% for author in entry.author_array %}
-            {% if forloop.length == 1 %}
-                {% if author.last == site.scholar.last_name %}
-                    <em>{{author.last}}, {{author.first}}</em>
-                {% else %}
-                    {{author.last}}, {{author.first}}
-                {% endif %}
+      {% for author in entry.author_array %}
+        {% if forloop.length == 1 %}
+          {% if author.last == site.scholar.last_name %}
+            <em>{{author.last}}, {{author.first}}</em>
+          {% else %}
+            {{author.last}}, {{author.first}}
+          {% endif %}
+        {% else %}
+          {% unless forloop.last %}
+            {% if author.last == site.scholar.last_name %}
+              <em>{{author.last}}, {{author.first}}</em>,
             {% else %}
-                {% unless forloop.last %}
-                    {% if author.last == site.scholar.last_name %}
-                        <em>{{author.last}}, {{author.first}}</em>,
-                    {% else %}
-                        {% if site.data.coauthors[author.last] %}
-                            <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>, 
-                        {% else %}
-                            {{author.last}}, {{author.first}},
-                        {% endif %}
-                    {% endif %}
-                {% else %}
-                    {% if author.last == site.scholar.last_name %}
-                        and <em>{{author.last}}, {{author.first}}</em>
-                    {% else %}
-                        {% if site.data.coauthors[author.last] %}
-                            and <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a> 
-                        {% else %}
-                            and {{author.last}}, {{author.first}}
-                        {% endif %}
-                    {% endif %}
-                {% endunless %}
+              {% if site.data.coauthors[author.last] %}
+                <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>, 
+              {% else %}
+                {{author.last}}, {{author.first}},
+              {% endif %}
             {% endif %}
-        {% endfor %}
+          {% else %}
+            {% if author.last == site.scholar.last_name %}
+              and <em>{{author.last}}, {{author.first}}</em>
+            {% else %}
+              {% if site.data.coauthors[author.last] %}
+                and <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a> 
+              {% else %}
+                and {{author.last}}, {{author.first}}
+              {% endif %}
+            {% endif %}
+          {% endunless %}
+        {% endif %}
+      {% endfor %}
     </span>
 
     <span class="periodical">

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -18,16 +18,15 @@
       {% for author in entry.author_array %}
         {% unless forloop.last %}
           {% if author.last == site.scholar.last_name %}
-            <em>{{author.last}}, {{author.first}}</em>,
+            <em>{{author.last}}, {{author.first}}</em>, and
           {% else %}
             {% if site.data.coauthors[author.last] %}
-              <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>,
+              <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>, and
             {% else %}
-              {{author.last}}, {{author.first}},
+              {{author.last}}, {{author.first}}, and
             {% endif %}
           {% endif %}
         {% else %}
-          and
           {% if author.last == site.scholar.last_name %}
             <em>{{author.last}}, {{author.first}}</em>
           {% else %}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -15,29 +15,37 @@
   {% else %}
     <span class="title">{{entry.title}}</span>
     <span class="author">
-      {% for author in entry.author_array %}
-        {% unless forloop.last %}
-          {% if author.last == site.scholar.last_name %}
-            <em>{{author.last}}, {{author.first}}</em>, and
-          {% else %}
-            {% if site.data.coauthors[author.last] %}
-              <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>, and
+        {% for author in entry.author_array %}
+            {% if forloop.length == 1 %}
+                {% if author.last == site.scholar.last_name %}
+                    <em>{{author.last}}, {{author.first}}</em>
+                {% else %}
+                    {{author.last}}, {{author.first}}
+                {% endif %}
             {% else %}
-              {{author.last}}, {{author.first}}, and
+                {% unless forloop.last %}
+                    {% if author.last == site.scholar.last_name %}
+                        <em>{{author.last}}, {{author.first}}</em>,
+                    {% else %}
+                        {% if site.data.coauthors[author.last] %}
+                            <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>, 
+                        {% else %}
+                            {{author.last}}, {{author.first}},
+                        {% endif %}
+                    {% endif %}
+                {% else %}
+                    {% if author.last == site.scholar.last_name %}
+                        and <em>{{author.last}}, {{author.first}}</em>
+                    {% else %}
+                        {% if site.data.coauthors[author.last] %}
+                            and <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a> 
+                        {% else %}
+                            and {{author.last}}, {{author.first}}
+                        {% endif %}
+                    {% endif %}
+                {% endunless %}
             {% endif %}
-          {% endif %}
-        {% else %}
-          {% if author.last == site.scholar.last_name %}
-            <em>{{author.last}}, {{author.first}}</em>
-          {% else %}
-            {% if site.data.coauthors[author.last] %}
-              <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>
-            {% else %}
-              {{author.last}}, {{author.first}}
-            {% endif %}
-          {% endif %}
-        {% endunless %}
-      {% endfor %}
+        {% endfor %}
     </span>
 
     <span class="periodical">


### PR DESCRIPTION
There currently is a bug when generating the author field for single-author publications: an "and" is added in front of the name of the author (as in the demo, where we have "and Einstein, Albert", see [here](https://alshedivat.github.io/al-folio/publications/)).

This PR fixes it with with some minimal changes in `_layouts/bib.html`.