### PR TITLE
minor updates to CONTRIBUTING and LICENSE, add website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Before submitting an issue, please make sure:
 1. You have read [the FAQ section](https://github.com/alshedivat/al-folio#faq) of the README and your question is NOT addressed there.
 2. You have done your best to ensure that your issue is NOT a duplicate of one of [the previous issues](https://github.com/alshedivat/al-folio/issues).
 3. Your issue is either a bug (unexpected/undesirable behavior) or a feature request.
-If it is just a question, please ask it on [gitter](https://gitter.im/alshedivat/al-folio).
+If it is just a question, please ask it in the [Discussions](https://github.com/alshedivat/al-folio/discussions) forum.
 
 When submitting an issue, please make sure to use the appropriate template.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Maruan Al-Shedivat.
+Copyright (c) 2021 Maruan Al-Shedivat.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://zrqiao.github.io/" target="_blank">★</a>
 <a href="https://abstractgeek.github.io/" target="_blank">★</a>
 <a href="https://www.compphys.de/" target="_blank">★</a>
+<a href="https://julianstreyczek.github.io" target="_blank">★</a>
 
 </td>
 </tr>


### PR DESCRIPTION
Love the template, thanks for all the great work! While browsing the project I noticed some outdated details and proposed some updates:

- CONTRIBUTING: Referred to the [Discussions](https://github.com/alshedivat/al-folio/discussions) forum instead of gitter for general questions (see #210)
- LICENSE: Bumped year to 2021

Also, I took the opportunity to add my website to the list of websites in README. 