### PR TITLE
Added css to take account of vertical scroll bar and avoid content jumps

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,4 +1,8 @@
 @charset "UTF-8";
+html{
+    margin-left: calc(100vw - 100%);
+    margin-right: 0;
+}
 
 html, body {
   height: auto;

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -3,7 +3,7 @@
     background-color: #fff;
     opacity: 0.95;
     position:fixed;
-    left:0px;
+    left:calc((100vw - 100%)/2);
     top:0px;
     width:100%;
     z-index: 50;


### PR DESCRIPTION
Fixed issue #26, as explained [here](https://css-tricks.com/elegant-fix-jumping-scrollbar-issue/). I've added an overall left margin to the main html tag, so that margin:auto works as if the scrollbar is invisible. Since the header has a fixed position, I've also changed the left position of the header. The horizontal alignment of the header now doesn't change between 'short' and 'long' pages.

The other way to fix this would be to make the vertical scrollbar always appear, regardless of whether or not the content requires it. This would achieve the same visual consistency, but I think is much less aesthetically pleasing.