### PR TITLE
adds color transition support to li elements

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -4,7 +4,7 @@
 
 // Typography
 
-p, h1, h2, h3, h4, h5, h6, em, div, span, strong {
+p, h1, h2, h3, h4, h5, h6, em, div, li, span, strong {
   color: var(--global-text-color);
 }
 


### PR DESCRIPTION
Adds `li` to top section inside `_sass/_base.scss` to support color change transitions rather than color popping in and out