### PR TITLE
Github action: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - source
+  pull_request:
+    branches:
+      - master
+      - source
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+    - name: Enable bundler cache
+      uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+    - name: Install deps
+      run: |
+        gem install bundler
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - name: Setup deploy options
+      id: setup
+      run: |
+        git config --global user.name "GitHub Action"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        if [[ ${GITHUB_REF} = refs/pull/*/merge ]]; then # pull request
+          echo "::set-output name=SRC_BRANCH::${GITHUB_BASE_REF}"
+          echo "::set-output name=DRY_RUN::--dry-run"
+        elif [[ ${GITHUB_REF} = refs/heads/* ]]; then # branch, e.g. master, source etc
+          echo "::set-output name=SRC_BRANCH::${GITHUB_REF#refs/heads/}"
+        fi
+        if [[ ${{ github.repository }} = *.github.io ]]; then # user/org repo
+          echo "::set-output name=DEPLOY_BRANCH::master"
+        else
+          echo "::set-output name=DEPLOY_BRANCH::gh-pages"
+        fi
+    - name: Deploy website 
+      run:  yes | bin/deploy --verbose ${{ steps.setup.outputs.DRY_RUN }}
+                    --src ${{ steps.setup.outputs.SRC_BRANCH }} 
+                    --deploy ${{ steps.setup.outputs.DEPLOY_BRANCH }} 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         git config --global user.name "GitHub Action"
         git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
         if [[ ${GITHUB_REF} = refs/pull/*/merge ]]; then # pull request
-          echo "::set-output name=SRC_BRANCH::${GITHUB_BASE_REF}"
+          echo "::set-output name=SRC_BRANCH::${GITHUB_HEAD_REF}"
           echo "::set-output name=DRY_RUN::--dry-run"
         elif [[ ${GITHUB_REF} = refs/heads/* ]]; then # branch, e.g. master, source etc
           echo "::set-output name=SRC_BRANCH::${GITHUB_REF#refs/heads/}"

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,7 +7,7 @@
 SRC_BRANCH="master"
 DEPLOY_BRANCH="gh-pages"
 
-USAGE_MSG="usage: deploy [-h|--help] [-u|--user] [-s|--src SRC_BRANCH] [-d|--deploy DEPLOY_BRANCH]"
+USAGE_MSG="usage: deploy [-h|--help] [-u|--user] [-s|--src SRC_BRANCH] [-d|--deploy DEPLOY_BRANCH] [--verbose] [--dry-run]"
 
 while [[ $# > 0 ]]; do
     key="$1"
@@ -20,7 +20,6 @@ while [[ $# > 0 ]]; do
         -u|--user)
         SRC_BRANCH="source"
         DEPLOY_BRANCH="master"
-        shift
         ;;
         -s|--src)
         SRC_BRANCH="$2"
@@ -30,10 +29,16 @@ while [[ $# > 0 ]]; do
         DEPLOY_BRANCH="$2"
         shift
         ;;
+        --verbose)
+        set -x
+        ;;
+        --dry-run)
+        DRY_RUN="--dry-run"
+        ;;
         *)
-        echo "Option $1 is unknown."
-        echo $USAGE_MSG
-        exit 0
+        echo "Option $1 is unknown." >&2
+        echo $USAGE_MSG >&2
+        exit 1
         ;;
     esac
     shift
@@ -88,7 +93,7 @@ rm -R _site/
 # Push to DEPLOY_BRANCH
 git add -fA
 git commit --allow-empty -m "$(git log -1 --pretty=%B) [ci skip]"
-git push -f -q origin $DEPLOY_BRANCH
+git push ${DRY_RUN} -f -q origin $DEPLOY_BRANCH
 
 # Move back to SRC_BRANCH
 git checkout $SRC_BRANCH


### PR DESCRIPTION
This will automatically deploy the page when pushing to source branch (i.e. `master` and `source`).
That basically allows editing through the GitHub web interface, no more need to install bundler locally.

This also supports pull requests, which can be useful to collaboratively make a conference page. For PRs the whole build is still done except the actual `git push` at the end. To achieve this I added a `--dry-run` option to `bin/deploy`.

Side notes:
- added `--verbose` option to make debugging of `bin/deploy` easier
- changed the exit code for unknown options to 1, before it would end gracefully (`exit 0`)
- fixed `--user` option calling `shift` twice
- using actions/cache to cache bundle
- the current branch is always used as the source branch, however the deploy action is only triggered for `master` / `source` (and PR to these, but PR are not deployed).
- in case of a `.github.io` repo, the deploy branch is switched from `gh-pages` to `master`.
- all the GitHub action stuff is pretty easy to customize
- all changes to `bin/deploy` are backward compatible 
