### PR TITLE
Add 'main' branch for newer GitHub repositories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
The 'main' branch is used in newer GitHub repositories. So I've added it to the trigger list of deploy.yml.