### PR TITLE
Added a plugin to filter irrelevant bibtex keywords from bib output

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -237,6 +237,7 @@ scholar:
 
   query: "@*"
 
+filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, slides, website] # Filter out certain bibtex entry keywords used internally from the bib output
 
 # -----------------------------------------------------------------------------
 # Responsive WebP Images

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -153,7 +153,7 @@
           {% if entry.bibtex_show -%}
           <!-- Hidden bibtex block -->
           <div class="bibtex hidden">
-            {% highlight bibtex %}{{ entry.bibtex }}{% endhighlight %}
+            {% highlight bibtex %}{{ entry.bibtex | hideCustomBibtex }}{% endhighlight %}
           </div>
           {%- endif %}
         </div>

--- a/_plugins/hideCustomBibtex.rb
+++ b/_plugins/hideCustomBibtex.rb
@@ -1,0 +1,15 @@
+ module Jekyll
+  module HideCustomBibtex
+    def hideCustomBibtex(input)
+	  keywords = @context.registers[:site].config['filtered_bibtex_keywords']
+
+	  keywords.each do |keyword|
+		input = input.gsub(/^.*#{keyword}.*$\n/, '')
+	  end
+
+      return input
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::HideCustomBibtex)


### PR DESCRIPTION
Added a plugin to filter irrelevant bibtex keywords in the bib output turned on by `bibtex_show`. The `filtered_keywords` setting in the config decides which keywords to filter out, and I've added all keywords used internally by the webpage as default.

Fixes #547 