### PR TITLE
Revert jekyll-scholar bibtex filters

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -162,6 +162,10 @@ scholar:
   source: /_bibliography/
   bibliography: papers.bib
   bibliography_template: bib
+  # Note: if you have latex math in your bibtex, the latex filter
+  # preprocessing may conflict with MathJAX if the latter is enabled.
+  # See https://github.com/alshedivat/al-folio/issues/357.
+  bibtex_filters: [latex, smallcaps, superscript]
 
   replace_strings: true
   join_strings: true


### PR DESCRIPTION
Reverts #358. Fixes #380.

Context: jekyll-scholar bibtex filters were removed in #358 to avoid a clash between the latex filter and mathjax (#357) when paper titles and/or abstracts have nontrivial math. However, it looks like these filters are essential for processing non-math latex, useful for the majority of the users.

The conflict between jekyll-scholar bibtex filters and mathjax is a known issue: https://github.com/inukshuk/jekyll-scholar/issues/2. We'll reopen #357 to investigate this further. For now, to avoid the clash, users can turn off bibtex filters and/or manually adjust their bibtex files.