### PR TITLE
add coauthor annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,17 +151,24 @@ scholar:
 Keep meta-information about your co-authors in `_data/coauthors.yml` and Jekyll will insert links to their webpages automatically.
 The coauthor data format in `_data/coauthors.yml` is as follows,
 ```
-- lastname: [Adams]
-  firstname: [Edwin, E., E. P., Edwin Plimpton]
-  url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
+"Adams":
+  - firstname: ["Edwin", "E.", "E. P.", "Edwin Plimpton"]
+    url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
 
-- lastname: [Podolsky]
-  firstname: [Boris, B., B. Y., Boris Yakovlevich]
-  url: https://en.wikipedia.org/wiki/Boris_Podolsky
+"Podolsky":
+  - firstname: ["Boris", "B.", "B. Y.", "Boris Yakovlevich"]
+    url: https://en.wikipedia.org/wiki/Boris_Podolsky
 
-- lastname: [Rosen]
-  firstname: [Nathan, N.]
-  url: https://en.wikipedia.org/wiki/Nathan_Rosen
+"Rosen":
+  - firstname: ["Nathan", "N."]
+    url: https://en.wikipedia.org/wiki/Nathan_Rosen
+
+"Bach": 
+  - firstname: ["Johann Sebastian", "J. S."]
+    url: https://en.wikipedia.org/wiki/Johann_Sebastian_Bach
+
+  - firstname: ["Carl Philipp Emanuel", "C. P. E."]
+    url: https://en.wikipedia.org/wiki/Carl_Philipp_Emanuel_Bach
 ```
 If the entry matches one of the combinations of the last names and the first names, it will be highlighted and linked to the url provided. 
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,29 @@ Your publications page is generated automatically from your BibTex bibliography.
 Simply edit `_bibliography/papers.bib`.
 You can also add new `*.bib` files and customize the look of your publications however you like by editing `_pages/publications.md`.
 
+#### Author Annotation
+In publications, the author entry for your self is identified by string `scholar:last_name` and string array `scholar:first_name` in `_config.yml`. If the entry matches the last name and one form of the first names, it will be underlined. 
+```
+scholar:
+  last_name: Einstein
+  first_name: [Albert, A.]
+```
 Keep meta-information about your co-authors in `_data/coauthors.yml` and Jekyll will insert links to their webpages automatically.
+The coauthor data format in `_data/coauthors.yml` is as follows,
+```
+- lastname: [Adams]
+  firstname: [Edwin, E., E. P., Edwin Plimpton]
+  url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
+
+- lastname: [Podolsky]
+  firstname: [Boris, B., B. Y., Boris Yakovlevich]
+  url: https://en.wikipedia.org/wiki/Boris_Podolsky
+
+- lastname: [Rosen]
+  firstname: [Nathan, N.]
+  url: https://en.wikipedia.org/wiki/Nathan_Rosen
+```
+If the entry matches one of the combinations of the last names and the first names, it will be highlighted and linked to the url provided. 
 
 <p align="center"><img src="assets/img/publications-screenshot.png" width=800></p>
 

--- a/_data/coauthors.yml
+++ b/_data/coauthors.yml
@@ -3,7 +3,7 @@
   url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
 
 - lastname: [Podolsky]
-  firstname: [Boris", B., B. Y., Boris Yakovlevich]
+  firstname: [Boris, B., B. Y., Boris Yakovlevich]
   url: https://en.wikipedia.org/wiki/Boris_Podolsky
 
 - lastname: [Rosen]

--- a/_data/coauthors.yml
+++ b/_data/coauthors.yml
@@ -1,8 +1,11 @@
-Adams:
-    url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
+- lastname: [Adams]
+  firstname: [Edwin, E., E. P., Edwin Plimpton]
+  url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
 
-Podolsky:
-    url: https://en.wikipedia.org/wiki/Boris_Podolsky
+- lastname: [Podolsky]
+  firstname: [Boris", B., B. Y., Boris Yakovlevich]
+  url: https://en.wikipedia.org/wiki/Boris_Podolsky
 
-Rosen:
-    url: https://en.wikipedia.org/wiki/Nathan_Rosen
+- lastname: [Rosen]
+  firstname: [Nathan, N.]
+  url: https://en.wikipedia.org/wiki/Nathan_Rosen

--- a/_data/coauthors.yml
+++ b/_data/coauthors.yml
@@ -1,11 +1,18 @@
-- lastname: [Adams]
-  firstname: [Edwin, E., E. P., Edwin Plimpton]
-  url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
+"Adams":
+  - firstname: ["Edwin", "E.", "E. P.", "Edwin Plimpton"]
+    url: https://en.wikipedia.org/wiki/Edwin_Plimpton_Adams
 
-- lastname: [Podolsky]
-  firstname: [Boris, B., B. Y., Boris Yakovlevich]
-  url: https://en.wikipedia.org/wiki/Boris_Podolsky
+"Podolsky":
+  - firstname: ["Boris", "B.", "B. Y.", "Boris Yakovlevich"]
+    url: https://en.wikipedia.org/wiki/Boris_Podolsky
 
-- lastname: [Rosen]
-  firstname: [Nathan, N.]
-  url: https://en.wikipedia.org/wiki/Nathan_Rosen
+"Rosen":
+  - firstname: ["Nathan", "N."]
+    url: https://en.wikipedia.org/wiki/Nathan_Rosen
+
+"Bach": 
+  - firstname: ["Johann Sebastian", "J. S."]
+    url: https://en.wikipedia.org/wiki/Johann_Sebastian_Bach
+
+  - firstname: ["Carl Philipp Emanuel", "C. P. E."]
+    url: https://en.wikipedia.org/wiki/Carl_Philipp_Emanuel_Bach

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -1,19 +1,5 @@
 ---
 ---
-{% assign db_coauthor_keys = '' %}
-{% assign db_coauthor_values = '' %}
-{% capture db_all_coauthors %}
-{% for db_author in site.data.coauthors %}
-  {% for first_name in db_author.firstname %}
-    {% for last_name in db_author.lastname %}
-      {% capture fullname %}{{ last_name }}, {{ first_name }}{% endcapture %}
-      {% assign db_coauthor_keys = db_coauthor_keys| append: ';' | append: fullname  %}
-      {% assign db_coauthor_values = db_coauthor_values| append: ';' | append: db_author.url  %}
-    {% endfor %}
-  {% endfor %}
-{% endfor %} {% endcapture %}
-{% assign db_coauthor_keys = db_coauthor_keys | remove_first: ';' | split: ';' %}
-{% assign db_coauthor_values = db_coauthor_values | remove_first: ';' | split: ';' %}
 
 <div class="row">
   <div class="col-sm-2 abbr">
@@ -39,14 +25,15 @@
               {% assign author_is_self = true %}
             {% endif %}
           {% endif %}
-          {% capture fullname %}{{author.last}}, {{author.first}}{% endcapture %}
-          {% assign coauthor_index= -1 %}
-          {% for key in db_coauthor_keys %}
-            {% if key == fullname %}
-              {% assign coauthor_index = forloop.index0 %}
-              {% break %}
-            {% endif %}
-          {% endfor %}
+          {% assign coauthor_url = "" %}
+          {% if site.data.coauthors[author.last] %}
+            {% for db_author in site.data.coauthors[author.last] %}
+              {% if db_author.firstname contains author.first %}
+                {% assign coauthor_url = db_author.url %}
+                {% break %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
           
           {% if forloop.length == 1 %}
             {% if author_is_self %}
@@ -59,8 +46,8 @@
               {% if author_is_self %}
                 <em>{{author.last}}, {{author.first}}</em>,
               {% else %}
-                {% if coauthor_index >= 0 %}
-                  <a href="{{db_coauthor_values[coauthor_index]}}" target="_blank">{{author.last}}, {{author.first}}</a>,
+                {% if coauthor_url != "" %}
+                  <a href="{{coauthor_url}}" target="_blank">{{author.last}}, {{author.first}}</a>,
                 {% else %}
                   {{author.last}}, {{author.first}},
                 {% endif %}
@@ -69,8 +56,8 @@
               {% if author_is_self %}
                 and <em>{{author.last}}, {{author.first}}</em>
               {% else %}
-                {% if coauthor_index >= 0 %}
-                  and <a href="{{db_coauthor_values[coauthor_index]}}" target="_blank">{{author.last}}, {{author.first}}</a>
+                {% if coauthor_url != "" %}
+                  and <a href="{{coauthor_url}}" target="_blank">{{author.last}}, {{author.first}}</a>
                 {% else %}
                   and {{author.last}}, {{author.first}}
                 {% endif %}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -56,7 +56,7 @@
               {% if author_is_self %}
                 and <em>{{author.last}}, {{author.first}}</em>
               {% else %}
-                {% if coauthor_url != "" %}
+                {% if coauthor_url %}
                   and <a href="{{coauthor_url}}" target="_blank">{{author.last}}, {{author.first}}</a>
                 {% else %}
                   and {{author.last}}, {{author.first}}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -1,5 +1,19 @@
 ---
 ---
+{% assign db_coauthor_keys = '' %}
+{% assign db_coauthor_values = '' %}
+{% capture db_all_coauthors %}
+{% for db_author in site.data.coauthors %}
+  {% for first_name in db_author.firstname %}
+    {% for last_name in db_author.lastname %}
+      {% capture fullname %}{{ last_name }}, {{ first_name }}{% endcapture %}
+      {% assign db_coauthor_keys = db_coauthor_keys| append: ';' | append: fullname  %}
+      {% assign db_coauthor_values = db_coauthor_values| append: ';' | append: db_author.url  %}
+    {% endfor %}
+  {% endfor %}
+{% endfor %} {% endcapture %}
+{% assign db_coauthor_keys = db_coauthor_keys | remove_first: ';' | split: ';' %}
+{% assign db_coauthor_values = db_coauthor_values | remove_first: ';' | split: ';' %}
 
 <div class="row">
   <div class="col-sm-2 abbr">
@@ -25,6 +39,15 @@
               {% assign author_is_self = true %}
             {% endif %}
           {% endif %}
+          {% capture fullname %}{{author.last}}, {{author.first}}{% endcapture %}
+          {% assign coauthor_index= -1 %}
+          {% for key in db_coauthor_keys %}
+            {% if key == fullname %}
+              {% assign coauthor_index = forloop.index0 %}
+              {% break %}
+            {% endif %}
+          {% endfor %}
+          
           {% if forloop.length == 1 %}
             {% if author_is_self %}
               <em>{{author.last}}, {{author.first}}</em>
@@ -36,8 +59,8 @@
               {% if author_is_self %}
                 <em>{{author.last}}, {{author.first}}</em>,
               {% else %}
-                {% if site.data.coauthors[author.last] %}
-                  <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>,
+                {% if coauthor_index >= 0 %}
+                  <a href="{{db_coauthor_values[coauthor_index]}}" target="_blank">{{author.last}}, {{author.first}}</a>,
                 {% else %}
                   {{author.last}}, {{author.first}},
                 {% endif %}
@@ -46,8 +69,8 @@
               {% if author_is_self %}
                 and <em>{{author.last}}, {{author.first}}</em>
               {% else %}
-                {% if site.data.coauthors[author.last] %}
-                  and <a href="{{site.data.coauthors[author.last].url}}" target="_blank">{{author.last}}, {{author.first}}</a>
+                {% if coauthor_index >= 0 %}
+                  and <a href="{{db_coauthor_values[coauthor_index]}}" target="_blank">{{author.last}}, {{author.first}}</a>
                 {% else %}
                   and {{author.last}}, {{author.first}}
                 {% endif %}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -46,7 +46,7 @@
               {% if author_is_self %}
                 <em>{{author.last}}, {{author.first}}</em>,
               {% else %}
-                {% if coauthor_url != "" %}
+                {% if coauthor_url %}
                   <a href="{{coauthor_url}}" target="_blank">{{author.last}}, {{author.first}}</a>,
                 {% else %}
                   {{author.last}}, {{author.first}},

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -25,7 +25,7 @@
               {% assign author_is_self = true %}
             {% endif %}
           {% endif %}
-          {% assign coauthor_url = "" %}
+          {% assign coauthor_url = nil %}
           {% if site.data.coauthors[author.last] %}
             {% for coauthor in site.data.coauthors[author.last] %}
               {% if coauthor.firstname contains author.first %}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -27,9 +27,9 @@
           {% endif %}
           {% assign coauthor_url = "" %}
           {% if site.data.coauthors[author.last] %}
-            {% for db_author in site.data.coauthors[author.last] %}
-              {% if db_author.firstname contains author.first %}
-                {% assign coauthor_url = db_author.url %}
+            {% for coauthor in site.data.coauthors[author.last] %}
+              {% if coauthor.firstname contains author.first %}
+                {% assign coauthor_url = coauthor.url %}
                 {% break %}
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
@gkthiruvathukal , I have added coauthor annotation using your suggested `flat` format. Since the author name parsing from bibtex is handled by upstream jekyll-scholar, only first name and last name is processed here. 

The code is not very elegant, but since the code is only used to generate static web pages, it might be okay for now. 

And @alshedivat ,  do you have any suggestions?

We can have more discussion on the implementation here. 

Related issue #100 