### PR TITLE
Adding back the description on the About page.

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -8,6 +8,7 @@ layout: default
     <h1 class="post-title">
      {% if site.title == blank %}{{ site.title }}{% else %}<span class="font-weight-bold">{{ site.first_name }}</span> {{ site.middle_name }}  {{ site.last_name }}{% endif %}
     </h1>
+     <p class="desc">{{ page.description }}</p>
   </header>
 
   <article>


### PR DESCRIPTION
Added back the missing description on `about.html`, similar to `page.html`. This could additionally be added back to the `post.html` template as well.