### PR TITLE
Fix for project category text color in light mode

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -337,8 +337,8 @@ footer.sticky-bottom {
   }
 
   h2.category {
-    color: $grey-color-light;
-    border-bottom: 1px solid $grey-color-light;
+    color: var(--global-text-color);
+    border-bottom: 1px solid var(--global-text-color);
     padding-top: 0.5rem;
     margin-top: 2rem;
     margin-bottom: 1rem;


### PR DESCRIPTION
This is a minor fix for the Projects page's project category headers. Currently, the headers are hard-coded to light grey which makes them difficult to read in light-mode. This can be seen on the [demo website](https://alshedivat.github.io/al-folio/projects/) and in the screenshot below

![al-folio-light-theme](https://user-images.githubusercontent.com/36479843/124980426-f8dcc200-dff9-11eb-8624-0ef666c4c5d4.png)

This fix simply changes the color to the `--global-text-color` allowing the color of the headers to change based on whether the site is in light or dark mode. You can see screenshots for both light and dark mode below:

![al-folio-pr-dark-theme](https://user-images.githubusercontent.com/36479843/124980419-f7ab9500-dff9-11eb-8382-067a4d5f4781.png)
![al-folio-pr-light-theme](https://user-images.githubusercontent.com/36479843/124980423-f8442b80-dff9-11eb-94fb-42797abbdc21.png)

