### PR TITLE
Adds support for GA4 analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,7 +79,7 @@ contact_note: >
 # Analytics and search engine verification
 # -----------------------------------------------------------------------------
 
-google_analytics:  # your GA4 measurement ID (format: G-XXXXXXXXXX)
+google_analytics:  # your Goole Analytics measurement ID (format: G-XXXXXXXXXX)
 panelbear_analytics:  # panelbear analytics site ID (format: XXXXXXXXX)
 
 google_site_verification:  # your google-site-verification ID (Google Search Console)

--- a/_config.yml
+++ b/_config.yml
@@ -79,7 +79,7 @@ contact_note: >
 # Analytics and search engine verification
 # -----------------------------------------------------------------------------
 
-google_analytics:  # your google-analytics ID (format: UA-XXXXXXXXX)
+google_analytics:  # your GA4 measurement ID (format: G-XXXXXXXXXX)
 panelbear_analytics:  # panelbear analytics site ID (format: XXXXXXXXX)
 
 google_site_verification:  # your google-site-verification ID (Google Search Console)

--- a/_includes/scripts/analytics.html
+++ b/_includes/scripts/analytics.html
@@ -3,7 +3,7 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
+    function gtag(){ window.dataLayer.push(arguments); }
     gtag('js', new Date());
     gtag('config', '{{ site.google_analytics }}');
   </script>

--- a/_includes/scripts/analytics.html
+++ b/_includes/scripts/analytics.html
@@ -7,8 +7,8 @@
     gtag('js', new Date());
     gtag('config', '{{ site.google_analytics }}');
   </script>
-  {%- endif -%}
-  {%- if site.enable_panelbear_analytics -%}
+{%- endif -%}
+{%- if site.enable_panelbear_analytics -%}
   <!-- Panelbear Analytics - We respect your privacy -->
   <script async src="https://cdn.panelbear.com/analytics.js?site={{site.panelbear_analytics}}"></script>
   <script>


### PR DESCRIPTION
Seems like GA4 analytics uses the same scripts as previous Google Analytics. 

Therefore, I don't think we need to make any more changes. Just added a note in the `_config.yml` and changed the ID to `G-XXXXXXXXXX` to make it clearer.

As Google will [stop supporting previous Universal Analytics](https://support.google.com/analytics/answer/11583528?hl=en&ref_topic=10094551), I did not mention it in code.