### PR TITLE
jQuery should be load in head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,6 +43,8 @@
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | relative_url }}">
 
+{% include scripts/jquery.html %}
+
 {% if site.enable_darkmode %}
 <!-- Dark Mode -->
 <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,6 @@
 
   </body>
 
-  {% include scripts/jquery.html %}
   {% include scripts/bootstrap.html %}
   {% include scripts/mansory.html %}
   {% include scripts/misc.html %}


### PR DESCRIPTION
If jQuery load after footer get this error (chrome developer):

<img width="602" alt="Screenshot of Google Chrome (20-11-21, 01-23-17)" src="https://user-images.githubusercontent.com/28966312/142707023-99159f58-9415-4bcb-a568-441054b81341.png">

Moved to head.

