### PR TITLE
Adds support for bypassing GitHub Pages Jekyll processing

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -102,6 +102,9 @@ find . -maxdepth 1 ! -name '_site' ! -name '.git' ! -name 'CNAME' ! -name '.giti
 mv _site/* .
 rm -R _site/
 
+# Create `.nojekyll` file (bypass GitHub Pages Jekyll processing)
+touch .nojekyll
+
 # Push to DEPLOY_BRANCH
 git add -fA
 git commit --allow-empty -m "$(git log -1 --pretty=%B) [ci skip]"


### PR DESCRIPTION
GitHub Pages automatically tries to process Jekyll site for every deployment. But since, we precompile our Jekyll using GitHub Actions, therefore it will not be required to be processed by GitHub pages. We just need GitHub Pages to deploy the `gh-pages` branch as a static site.

More information: https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/