### PR TITLE
Fix broken read_time in blog/index.html

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -24,7 +24,7 @@ pagination:
   <ul class="post-list">
     {% for post in paginator.posts %}
 
-    {% assign read_time = page.content | number_of_words | divided_by: 180 | plus: 1 %}
+    {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
     {% assign year = post.date | date: "%Y" %}
     {% assign tags = post.tags | join: "" %}
     {% assign categories = post.categories | join: "" %}


### PR DESCRIPTION
Previously the `read_time` shown in blogs page is broken and always shows 2 minutes. This is due to the wrong variable name in `blog/index.html`. Simply changing `page` to `post` would fix it.