### PR TITLE
Issue 180 - Distill Bugfix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -33,9 +33,14 @@
 
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | relative_url }}">
 
+<!-- JQuery -->
+{% include scripts/jquery.html %}
+
 <!-- Theming-->
 {% if site.enable_darkmode %}
   <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
+  <!-- Load DarkMode JS -->
+<script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
 {% endif %}
 
 {% if site.enable_google_analytics %}

--- a/_includes/scripts/misc.html
+++ b/_includes/scripts/misc.html
@@ -8,6 +8,3 @@ $(function () {$('[data-toggle="tooltip"]').tooltip()})
 
 <!-- Load Common JS -->
 <script src="{{ '/assets/js/common.js' | relative_url }}"></script>
-
-<!-- Load DarkMode JS -->
-<script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,6 @@
 
   </body>
 
-  {% include scripts/jquery.html %}
   {% include scripts/bootstrap.html %}
   {% include scripts/mansory.html %}
   {% include scripts/misc.html %}


### PR DESCRIPTION
* dark_mode.js was not being loaded on distill blog pages.
* Moved dark_mode.js and jquery.html to head.html to simplify/standardize dark mode/theming for other pages.