### PR TITLE
Change gitcdn link in 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,7 +25,7 @@
 <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:100,300,400,500,700|Material+Icons">
 
 <!-- Code Syntax Highlighting -->
-<link rel="stylesheet" href="https://gitcdn.link/repo/jwarby/jekyll-pygments-themes/master/{{ site.highlight_theme }}.css" />
+<link rel="stylesheet" href="https://gitcdn.xyz/repo/jwarby/jekyll-pygments-themes/master/{{ site.highlight_theme }}.css" />
 
 <!-- Styles -->
 {% if site.icon != empty %}


### PR DESCRIPTION
`gitcdn.link` was quite slow, so I tried the alternate link at `gitcdn.xyz` and there are no issues with lag anymore.
`gitcdn` was used to quickly get pygments code highlighting css themes inside `_includes/head.html` from [this](https://github.com/jwarby/jekyll-pygments-themes) repo.