### PR TITLE
Enable preview images on social media

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ Just use the liquid tags `{% highlight python %}` and `{% endhighlight %}` to de
   </a>
 </p>
 
+#### Social media previews
+The al-folio theme optionally supports preview images on social media.
+To enable this functionality you will need to set `serve_og_meta` to `true` in
+your `_config.yml`. Once you have done so, all your site's pages will include
+Open Graph data in the HTML head element.
+
+You will then need to configure what image to display in your site's social
+media previews. This can be configured on a per-page basis, by setting the
+`og_image` page variable. If for an individual page this variable is not set,
+then the theme will fall back to a site-wide `og_image` variable, configurable
+in your `_config.yml`. In both the page-specific and site-wide cases, the
+`og_image` variable needs to hold the URL for the image you wish to display in
+social media previews.
+
 ## Contributing
 
 Feel free to contribute new features and theme improvements by sending a pull request.

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,14 @@ baseurl: /al-folio # the subpath of your site, e.g. /blog/
 last_updated: # leave blank if you don't want to display last updated
 
 # -----------------------------------------------------------------------------
+# Open Graph
+# -----------------------------------------------------------------------------
+# Display links to the page with a preview object on social media.
+# To achieve this, change serve_og_meta to true and then provide the URL of the
+# preview image as the value of og_image.
+serve_og_meta: false # Include Open Graph meta tags in the HTML head
+og_image: # The Open Graph preview image
+# -----------------------------------------------------------------------------
 # Social integration
 # -----------------------------------------------------------------------------
 github_username: # your GitHub user name

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ last_updated: # leave blank if you don't want to display last updated
 # To achieve this, change serve_og_meta to true and then provide the URL of the
 # preview image as the value of og_image.
 serve_og_meta: false # Include Open Graph meta tags in the HTML head
-og_image: # The Open Graph preview image
+og_image: # The site-wide (default for all links) Open Graph preview image
 # -----------------------------------------------------------------------------
 # Social integration
 # -----------------------------------------------------------------------------

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,13 +6,13 @@
   <title>{{ site.name }}{% if page.title and page.url != "/" %} | {{ page.title }}{% endif %}</title>
   <meta name="description" content="{{ site.description }}">
 
-  {% if site.serve_og_meta %}  
+  {% if site.serve_og_meta %}
     <meta property="og:site_name" content="{{ site.url }}" />
     <meta property="og:type" content="object" />
     <meta property="og:title" content="{{ site.name }}" />
     <meta property="og:url" content="{{ site.url }}" />
     <meta property="og:description" content="{{ site.description }}" />
-    <meta property="og:image" content="{{ site.og_image }}" />  
+    <meta property="og:image" content="{{ site.og_image }}" />
   {% endif %}
 
   <link rel="shortcut icon" href="{{ '/assets/img/favicon.ico' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,9 +10,10 @@
     <meta property="og:site_name" content="{{ site.url }}" />
     <meta property="og:type" content="object" />
     <meta property="og:title" content="{{ site.name }}" />
-    <meta property="og:url" content="{{ site.url }}" />
-    <meta property="og:description" content="{{ site.description }}" />
-    <meta property="og:image" content="{{ site.og_image }}" />
+    <meta property="og:url" content="{{ page.url }}" />
+    <meta property="og:description" content="{{ page.description }}" />
+    <meta property="og:image"
+          content="{%- if page.og_image -%}{{ page.og_image }}{%- else -%}{{ site.og_image }}{%- endif -%}" />
   {% endif %}
 
   <link rel="shortcut icon" href="{{ '/assets/img/favicon.ico' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,11 +7,11 @@
   <meta name="description" content="{{ site.description }}">
 
   {% if site.serve_og_meta %}
-    <meta property="og:site_name" content="{{ site.url }}" />
+    <meta property="og:site_name" content="{{ site.description }}" />
     <meta property="og:type" content="object" />
     <meta property="og:title" content="{{ site.name }}" />
-    <meta property="og:url" content="{{ page.url }}" />
-    <meta property="og:description" content="{{ page.description }}" />
+    <meta property="og:url" content="{{ page.url | prepend: site.baseurl | prepend: site.url }}" />
+    <meta property="og:description" content="{{ page.title }}" />
     <meta property="og:image"
           content="{%- if page.og_image -%}{{ page.og_image }}{%- else -%}{{ site.og_image }}{%- endif -%}" />
   {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,15 @@
   <title>{{ site.name }}{% if page.title and page.url != "/" %} | {{ page.title }}{% endif %}</title>
   <meta name="description" content="{{ site.description }}">
 
+  {% if site.serve_og_meta %}  
+    <meta property="og:site_name" content="{{ site.url }}" />
+    <meta property="og:type" content="object" />
+    <meta property="og:title" content="{{ site.name }}" />
+    <meta property="og:url" content="{{ site.url }}" />
+    <meta property="og:description" content="{{ site.description }}" />
+    <meta property="og:image" content="{{ site.og_image }}" />  
+  {% endif %}
+
   <link rel="shortcut icon" href="{{ '/assets/img/favicon.ico' | prepend: site.baseurl | prepend: site.url }}">
 
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
This commit adds support for serving Open Graph meta tags inside the HTML head. When enabled, links to the page on social media will display a preview.

NB: twitter behaves somewhat differently and may require twitter card meta tags in addition to Open Graph.

https://ogp.me/

Draft for now: Works nicely on skype. The twitter validator likes it, but I failed to make it work inside a tweet. Need to also test a couple more sites/apps. Success/failure reports welcome!