### PR TITLE
Empty entrytype if not article or inproceedings

### DIFF
--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -75,6 +75,8 @@
             {%- capture entrytype -%}<em>{{entry.journal}}</em>{%- endcapture -%}
           {%- elsif entry.type == "inproceedings" -%}
             {%- capture entrytype -%}<em>In {{entry.booktitle}}</em> {%- endcapture -%}
+          {%- else -%}
+            {%- capture entrytype -%}{%- endcapture -%}
           {%- endif -%}
           {%- if entry.month -%}
             {%- capture entrymonth -%}{{ " " }}{{ entry.month | capitalize }}{%- endcapture -%}


### PR DESCRIPTION
For bibtex entries that are neither articles nor proceedings, the value `entrytype` carries over from the previous entry in the loop, leading to incorrect displays. This PR fixes that.