### PR TITLE
Added documentation on publication buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,25 @@ If the entry matches one of the combinations of the last names and the first nam
 
 </details>
 
+<details><summary>(click to expand) <strong>Buttons (through custom bibtex keywords):</strong></summary>
 
+There are several custom bibtex keywords that you can use to affect how the entries are displayed on the webpage:
+   
+- `abbr`: Adds an abbreviation to the left of the entry. You can add links to these by creating a venue.yaml-file in the _data folder and adding entries that match.
+- `abstract`: Adds an "Abs" button that expands a hidden text field when clicked to show the abstract text
+- `arxiv`: Adds a link to the Arxiv website (Note: only add the arxiv identifier here - the link is generated automatically)
+- `bibtex_show`: Adds a "Bib" button that expands a hidden text field with the full bibliography entry
+- `html`: Inserts a "HTML" button redirecting to the user-specified link
+- `pdf`: Adds a "PDF" button redirecting to a specified file (if a full link is not specified, the file will be assumed to be placed in the /assets/pdf/ directory)
+- `supp`: Adds a "Supp" button to a specified file (if a full link is not specified, the file will be assumed to be placed in the /assets/pdf/ directory)
+- `blog`: Adds a "Blog" button redirecting to the specified link
+- `code`: Adds a "Code" button redirecting to the specified link
+- `poster`: Adds a "Poster" button redirecting to a specified file (if a full link is not specified, the file will be assumed to be placed in the /assets/pdf/ directory)
+- `slides`: Adds a "Slides" button redirecting to a specified file (if a full link is not specified, the file will be assumed to be placed in the /assets/pdf/ directory)
+- `website`: Adds a "Website" button redirecting to the specified link
+   
+You can implement your own buttons by editing the bib.html file.
+   
 ### Collections
 
 This Jekyll theme implements `collections` to let you break up your work into categories.
@@ -315,8 +333,7 @@ Items from the `projects` collection are displayed on a responsive grid on proje
 
 You can easily create your own collections, apps, short stories, courses, or whatever your creative work is.
 To do this, edit the collections in the `_config.yml` file, create a corresponding folder, and create a landing page for your collection, similar to `_pages/projects.md`.
-
-
+   
 ### Layouts
 
 **al-folio** comes with stylish layouts for pages and blog posts.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ There are several custom bibtex keywords that you can use to affect how the entr
    
 You can implement your own buttons by editing the bib.html file.
    
+</details>
+   
 ### Collections
 
 This Jekyll theme implements `collections` to let you break up your work into categories.


### PR DESCRIPTION
I did not find the custom bibtex keywords documented anywhere, so I've added them to the main readme under a details tag.