### PR TITLE
changes allow for more than first and last name to be displayed.  

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Site settings
 # -----------------------------------------------------------------------------
 
-title: Your Name
+title: You R. Name
 email: you@example.com
 description: > # this means to ignore newlines until "url:"
   A simple, whitespace theme for academics. Based on [*folio](https://github.com/bogoli/-folio) design.

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,8 +4,17 @@
     <nav id="navbar" class="navbar navbar-light bg-white navbar-expand-sm {% if site.navbar_fixed %}fixed-top{% else %}sticky-top{% endif %}">
     <div class="container">
       {% if page.title != "about" %}
-        {% assign name = site.title | split: ' ' %}
-        <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl | prepend: site.url }}/"><span class="font-weight-bold">{{ name | first }}</span> {{ name | last }}</a>
+      {% assign name = site.title | split: ' ' %}
+      {% assign firstname = name | first %}
+      {% if name.size > 2 %}
+         {% assign middlenames =  name | slice:1, name.size-1 | join:" " %}
+      {% else %}
+         {% assign middlenames = '' %}
+      {% endif %}
+      {% assign lastname = name | last %}
+      <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl | prepend: site.url }}/">
+       <span class="font-weight-bold">{{ firstname }}</span> {{ middlenames }}  {{ lastname }}
+      </a>
       {% elsif site.show_social_icons %}
         <!-- Social Icons -->
         <div class="row ml-1 ml-sm-0">

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -6,8 +6,16 @@ layout: default
 
   <header class="post-header">
     {% assign name = site.title | split: ' ' %}
-    <h1 class="post-title"><span class="font-weight-bold">{{ name | first }}</span> {{ name | last }}</h1>
-    <p class="post-description">{{ page.description }}</p>
+    {% assign firstname = name | first %}
+    {% if name.size > 2 %}
+       {% assign middlenames =  name | slice:1, name.size-1 | join:" " %}
+    {% else %}
+       {% assign middlenames = '' %}
+    {% endif %}
+    {% assign lastname = name | last %}
+    <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl | prepend: site.url }}/">
+     <span class="font-weight-bold">{{ firstname }}</span> {{ middlenames }}  {{ lastname }}
+    </a>
   </header>
 
   <article>


### PR DESCRIPTION
If more than 2 elements in _config.yml variable title, any middle names or initials will be displayed.

This doesn't handle things like a Jr. or III yet.  The lastname variable will always catch the last thing.  

An alternative would be adding  either
- a separate variable in _config.yml for name suffix.  
- Or perhaps revamp all this with separate config variables explicitly set for Personal name, Middle names, Family name, Suffix