### PR TITLE
Make the display of an email conditional

### DIFF
--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,6 +1,6 @@
 <div class="social">
   <span class="contacticon center">
-    <a href="mailto:{{ site.email | encode_email }}"><i class="fas fa-envelope"></i></a>
+    {% if site.email %}<a href="mailto:{{ site.email | encode_email }}"><i class="fas fa-envelope"></i></a>{% endif %}
     {% if site.orcid_id %}<a href="https://orcid.org/{{ site.orcid_id }}" target="_blank" title="ORCID"><i class="ai ai-orcid"></i></a>{% endif %}
     {% if site.scholar_userid %}<a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}" target="_blank" title="Google Scholar"><i class="ai ai-google-scholar"></i></a>{% endif %}
     {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}" target="_blank" title="GitHub"><i class="fab fa-github"></i></a>{% endif %}


### PR DESCRIPTION
This pull proposes hiding the social email button altogether if `site.email` is falsy.