### PR TITLE
Update Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 _site
 .bundle
 .sass-cache
+.jekyll-cache
 .jekyll-metadata
 .DS_store
 .ruby-version
-.tweet-cache/
+.tweet-cache
 Gemfile.lock
 vendor

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 group :jekyll_plugins do
-    gem 'github-pages'
     gem 'jekyll'
     gem 'jekyll-email-protect'
     gem 'jekyll-github-metadata'
@@ -9,4 +8,5 @@ group :jekyll_plugins do
     gem 'jekyll-twitter-plugin'
     gem 'jemoji'
     gem 'unicode_utils'
+    gem 'webrick'
 end


### PR DESCRIPTION
Allows using ruby3 and newer versions of Jekyll. Should resolve #161. Uses the changes suggested [here](https://github.com/alshedivat/al-folio/issues/161#issuecomment-751539986).