### PR TITLE
Document that blog_name changes the navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ google_analytics: UA-XXXXXXXXX # out your google-analytics code
 # Blog
 # -----------------------------------------------------------------------------
 
-blog_name: al-folio
+blog_name: al-folio  # your blog must have a name for it to show up in the nav bar
 blog_description: a simple whitespace theme for academics
 permalink: /blog/:year/:title/
 


### PR DESCRIPTION
I love the new design, but was confused why the blog link didn't show up on the nav bar.  It was because the blog needs a name for it to appear.  Just added a comment in the config that documents this behavior.  

Thank you for a great template!