### PR TITLE
GDPR cookie consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,24 @@ Easily create beautiful grids within your blog posts and project pages:
   </a>
 </p>
 
+### Cookie Consent
+Includes a cookie consent dialog to allow your user to opt out of non-necessary cookies. 
+To block scripts based on the user's cookie settings, include the javascrip as:
+```
+<script type="text/plain" cookie-consent="<level>">
+   // only executed if user agreed to cookies
+</script>
+```
+Where `<level>` is one of:
+- strictly-necessary
+- functionality
+- tracking
+- targeting
+
+###### Disclaimer
+Please note that we do not give any guarantee that our implementation is actually compliant with local laws 
+(such as GDPR), nor do we take any responsibility for resulting legal problems. You need to verify yourself, 
+that your website is compliant with all applicable regulation in your country before publishing.    
 
 ### Other features
 

--- a/README.md
+++ b/README.md
@@ -318,18 +318,24 @@ Easily create beautiful grids within your blog posts and project pages:
 </p>
 
 ### Cookie Consent
-Includes a cookie consent dialog to allow your user to opt out of non-necessary cookies. 
-To block scripts based on the user's cookie settings, include the javascrip as:
+The theme includes the cookie consent dialog by [ihavecookies](https://github.com/ketanmistry/ihavecookies) to allow your user to opt out of non-necessary cookies. 
+In JavaScript, you can check if a certain type of cookie is enabled like so:
 ```
-<script type="text/plain" cookie-consent="<level>">
-   // only executed if user agreed to cookies
-</script>
+if ($.fn.ihavecookies && $.fn.ihavecookies.preference("cookieType") == true) {
+   // cookie "cookieType" is allowed
+} else {
+   // cookie "cookieType" is not allowed
+}
 ```
-Where `<level>` is one of:
-- strictly-necessary
-- functionality
-- tracking
-- targeting
+Where `cookieType` is one of:
+- preferences
+- social
+- analytics
+
+Essential cookies are always enabled. In `_config.yml` you can specify `cookie_info`, a link to a page where you
+explain your usage of cookies. You can disable the cookie consent dialog by setting the Jekyll 
+variable `disable_cc: true` either in `_config.yml` or for an individual page. This will default to 
+the old behaviour and allow all cookies without asking. 
 
 ###### Disclaimer
 Please note that we do not give any guarantee that our implementation is actually compliant with local laws 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://yoonholee.com/" target="_blank">★</a>
 <a href="https://zrqiao.github.io/" target="_blank">★</a>
 <a href="https://abstractgeek.github.io/" target="_blank">★</a>
+<a href="https://hschwane.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ footer_text: >
   Powered by <a href="http://jekyllrb.com/" target="_blank">Jekyll</a> with <a href="https://github.com/alshedivat/al-folio">al-folio</a> theme.
   Hosted by <a href="https://pages.github.com/" target="_blank">GitHub Pages</a>.
   Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
-  <button id="footerCookieSettings">Cookie Preference</button>
+  <button class="cookieSettings">Cookie Preference</button>
 
 icon: 🔥 # the emoji used as the favicon
 url:  # the base hostname & protocol for your site

--- a/_config.yml
+++ b/_config.yml
@@ -13,13 +13,14 @@ footer_text: >
   Powered by <a href="http://jekyllrb.com/" target="_blank">Jekyll</a> with <a href="https://github.com/alshedivat/al-folio">al-folio</a> theme.
   Hosted by <a href="https://pages.github.com/" target="_blank">GitHub Pages</a>.
   Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
-  <button id="changeCookiePreferences">Cookie Preference</button>
+  <button id="footerCookieSettings">Cookie Preference</button>
 
 icon: 🔥 # the emoji used as the favicon
 url:  # the base hostname & protocol for your site
 baseurl: /al-folio # the subpath of your site, e.g. /blog/
 last_updated: false # set to true if you want to display last updated in the footer
-impressum_path:  # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
+impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
+cookie_info: # link to a info page about how you use cookies or your impressum
 
 # -----------------------------------------------------------------------------
 # Layout

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ footer_text: >
   Powered by <a href="http://jekyllrb.com/" target="_blank">Jekyll</a> with <a href="https://github.com/alshedivat/al-folio">al-folio</a> theme.
   Hosted by <a href="https://pages.github.com/" target="_blank">GitHub Pages</a>.
   Photos from <a href="https://unsplash.com" target="_blank">Unsplash</a>.
+  <button id="changeCookiePreferences">Cookie Preference</button>
 
 url:  # the base hostname & protocol for your site
 baseurl: /al-folio # the subpath of your site, e.g. /blog/

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ url:  # the base hostname & protocol for your site
 baseurl: /al-folio # the subpath of your site, e.g. /blog/
 last_updated: false # set to true if you want to display last updated in the footer
 impressum_path: # set to path to include impressum link in the footer, use the same path as permalink in a page, helps to conform with EU GDPR
+
+disable_cc: false # you can disable the cookie consent dialog here globally, or disable it per page
 cookie_info: # link to a info page about how you use cookies or your impressum
 
 # -----------------------------------------------------------------------------

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,18 +1,25 @@
+
 {% if site.footer_fixed %}
-<footer class="fixed-bottom">
-  <div class="container mt-0">
-    &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
-    {{ site.footer_text }}
-    {% if site.impressum_path %}
-    <a href="{{ site.url }}{{ site.baseurl }}{{ site.impressum_path }}">Impressum</a>.
-    {% endif %}
-    {% if site.last_updated %}
-    Last updated: {{ "now" | date: '%B %d, %Y' }}.
-    {% endif %}
-  </div>
-</footer>
+<div id="footer-wrapper" class="fixed-bottom">
+  <div id="ihavecookiePlaceholder" class="mr-sm-4"></div>
+  <footer class="fixed_footer">
+    <div class="container mt-0">
+      &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
+      {{ site.footer_text }}
+      {% if site.impressum_path %}
+      <a href="{{ site.url }}{{ site.baseurl }}{{ site.impressum_path }}">Impressum</a>.
+      {% endif %}
+      {% if site.last_updated %}
+      Last updated: {{ "now" | date: '%B %d, %Y' }}.
+      {% endif %}
+    </div>
+  </footer>
+</div>
 {% else %}
-<footer class="sticky-bottom mt-5">
+<div id="footer-wrapper" class="fixed-bottom">
+  <div id="ihavecookiePlaceholder" class="mr-sm-4"></div>
+</div>
+<footer class="sticky-bottom mt-5 sticky_footer">
   <div class="container">
     &copy; Copyright {{ site.time | date: '%Y' }} {{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}.
     {{ site.footer_text }}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -92,14 +92,6 @@
     delay: 600,
     expires: 30,
     link: '{{site.cookie_info}}',
-    onAccept: function(){
-      // analytics
-      enableAnalyticsIfAllowed();
-      // store color theme
-      if ($.fn.ihavecookies && $.fn.ihavecookies.preference('preferences') == true) {
-        localStorage.setItem("theme", sessionStorage.getItem("theme"));
-      }
-    },
     acceptBtnLabel: 'Accept All',
     moreInfoLabel: 'More information',
     cookieTypesTitle: 'Select which cookies you want to accept',
@@ -124,6 +116,18 @@
     ]
   }
 
+  $.fn.ihavecookies.onPrefChange( function() {
+    // analytics
+    enableAnalyticsIfAllowed();
+    // store color theme
+    if ($.fn.ihavecookies && $.fn.ihavecookies.preference('preferences') == true) {
+      localStorage.setItem("theme", sessionStorage.getItem("theme"));
+    }
+
+    console.log("cookie pref changed");
+
+  });
+
   // run ihavecookies when document is ready
   $(document).ready(function() {
     $('body').ihavecookies(options);
@@ -135,7 +139,6 @@
     $('#footerCookieSettings').on('click', function(){
       $('body').ihavecookies(options, 'reinit');
     });
-
   });
 </script>
 {% endunless %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,27 +42,101 @@
 {% if site.enable_darkmode %}
   <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
   <!-- Load DarkMode JS -->
-<script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
 {% endif %}
 
-<!-- Cookie Consent by https://www.CookieConsent.com -->
-{% unless page.disable_cc %}
-<script type="text/javascript" src="//www.cookieconsent.com/releases/3.1.0/cookie-consent.js"></script>
-<script type="text/javascript">
-  document.addEventListener('DOMContentLoaded', function () {
-    cookieconsent.run({"notice_banner_type":"headline","consent_type":"express","palette":"dark","language":"en",
-      "change_preferences_selector":"#changeCookiePreferences"});
-  });
-</script>
-<noscript>ePrivacy and GPDR Cookie Consent by <a href="https://www.CookieConsent.com/" rel="nofollow noopener">Cookie Consent</a></noscript>
-{% endunless %}
-<!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->
 
 <!-- analytics -->
-<script type="text/plain" cookie-consent="tracking" src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
+<script type="text/javascript">
+  // funciton to enable analytics if cookie preferences allow it
+  // we call it directly here, and then also later whenver the cookie settings change
+  function enableAnalyticsIfAllowed() {
+    if ($.fn.ihavecookies && $.fn.ihavecookies.preference('analytics') == true) {
+      {% if site.enable_google_analytics %}
+        // google analytics
+        var gaScript = document.createElement('script');
+        gaScript.type = 'text/javascript';
+        gaScript.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
+        document.head.appendChild(gaScript);
 
-<!-- store theme over multiple sessions if functional cookies are on -->
-<script type="text/plain" cookie-consent="functionality">
-var allowThemeStored = true;
-localStorage.setItem("theme",sessionStorage.getItem("theme"));
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '{{ site.google_analytics }}');
+      {% endif %}
+
+      {% if site.enable_panelbear_analytics %}
+        // Panelbear analytics
+        var paScript = document.createElement('script');
+        paScript.type = 'text/javascript';
+        paScript.src = 'https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}';
+        document.head.appendChild(paScript);
+
+        window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
+        panelbear('config', { site: '{{site.panelbear_analytics}}' });
+      {% endif %}
+    }
+  }
+  enableAnalyticsIfAllowed();
 </script>
+
+{% unless page.disable_cc %}
+<!-- cookie  consent dialog using ihavecookies by ketan Mistry https://github.com/ketanmistry/ihavecookies -->
+<script type="text/javascript" src="{{ '/assets/js/jquery.ihavecookies.js' | relative_url }}"></script>
+<script type="text/javascript">
+
+  // setup ihavecookies options
+  var options = {
+    title: '&#x1F36A; Accept Cookies?',
+    message: 'We use cookies to enhance your experience on this website and to enable third party services.',
+    delay: 600,
+    expires: 30,
+    link: '{{site.cookie_info}}',
+    onAccept: function(){
+      // analytics
+      enableAnalyticsIfAllowed();
+      // store color theme
+      if ($.fn.ihavecookies && $.fn.ihavecookies.preference('preferences') == true) {
+        localStorage.setItem("theme", sessionStorage.getItem("theme"));
+      }
+    },
+    acceptBtnLabel: 'Accept All',
+    moreInfoLabel: 'More information',
+    cookieTypesTitle: 'Select which cookies you want to accept',
+    fixedCookieTypeLabel: 'Essential',
+    cookieTypes: [
+      {
+        type: 'Preferences',
+        value: 'preferences',
+        description: 'These are cookies that are related to your site preferences, e.g. remembering the color theme.'
+      },
+      {
+        type: 'Social',
+        value: 'social',
+        description: 'Cookies needed for social features (e.g. reading and writing comments), ' +
+                'as well as displaying external content (e.g. from YouTube or twitter)'
+      },
+      {
+        type: 'Analytics',
+        value: 'analytics',
+        description: 'Cookies we use to analyse the site usage.'
+      }
+    ]
+  }
+
+  // run ihavecookies when document is ready
+  $(document).ready(function() {
+    $('body').ihavecookies(options);
+
+    if ($.fn.ihavecookies.preference('marketing') === true) {
+      console.log('This should run because marketing is accepted.');
+    }
+
+    $('#footerCookieSettings').on('click', function(){
+      $('body').ihavecookies(options, 'reinit');
+    });
+
+  });
+</script>
+{% endunless %}
+<!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,3 +59,8 @@
 <!-- analytics -->
 <script type="text/plain" cookie-consent="tracking" src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
 
+<!-- store theme over multiple sessions if functional cookies are on -->
+<script type="text/plain" cookie-consent="functionality">
+var allowThemeStored = true;
+localStorage.setItem("theme",sessionStorage.getItem("theme"));
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,23 +43,19 @@
 <script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
 {% endif %}
 
-{% if site.enable_google_analytics %}
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-
-    gtag('config', '{{ site.google_analytics }}');
-  </script>
-{% endif %}
-
-{% if site.enable_panelbear_analytics %}
-<!-- Panelbear Analytics - We respect your privacy -->
-<script async src="https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}"></script>
-<script>
-    window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
-    panelbear('config', { site: '{{site.panelbear_analytics}}' });
+<!-- Cookie Consent by https://www.CookieConsent.com -->
+{% unless page.disable_cc %}
+<script type="text/javascript" src="//www.cookieconsent.com/releases/3.1.0/cookie-consent.js"></script>
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function () {
+    cookieconsent.run({"notice_banner_type":"headline","consent_type":"express","palette":"dark","language":"en",
+      "change_preferences_selector":"#changeCookiePreferences"});
+  });
 </script>
-{% endif %}
+<noscript>ePrivacy and GPDR Cookie Consent by <a href="https://www.CookieConsent.com/" rel="nofollow noopener">Cookie Consent</a></noscript>
+{% endunless %}
+<!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->
+
+<!-- analytics -->
+<script type="text/plain" cookie-consent="tracking" src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,10 +38,23 @@
 <!-- JQuery -->
 {% include scripts/jquery.html %}
 
-{% unless page.disable_cc %}
+{% unless page.disable_cc or site.disable_cc %}
 <!-- cookie  consent dialog using ihavecookies by ketan Mistry https://github.com/ketanmistry/ihavecookies -->
 <script type="text/javascript" src="{{ '/assets/js/jquery.ihavecookies.js' | relative_url }}"></script>
 <script type="text/javascript" src="{{ '/assets/js/ihavecookiesSetup.js' | relative_url }}"></script>
+{% else %}
+<script type="text/javascript">
+    console.log("cc disabled");
+    // define functions from ihavecookies.js and ihavecookiesSetup.js as if all cookies were enabled
+    $.fn.ihavecookies = {};
+    $.fn.ihavecookies.onPrefChange = function(handle) {};
+    $.fn.ihavecookies.preference = function(cookieTypeValue) {
+        return true;
+    };
+    function cookieDependentContent(cookieType, elementId, contentEnabled, contentDisabled) {
+        $(elementId).html(contentEnabled);
+    }
+</script>
 {% endunless %}
 <!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,108 +38,27 @@
 <!-- JQuery -->
 {% include scripts/jquery.html %}
 
-<!-- Theming-->
-{% if site.enable_darkmode %}
-  <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
-  <!-- Load DarkMode JS -->
-  <script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
-{% endif %}
-
-
-<!-- analytics -->
-<script type="text/javascript">
-  // funciton to enable analytics if cookie preferences allow it
-  // we call it directly here, and then also later whenver the cookie settings change
-  function enableAnalyticsIfAllowed() {
-    if ($.fn.ihavecookies && $.fn.ihavecookies.preference('analytics') == true) {
-      {% if site.enable_google_analytics %}
-        // google analytics
-        var gaScript = document.createElement('script');
-        gaScript.type = 'text/javascript';
-        gaScript.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
-        document.head.appendChild(gaScript);
-
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
-        gtag('config', '{{ site.google_analytics }}');
-      {% endif %}
-
-      {% if site.enable_panelbear_analytics %}
-        // Panelbear analytics
-        var paScript = document.createElement('script');
-        paScript.type = 'text/javascript';
-        paScript.src = 'https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}';
-        document.head.appendChild(paScript);
-
-        window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
-        panelbear('config', { site: '{{site.panelbear_analytics}}' });
-      {% endif %}
-    }
-  }
-  enableAnalyticsIfAllowed();
-</script>
-
 {% unless page.disable_cc %}
 <!-- cookie  consent dialog using ihavecookies by ketan Mistry https://github.com/ketanmistry/ihavecookies -->
 <script type="text/javascript" src="{{ '/assets/js/jquery.ihavecookies.js' | relative_url }}"></script>
+<script type="text/javascript" src="{{ '/assets/js/ihavecookiesSetup.js' | relative_url }}"></script>
+{% endunless %}
+<!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->
+
+<!-- analytics -->
+<script type="text/plain" src="{{ '/assets/js/analytics.js' | relative_url }}"></script>
+
+<!-- Theming-->
+{% if site.enable_darkmode %}
+<script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
+<!-- Load DarkMode JS -->
+<script src="{{ '/assets/js/dark_mode.js' | relative_url }}"></script>
+<!-- try to store color theme when cookie preferences are updated -->
 <script type="text/javascript">
-
-  // setup ihavecookies options
-  var options = {
-    title: '&#x1F36A; Accept Cookies?',
-    message: 'We use cookies to enhance your experience on this website and to enable third party services.',
-    delay: 600,
-    expires: 30,
-    link: '{{site.cookie_info}}',
-    acceptBtnLabel: 'Accept All',
-    moreInfoLabel: 'More information',
-    cookieTypesTitle: 'Select which cookies you want to accept',
-    fixedCookieTypeLabel: 'Essential',
-    cookieTypes: [
-      {
-        type: 'Preferences',
-        value: 'preferences',
-        description: 'These are cookies that are related to your site preferences, e.g. remembering the color theme.'
-      },
-      {
-        type: 'Social',
-        value: 'social',
-        description: 'Cookies needed for social features (e.g. reading and writing comments), ' +
-                'as well as displaying external content (e.g. from YouTube or twitter)'
-      },
-      {
-        type: 'Analytics',
-        value: 'analytics',
-        description: 'Cookies we use to analyse the site usage.'
-      }
-    ]
-  }
-
   $.fn.ihavecookies.onPrefChange( function() {
-    // analytics
-    enableAnalyticsIfAllowed();
-    // store color theme
     if ($.fn.ihavecookies && $.fn.ihavecookies.preference('preferences') == true) {
       localStorage.setItem("theme", sessionStorage.getItem("theme"));
     }
-
-    console.log("cookie pref changed");
-
-  });
-
-  // run ihavecookies when document is ready
-  $(document).ready(function() {
-    $('body').ihavecookies(options);
-
-    if ($.fn.ihavecookies.preference('marketing') === true) {
-      console.log('This should run because marketing is accepted.');
-    }
-
-    $('#footerCookieSettings').on('click', function(){
-      $('body').ihavecookies(options, 'reinit');
-    });
   });
 </script>
-{% endunless %}
-<!-- include scripts that use cokies and tracking stuff as text/plain and add cookie-consent="<category>"-->
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,18 +20,20 @@ layout: default
   </article>
 
   {% if site.disqus_shortname and page.comments %}
-    <div id="disqus_thread"></div>
-    <script type="text/javascript">
-      var disqus_shortname  = '{{ site.disqus_shortname }}';
-      var disqus_identifier = '{{ page.id }}';
-      var disqus_title      = {{ page.title | jsonify }};
-      (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-      })();
-    </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+  <hr>
+  <div id="disqus_thread">Please enable functional cookies in the cookie preferences (botom of the page) to view the <a href="http://disqus.com/">comments powered by Disqus.</a></div>
+  <script type="text/plain" cookie-consent="functionality">
+    var disqus_shortname  = '{{ site.disqus_shortname }}';
+    var disqus_identifier = '{{ page.id }}';
+    var disqus_title      = {{ page.title | jsonify }};
+    function loadDisqus() {
+      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    };
+    loadDisqus();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
   {% endif %}
 
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,17 +21,31 @@ layout: default
 
   {% if site.disqus_shortname and page.comments %}
   <hr>
-  <div id="disqus_thread">Please enable functional cookies in the cookie preferences (botom of the page) to view the <a href="http://disqus.com/">comments powered by Disqus.</a></div>
-  <script type="text/plain" cookie-consent="functionality">
-    var disqus_shortname  = '{{ site.disqus_shortname }}';
-    var disqus_identifier = '{{ page.id }}';
-    var disqus_title      = {{ page.title | jsonify }};
-    function loadDisqus() {
-      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    };
-    loadDisqus();
+  <div id="disqus_thread"></div>
+  <script type="text/javascript">
+    function handleDisqus() {
+      if ($.fn.ihavecookies && $.fn.ihavecookies.preference("social") == true) {
+        var disqus_shortname = '{{ site.disqus_shortname }}';
+        var disqus_identifier = '{{ page.id }}';
+        var disqus_title = '{{ page.title | jsonify }}';
+
+        var dsq = document.createElement('script');
+        dsq.type = 'text/javascript';
+        dsq.id = 'disqus_script';
+        dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+      } else {
+        var disableText = 'Please enable "social" cookies in the <button class="cookieSettings">Cookie Preferences</button> to view the <a href="http://disqus.com/">comments powered by Disqus.</a>';
+        $("#disqus_thread").html(disableText); // display the new text
+        $('#disqus_thread').attr('style',''); // also reset style
+        $("#disqus_script").remove(); // remove the disqus script
+      }
+    }
+    // try to enable disqus now
+    handleDisqus();
+    // try to enable disqus when settings change
+    $.fn.ihavecookies.onPrefChange(handleDisqus);
   </script>
   <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
   {% endif %}

--- a/_posts/2021-03-20-youtube.md
+++ b/_posts/2021-03-20-youtube.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: a post with youtube
+date: 2021-03-20 11:12:00-0400
+description: an example of a blog post with a youtube video
+---
+A sample blog page that demonstrates the inclusion of youtube videos depending on the users cookie consent setting
+
+<br />
+
+# Video
+An example of embedding a youtube video: 
+
+<div>
+<div id="yt-wrap" style="position:relative; padding-top:56.25%; background-color: lightgray;">
+<div style="text-align:center; position:absolute;top:0;left:0;width:100%;height:100%; display:flex; justify-content:center; align-items:center;">
+<p style="color:black;">Please enable functional cookies in the cookie preferences (botom of the page),<br> to view the video. Or view on <a href="https://youtu.be/PUyE3j0aoMw">youtube</a>.</p>
+</div>
+</div>
+</div>
+<script type="text/plain" cookie-consent="functionality"> 
+var obj = {"video": {"value": "<iframe style='position:absolute;top:0;left:0;width:100%;height:100%;' \
+src='https://www.youtube-nocookie.com/embed/ekthcIHDt3I' frameborder='0'; allow='accelerometer; autoplay; \
+clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>"}};
+$("#yt-wrap").html(obj.video.value);
+</script>
+

--- a/_posts/2021-03-20-youtube.md
+++ b/_posts/2021-03-20-youtube.md
@@ -13,15 +13,19 @@ An example of embedding a youtube video:
 
 <div>
 <div id="yt-wrap" style="position:relative; padding-top:56.25%; background-color: lightgray;">
-<div style="text-align:center; position:absolute;top:0;left:0;width:100%;height:100%; display:flex; justify-content:center; align-items:center;">
-<p style="color:black;">Please enable functional cookies in the cookie preferences (botom of the page),<br> to view the video. Or view on <a href="https://youtu.be/PUyE3j0aoMw">youtube</a>.</p>
+<!-- below javascript will put the video here -->
 </div>
 </div>
-</div>
-<script type="text/plain" cookie-consent="functionality"> 
-var obj = {"video": {"value": "<iframe style='position:absolute;top:0;left:0;width:100%;height:100%;' \
-src='https://www.youtube-nocookie.com/embed/ekthcIHDt3I' frameborder='0'; allow='accelerometer; autoplay; \
-clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>"}};
-$("#yt-wrap").html(obj.video.value);
+<script type="text/javascript">
+cookieDependentContent('social','#yt-wrap',
+    "<iframe style='position:absolute;top:0;left:0;width:100%;height:100%;' \
+     src='https://www.youtube-nocookie.com/embed/ekthcIHDt3I' frameborder='0'; allow='accelerometer; autoplay; \
+     clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>",
+    "<div style='text-align:center; position:absolute;top:0;left:0;width:100%;height:100%; display:flex; justify-content:center; align-items:center;'> \
+     <p style='color:black;'>Please enable 'social' cookies in the <button class='cookieSettings'>Cookie Preferences</button>,<br> \
+     to view the video. Or view on <a href='https://www.youtube-nocookie.com/embed/ekthcIHDt3I'>youtube</a>.</p> \
+     </div>");
 </script>
+
+
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -19,6 +19,17 @@ a, table.table a {
   }
 }
 
+// fix hr tag
+hr {
+  background-color: var(--global-text-color);
+  border-color: var(--global-text-color);
+}
+
+// fix card title
+.card-title {
+  color: black;
+}
+
 // Math
 
 .equation {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -196,7 +196,13 @@ hr {
 
 
 // Footer
-footer.fixed-bottom {
+#footer-wrapper {
+  pointer-events: none;
+}
+footer {
+  pointer-events: auto;
+}
+footer.fixed_footer {
   background-color: var(--global-footer-bg-color);
   font-size: 0.75rem;
   .container {
@@ -213,7 +219,7 @@ footer.fixed-bottom {
   }
 }
 
-footer.sticky-bottom {
+footer.sticky_footer {
   border-top: 1px solid $grey-color-light;
   padding-top: 40px;
   padding-bottom: 40px;
@@ -440,65 +446,46 @@ html.transition *:after {
   transition-delay: 0 !important;
 }
 
-/* Cookie Dialog */
+// cookie dialog
+#ihavecookiePlaceholder {
+  text-align: right;
+}
 #gdpr-cookie-message {
-  position: fixed;
-  right: 30px;
-  bottom: 30px;
-  max-width: 375px;
-  background-color: var(--purple);
-  padding: 20px;
-  border-radius: 5px;
-  box-shadow: 0 6px 6px rgba(0,0,0,0.25);
+  pointer-events: auto;
+  padding: 15px 15px 5px 15px;
+  display: inline-block;
+  text-align: left;
+  max-width: 400px;
+  background-color: var(--global-bg-color);
+  border-radius: 8px 8px 0px 0px;
+  border-top: 4px solid var(--global-footer-bg-color);
+  border-left: 4px solid var(--global-footer-bg-color);
+  border-right: 4px solid var(--global-footer-bg-color);
+  box-shadow: 0px -5px 8px -5px rgba(0,0,0,0.25),
+              5px 0px 8px -6px rgba(0,0,0,0.25),
+              -5px 0px 8px -6px rgba(0,0,0,0.25);
   margin-left: 30px;
-  font-family: system-ui;
+  font-size: 0.9rem;
 }
 #gdpr-cookie-message h4 {
-  color: var(--red);
-  font-family: 'Quicksand', sans-serif;
-  font-size: 18px;
-  font-weight: 500;
+  color: var(--global-theme-color);
+  font-weight: 700;
   margin-bottom: 10px;
 }
 #gdpr-cookie-message h5 {
-  color: var(--red);
-  font-family: 'Quicksand', sans-serif;
-  font-size: 15px;
+  color: var(--global-theme-color);
   font-weight: 500;
   margin-bottom: 10px;
-}
-#gdpr-cookie-message p, #gdpr-cookie-message ul {
-  color: white;
-  font-size: 15px;
-  line-height: 1.5em;
-}
-#gdpr-cookie-message p:last-child {
-  margin-bottom: 0;
-  text-align: right;
+  font-size: 1.1rem;
 }
 #gdpr-cookie-message li {
   width: 49%;
   display: inline-block;
 }
-#gdpr-cookie-message a {
-  color: var(--red);
-  text-decoration: none;
-  font-size: 15px;
-  padding-bottom: 2px;
-  border-bottom: 1px dotted rgba(255,255,255,0.75);
-  transition: all 0.3s ease-in;
-}
-#gdpr-cookie-message a:hover {
-  color: white;
-  border-bottom-color: var(--red);
-  transition: all 0.3s ease-in;
-}
 #gdpr-cookie-message button{
   border: none;
-  background: var(--red);
-  color: white;
-  font-family: 'Quicksand', sans-serif;
-  font-size: 15px;
+  background: var(--global-theme-color);
+  color: var(--global-text-color);
   padding: 7px;
   border-radius: 3px;
   margin-left: 15px;
@@ -506,13 +493,13 @@ html.transition *:after {
   transition: all 0.3s ease-in;
 }
 #gdpr-cookie-message button:hover {
-  background: white;
-  color: var(--red);
+  background: var(--global-text-color);
+  color: var(--global-theme-color);
   transition: all 0.3s ease-in;
 }
 button#gdpr-cookie-advanced {
-  background: white;
-  color: var(--red);
+  background: var(--global-footer-bg-color);
+  color: var(--global-theme-color);
 }
 #gdpr-cookie-message button:disabled {
   opacity: 0.3;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -439,3 +439,86 @@ html.transition *:after {
   transition: all 750ms !important;
   transition-delay: 0 !important;
 }
+
+/* Cookie Dialog */
+#gdpr-cookie-message {
+  position: fixed;
+  right: 30px;
+  bottom: 30px;
+  max-width: 375px;
+  background-color: var(--purple);
+  padding: 20px;
+  border-radius: 5px;
+  box-shadow: 0 6px 6px rgba(0,0,0,0.25);
+  margin-left: 30px;
+  font-family: system-ui;
+}
+#gdpr-cookie-message h4 {
+  color: var(--red);
+  font-family: 'Quicksand', sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+#gdpr-cookie-message h5 {
+  color: var(--red);
+  font-family: 'Quicksand', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  margin-bottom: 10px;
+}
+#gdpr-cookie-message p, #gdpr-cookie-message ul {
+  color: white;
+  font-size: 15px;
+  line-height: 1.5em;
+}
+#gdpr-cookie-message p:last-child {
+  margin-bottom: 0;
+  text-align: right;
+}
+#gdpr-cookie-message li {
+  width: 49%;
+  display: inline-block;
+}
+#gdpr-cookie-message a {
+  color: var(--red);
+  text-decoration: none;
+  font-size: 15px;
+  padding-bottom: 2px;
+  border-bottom: 1px dotted rgba(255,255,255,0.75);
+  transition: all 0.3s ease-in;
+}
+#gdpr-cookie-message a:hover {
+  color: white;
+  border-bottom-color: var(--red);
+  transition: all 0.3s ease-in;
+}
+#gdpr-cookie-message button{
+  border: none;
+  background: var(--red);
+  color: white;
+  font-family: 'Quicksand', sans-serif;
+  font-size: 15px;
+  padding: 7px;
+  border-radius: 3px;
+  margin-left: 15px;
+  cursor: pointer;
+  transition: all 0.3s ease-in;
+}
+#gdpr-cookie-message button:hover {
+  background: white;
+  color: var(--red);
+  transition: all 0.3s ease-in;
+}
+button#gdpr-cookie-advanced {
+  background: white;
+  color: var(--red);
+}
+#gdpr-cookie-message button:disabled {
+  opacity: 0.3;
+}
+#gdpr-cookie-message input[type="checkbox"] {
+  float: none;
+  margin-top: 0;
+  margin-right: 5px;
+}

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,26 @@
+---
+---
+
+{% if site.enable_google_analytics %}
+    // google analytics
+    var gaScript = document.createElement('script');
+    gaScript.type = 'text/javascript';
+    gaScript.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
+    document.head.appendChild(gaScript);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{ site.google_analytics }}');
+{% endif %}
+
+{% if site.enable_panelbear_analytics %}
+    // Panelbear analytics
+    var paScript = document.createElement('script');
+    paScript.type = 'text/javascript';
+    paScript.src = 'https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}';
+    document.head.appendChild(paScript);
+
+    window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
+    panelbear('config', { site: '{{site.panelbear_analytics}}' });
+{% endif %}

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -32,7 +32,6 @@ function enableAnalyticsIfAllowed() {
 
 // try to enable analytics after preferences changed
 $.fn.ihavecookies.onPrefChange( function() {
-    // analytics
     enableAnalyticsIfAllowed();
 });
 

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,26 +1,40 @@
 ---
 ---
 
-{% if site.enable_google_analytics %}
-    // google analytics
-    var gaScript = document.createElement('script');
-    gaScript.type = 'text/javascript';
-    gaScript.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
-    document.head.appendChild(gaScript);
+// funciton to enable analytics if cookie preferences allow it
+function enableAnalyticsIfAllowed() {
+    if ($.fn.ihavecookies && $.fn.ihavecookies.preference('analytics') == true) {
+        {% if site.enable_google_analytics %}
+        // google analytics
+        var gaScript = document.createElement('script');
+        gaScript.type = 'text/javascript';
+        gaScript.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}';
+        document.head.appendChild(gaScript);
 
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', '{{ site.google_analytics }}');
-{% endif %}
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '{{ site.google_analytics }}');
+        {% endif %}
 
-{% if site.enable_panelbear_analytics %}
-    // Panelbear analytics
-    var paScript = document.createElement('script');
-    paScript.type = 'text/javascript';
-    paScript.src = 'https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}';
-    document.head.appendChild(paScript);
+        {% if site.enable_panelbear_analytics %}
+        // Panelbear analytics
+        var paScript = document.createElement('script');
+        paScript.type = 'text/javascript';
+        paScript.src = 'https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}';
+        document.head.appendChild(paScript);
 
-    window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
-    panelbear('config', { site: '{{site.panelbear_analytics}}' });
-{% endif %}
+        window.panelbear = window.panelbear || function() { (window.panelbear.q = window.panelbear.q || []).push(arguments); };
+        panelbear('config', { site: '{{site.panelbear_analytics}}' });
+        {% endif %}
+    }
+}
+
+// try to enable analytics after preferences changed
+$.fn.ihavecookies.onPrefChange( function() {
+    // analytics
+    enableAnalyticsIfAllowed();
+});
+
+// try to enable analytics now
+enableAnalyticsIfAllowed();

--- a/assets/js/dark_mode.js
+++ b/assets/js/dark_mode.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
     const mode_toggle = document.getElementById("light-toggle");
 
     mode_toggle.addEventListener("click", function() {
-        const temp = localStorage.getItem("theme");
+        const temp = sessionStorage.getItem("theme");
         toggleTheme(temp);
     });
 
@@ -22,7 +22,10 @@ $(document).ready(function() {
         else {
             document.documentElement.removeAttribute("data-theme");
         }
-        localStorage.setItem("theme", theme);
+        sessionStorage.setItem("theme", theme);
+        if(allowThemeStored == true) {
+            localStorage.setItem("theme", theme);
+        }
     };
 
     let trans = () => {

--- a/assets/js/dark_mode.js
+++ b/assets/js/dark_mode.js
@@ -23,7 +23,9 @@ $(document).ready(function() {
             document.documentElement.removeAttribute("data-theme");
         }
         sessionStorage.setItem("theme", theme);
-        if(allowThemeStored == true) {
+
+        // store also in persistent storage if user allowed it
+        if($.fn.ihavecookies && $.fn.ihavecookies.preference('preferences') === true) {
             localStorage.setItem("theme", theme);
         }
     };

--- a/assets/js/ihavecookiesSetup.js
+++ b/assets/js/ihavecookiesSetup.js
@@ -1,0 +1,42 @@
+---
+---
+
+// setup ihavecookies options
+var options = {
+    title: '&#x1F36A; Accept Cookies?',
+    message: 'We use cookies to enhance your experience on this website and to enable third party services.',
+    delay: 600,
+    expires: 30,
+    link: '{{site.cookie_info}}',
+    acceptBtnLabel: 'Accept All',
+    moreInfoLabel: 'More information',
+    cookieTypesTitle: 'Select which cookies you want to accept',
+    fixedCookieTypeLabel: 'Essential',
+    cookieTypes: [
+        {
+            type: 'Preferences',
+            value: 'preferences',
+            description: 'These are cookies that are related to your site preferences, e.g. remembering the color theme.'
+        },
+        {
+            type: 'Social',
+            value: 'social',
+            description: 'Cookies needed for social features (e.g. reading and writing comments), ' +
+                'as well as displaying external content (e.g. from YouTube or twitter)'
+        },
+        {
+            type: 'Analytics',
+            value: 'analytics',
+            description: 'Cookies we use to analyse the site usage.'
+        }
+    ]
+}
+
+// run ihavecookies when document is ready
+$(document).ready(function() {
+    $('body').ihavecookies(options);
+
+    $('#footerCookieSettings').on('click', function(){
+        $('body').ihavecookies(options, 'reinit');
+    });
+});

--- a/assets/js/ihavecookiesSetup.js
+++ b/assets/js/ihavecookiesSetup.js
@@ -4,11 +4,12 @@
 // setup ihavecookies options
 var options = {
     title: '&#x1F36A; Accept Cookies?',
-    message: 'We use cookies to enhance your experience on this website and to enable third party services.',
+    message: 'We use cookies to enhance your experience on this website ' +
+             'and to display content from third party websites.',
     delay: 600,
     expires: 30,
     link: '{{site.cookie_info}}',
-    acceptBtnLabel: 'Accept All',
+    acceptBtnLabel: 'Accept',
     moreInfoLabel: 'More information',
     cookieTypesTitle: 'Select which cookies you want to accept',
     fixedCookieTypeLabel: 'Essential',
@@ -34,12 +35,12 @@ var options = {
 
 // run ihavecookies when document is ready
 $(document).ready(function() {
-    $('body').ihavecookies(options);
+    $('#ihavecookiePlaceholder').ihavecookies(options);
 
     $('.cookieSettings').on('click', function (event) {
         event.stopPropagation();
         event.stopImmediatePropagation();
-        $('body').ihavecookies(options, 'reinit');
+        $('#ihavecookiePlaceholder').ihavecookies(options, 'reinit');
     });
 });
 

--- a/assets/js/ihavecookiesSetup.js
+++ b/assets/js/ihavecookiesSetup.js
@@ -1,6 +1,9 @@
 ---
 ---
 
+// get ihavecookies
+
+
 // setup ihavecookies options
 var options = {
     title: '&#x1F36A; Accept Cookies?',

--- a/assets/js/ihavecookiesSetup.js
+++ b/assets/js/ihavecookiesSetup.js
@@ -36,7 +36,32 @@ var options = {
 $(document).ready(function() {
     $('body').ihavecookies(options);
 
-    $('#footerCookieSettings').on('click', function(){
+    $('.cookieSettings').on('click', function (event) {
+        event.stopPropagation();
+        event.stopImmediatePropagation();
         $('body').ihavecookies(options, 'reinit');
     });
 });
+
+/* Helper function to enable / disable content based on the cookie setting
+ cookieType: the type of cookie this code depends on
+ elementId: the html element the content will be appended to
+ contentEnables: content if cookie is enabled
+ contentDisables: content if cookie is disabled
+ */
+function cookieDependentContent(cookieType, elementId, contentEnabled, contentDisabled) {
+    function enableHelper() {
+        if ($.fn.ihavecookies && $.fn.ihavecookies.preference(cookieType) == true) {
+            $(elementId).html(contentEnabled);
+        } else {
+            $(elementId).html(contentDisabled);
+        }
+    }
+    // run now to apply settings at page load
+    enableHelper();
+    // attach to callback, to apply on preferences change
+    $.fn.ihavecookies.onPrefChange( function() {
+        enableHelper();
+    });
+}
+

--- a/assets/js/jquery.ihavecookies.js
+++ b/assets/js/jquery.ihavecookies.js
@@ -1,0 +1,219 @@
+/*!
+ * ihavecookies - jQuery plugin for displaying cookie/privacy message
+ * v0.3.2
+ *
+ * Copyright (c) 2018 Ketan Mistry (https://iamketan.com.au)
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/mit-license.php
+ *
+ */
+(function($) {
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cookie Message
+    |--------------------------------------------------------------------------
+    |
+    | Displays the cookie message on first visit or 30 days after their
+    | last visit.
+    |
+    | @param event - 'reinit' to reopen the cookie message
+    |
+    */
+    $.fn.ihavecookies = function(options, event) {
+
+        var $element = $(this);
+
+        // Set defaults
+        var settings = $.extend({
+            cookieTypes: [
+                {
+                    type: 'Site Preferences',
+                    value: 'preferences',
+                    description: 'These are cookies that are related to your site preferences, e.g. remembering your username, site colours, etc.'
+                },
+                {
+                    type: 'Analytics',
+                    value: 'analytics',
+                    description: 'Cookies related to site visits, browser types, etc.'
+                },
+                {
+                    type: 'Marketing',
+                    value: 'marketing',
+                    description: 'Cookies related to marketing, e.g. newsletters, social media, etc'
+                }
+            ],
+            title: 'Cookies & Privacy',
+            message: 'Cookies enable you to use shopping carts and to personalize your experience on our sites, tell us which parts of our websites people have visited, help us measure the effectiveness of ads and web searches, and give us insights into user behavior so we can improve our communications and products.',
+            link: '/privacy-policy',
+            delay: 2000,
+            expires: 30,
+            moreInfoLabel: 'More information',
+            acceptBtnLabel: 'Accept Cookies',
+            advancedBtnLabel: 'Customise Cookies',
+            cookieTypesTitle: 'Select cookies to accept',
+            fixedCookieTypeLabel:'Necessary',
+            fixedCookieTypeDesc: 'These are cookies that are essential for the website to work correctly.',
+            onAccept: function(){},
+            uncheckBoxes: false
+        }, options);
+
+        var myCookie = getCookie('cookieControl');
+        var myCookiePrefs = getCookie('cookieControlPrefs');
+        if (!myCookie || !myCookiePrefs || event == 'reinit') {
+            // Remove all instances of the cookie message so it's not duplicated
+            $('#gdpr-cookie-message').remove();
+
+            // Set the 'necessary' cookie type checkbox which can not be unchecked
+            var cookieTypes = '<li><input type="checkbox" name="gdpr[]" value="necessary" checked="checked" disabled="disabled"> <label title="' + settings.fixedCookieTypeDesc + '">' + settings.fixedCookieTypeLabel + '</label></li>';
+
+            // Generate list of cookie type checkboxes
+            preferences = JSON.parse(myCookiePrefs);
+            $.each(settings.cookieTypes, function(index, field) {
+                if (field.type !== '' && field.value !== '') {
+                    var cookieTypeDescription = '';
+                    if (field.description !== false) {
+                        cookieTypeDescription = ' title="' + field.description + '"';
+                    }
+                    cookieTypes += '<li><input type="checkbox" id="gdpr-cookietype-' + field.value + '" name="gdpr[]" value="' + field.value + '" data-auto="on"> <label for="gdpr-cookietype-' + field.value + '"' + cookieTypeDescription + '>' + field.type + '</label></li>';
+                }
+            });
+
+            // Display cookie message on page
+            var cookieMessage = '<div id="gdpr-cookie-message"><h4>' + settings.title + '</h4><p>' + settings.message + ' <a href="' + settings.link + '">' + settings.moreInfoLabel + '</a><div id="gdpr-cookie-types" style="display:none;"><h5>' + settings.cookieTypesTitle + '</h5><ul>' + cookieTypes + '</ul></div><p><button id="gdpr-cookie-accept" type="button">' + settings.acceptBtnLabel + '</button><button id="gdpr-cookie-advanced" type="button">' + settings.advancedBtnLabel + '</button></p></div>';
+            setTimeout(function(){
+                $($element).append(cookieMessage);
+                $('#gdpr-cookie-message').hide().fadeIn('slow', function(){
+                    // If reinit'ing, open the advanced section of message
+                    // and re-check all previously selected options.
+                    if (event == 'reinit') {
+                        $('#gdpr-cookie-advanced').trigger('click');
+                        $.each(preferences, function(index, field) {
+                            $('input#gdpr-cookietype-' + field).prop('checked', true);
+                        });
+                    }
+                });
+            }, settings.delay);
+
+            // When accept button is clicked drop cookie
+            $('body').on('click','#gdpr-cookie-accept', function(){
+                // Set cookie
+                dropCookie(true, settings.expires);
+
+                // If 'data-auto' is set to ON, tick all checkboxes because
+                // the user hasn't clicked the customise cookies button
+                $('input[name="gdpr[]"][data-auto="on"]').prop('checked', true);
+
+                // Save users cookie preferences (in a cookie!)
+                var prefs = [];
+                $.each($('input[name="gdpr[]"]').serializeArray(), function(i, field){
+                    prefs.push(field.value);
+                });
+                setCookie('cookieControlPrefs', encodeURIComponent(JSON.stringify(prefs)), 365);
+
+                // Run callback function
+                settings.onAccept.call(this);
+            });
+
+            // Toggle advanced cookie options
+            $('body').on('click', '#gdpr-cookie-advanced', function(){
+                // Uncheck all checkboxes except for the disabled 'necessary'
+                // one and set 'data-auto' to OFF for all. The user can now
+                // select the cookies they want to accept.
+                $('input[name="gdpr[]"]:not(:disabled)').attr('data-auto', 'off').prop('checked', false);
+                $('#gdpr-cookie-types').slideDown('fast', function(){
+                    $('#gdpr-cookie-advanced').prop('disabled', true);
+                });
+            });
+
+        } else {
+            var cookieVal = true;
+            if (myCookie == 'false') {
+                cookieVal = false;
+            }
+            dropCookie(cookieVal, settings.expires);
+        }
+
+        // Uncheck any checkboxes on page load
+        if (settings.uncheckBoxes === true) {
+            $('input[type="checkbox"].ihavecookies').prop('checked', false);
+        }
+
+    };
+
+    // Method to get cookie value
+    $.fn.ihavecookies.cookie = function() {
+        var preferences = getCookie('cookieControlPrefs');
+        return JSON.parse(preferences);
+    };
+
+    // Method to check if user cookie preference exists
+    $.fn.ihavecookies.preference = function(cookieTypeValue) {
+        var control = getCookie('cookieControl');
+        var preferences = getCookie('cookieControlPrefs');
+        preferences = JSON.parse(preferences);
+        if (control === false) {
+            return false;
+        }
+        if (preferences === false || preferences.indexOf(cookieTypeValue) === -1) {
+            return false;
+        }
+        return true;
+    };
+
+    /*
+    |--------------------------------------------------------------------------
+    | Drop Cookie
+    |--------------------------------------------------------------------------
+    |
+    | Function to drop the cookie with a boolean value of true.
+    |
+    */
+    var dropCookie = function(value, expiryDays) {
+        setCookie('cookieControl', value, expiryDays);
+        $('#gdpr-cookie-message').fadeOut('fast', function() {
+            $(this).remove();
+        });
+    };
+
+    /*
+    |--------------------------------------------------------------------------
+    | Set Cookie
+    |--------------------------------------------------------------------------
+    |
+    | Sets cookie with 'name' and value of 'value' for 'expiry_days'.
+    |
+    */
+    var setCookie = function(name, value, expiry_days) {
+        var d = new Date();
+        d.setTime(d.getTime() + (expiry_days*24*60*60*1000));
+        var expires = "expires=" + d.toUTCString();
+        document.cookie = name + "=" + value + ";" + expires + ";path=/";
+        return getCookie(name);
+    };
+
+    /*
+    |--------------------------------------------------------------------------
+    | Get Cookie
+    |--------------------------------------------------------------------------
+    |
+    | Gets cookie called 'name'.
+    |
+    */
+    var getCookie = function(name) {
+        var cookie_name = name + "=";
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(cookie_name) === 0) {
+                return c.substring(cookie_name.length, c.length);
+            }
+        }
+        return false;
+    };
+
+}(jQuery));

--- a/assets/js/jquery.ihavecookies.js
+++ b/assets/js/jquery.ihavecookies.js
@@ -9,6 +9,9 @@
  */
 (function($) {
 
+    // store handler to be called when preferences are changed
+    var prefChangeHandlers = [];
+
     /*
     |--------------------------------------------------------------------------
     | Cookie Message
@@ -54,7 +57,6 @@
             cookieTypesTitle: 'Select cookies to accept',
             fixedCookieTypeLabel:'Necessary',
             fixedCookieTypeDesc: 'These are cookies that are essential for the website to work correctly.',
-            onAccept: function(){},
             uncheckBoxes: false
         }, options);
 
@@ -112,7 +114,8 @@
                 setCookie('cookieControlPrefs', encodeURIComponent(JSON.stringify(prefs)), 365);
 
                 // Run callback function
-                settings.onAccept.call(this);
+                for (const handler of prefChangeHandlers)
+                    handler(this);
             });
 
             // Toggle advanced cookie options
@@ -139,6 +142,11 @@
             $('input[type="checkbox"].ihavecookies').prop('checked', false);
         }
 
+    };
+
+    // Register allback to be executed whenever
+    $.fn.ihavecookies.onPrefChange = function(handler) {
+        prefChangeHandlers.push(handler);
     };
 
     // Method to get cookie value

--- a/assets/js/jquery.ihavecookies.js
+++ b/assets/js/jquery.ihavecookies.js
@@ -82,7 +82,13 @@
             });
 
             // Display cookie message on page
-            var cookieMessage = '<div id="gdpr-cookie-message"><h4>' + settings.title + '</h4><p>' + settings.message + ' <a href="' + settings.link + '">' + settings.moreInfoLabel + '</a><div id="gdpr-cookie-types" style="display:none;"><h5>' + settings.cookieTypesTitle + '</h5><ul>' + cookieTypes + '</ul></div><p><button id="gdpr-cookie-accept" type="button">' + settings.acceptBtnLabel + '</button><button id="gdpr-cookie-advanced" type="button">' + settings.advancedBtnLabel + '</button></p></div>';
+            var cookieMessage = '<div id="gdpr-cookie-message" data-nosnippet="data-nosnippet"><h4>'
+                + settings.title + '</h4><p>' + settings.message + ' <a href="' + settings.link + '">'
+                + settings.moreInfoLabel + '</a><div id="gdpr-cookie-types" style="display:none;"><h5>'
+                + settings.cookieTypesTitle + '</h5><ul>' + cookieTypes
+                + '</ul></div><p><button id="gdpr-cookie-accept" type="button">' + settings.acceptBtnLabel
+                + '</button><button id="gdpr-cookie-advanced" type="button">' + settings.advancedBtnLabel
+                + '</button></p></div>';
             setTimeout(function(){
                 $($element).append(cookieMessage);
                 $('#gdpr-cookie-message').hide().fadeIn('slow', function(){

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,9 +1,15 @@
 // Has to be in the head tag, otherwise a flicker effect will occur.
-let initTheme = (theme) => {
+let initTheme = () => {
+
+  var theme = localStorage.getItem("theme");
+  if (theme == null) {
+    theme = sessionStorage.getItem("theme");
+  }
+
   if (theme == null) {
     const userPref = window.matchMedia;
     if (userPref && userPref('(prefers-color-scheme: dark)').matches) {
-        theme = 'dark';
+      theme = 'dark';
     }
   }
 
@@ -11,7 +17,8 @@ let initTheme = (theme) => {
     document.documentElement.setAttribute('data-theme', theme)
   }
 
-  localStorage.setItem("theme", theme);
+  sessionStorage.setItem("theme", theme);
 }
 
-initTheme(localStorage.getItem("theme"));
+
+initTheme();


### PR DESCRIPTION
Adds a cookie consent notice as discussed in #199.

Currently the notice is scrolled up and down, even if the header is set to fixed, which looks a bit strange. 
Also we would somehow need to block the embedded twitter tweets in the twitter example, as they generate cookies as well.
I added a new example on how to block a youtube video based on the cookie settings, but I do not use the twitter plugin myself.

resolves #199