### PR TITLE
Use master for the source code for personal/organization webpages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - source
   pull_request:
     branches:
       - master
-      - source
 
 jobs:
   deploy:
@@ -43,11 +41,7 @@ jobs:
         elif [[ ${GITHUB_REF} = refs/heads/* ]]; then # branch, e.g. master, source etc
           echo "::set-output name=SRC_BRANCH::${GITHUB_REF#refs/heads/}"
         fi
-        if [[ ${{ github.repository }} = *.github.io ]]; then # user/org repo
-          echo "::set-output name=DEPLOY_BRANCH::master"
-        else
-          echo "::set-output name=DEPLOY_BRANCH::gh-pages"
-        fi
+        echo "::set-output name=DEPLOY_BRANCH::gh-pages"
     - name: Deploy website 
       run:  yes | bin/deploy --verbose ${{ steps.setup.outputs.NO_PUSH }}
                     --src ${{ steps.setup.outputs.SRC_BRANCH }} 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,10 @@ Starting version [v0.3.5](https://github.com/alshedivat/al-folio/releases/tag/v0
 **For personal and organization webpages:**
 - Rename your repository to `<your-github-username>.github.io` or `<your-github-orgname>.github.io`.
 - Click on **Actions** tab and **Enable GitHub Actions**; you no need to worry about creating any workflows as everything has already been set for you.
-- In the **Settings**, select **Branches** and [rename the branch](https://docs.github.com/en/github/administering-a-repository/renaming-a-branch) with the source code from `master` to `source`. From now on, this will be your default branch. Any changes you make should be committed and pushed to this branch.
 - Make sure the `url` and `baseurl` fields in `_config.yml` are empty.
 - Make any other changes to your webpage, commit, and push. This will automatically trigger the **Deploy** action.
 - Wait for a few minutes and let the action complete. You can see the progress in the **Actions** tab. If completed successfully, in addition to the `source` branch, your repository should now have a newly built `master` branch.
-- Finally, again in the **Settings**, in the Pages section, set the branch to `master` (**NOT** to `source`).
-
-**NOTE**: you **must** do all your changes in the `source` branch (the one you used to push) **NOT the master** one; this last one is used for **deploying** by Github Pages and it is not suitable for pushing changes.
+- Finally, in the **Settings**, in the Pages section, set the branch to `gh-pages` (**NOT** to `master`).
 
 <details><summary><strong>Manual deployment to GitHub Pages:</strong></summary>
 


### PR DESCRIPTION
This PR is for https://github.com/alshedivat/al-folio/issues/342 and makes the following changes:

1. Always push the generated website code to `gh-pages`.
2. Update the documentation for the personal/organization webpages.