### PR TITLE
Fix latex rendering issue in the bibliography entries

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -165,6 +165,7 @@ scholar:
 
   replace_strings: true
   join_strings: true
+  bibtex_filters:
 
   details_dir: bibliography
   details_layout: bibtex.html
@@ -208,7 +209,7 @@ jquery:
   version: "3.5.1"
   integrity: "sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg=="
 mathjax:
-  version: "3.1.2"
+  version: "3.2.0"
 mansory:
   version: "4.2.2"
   integrity: "sha256-Nn1q/fx0H7SNLZMQ5Hw5JLaTRZp0yILA/FRexe19VdI="


### PR DESCRIPTION
Fixes #357.

The problem stems from [the default `bibtex_filters`](https://github.com/inukshuk/jekyll-scholar#configuration) applied by `jekyll-scholar` to each field of each bib entry. Since al-folio uses mathjax, these filters are unnecessary.

Also, bump up the MathJAX version to 3.2.0.