### PR TITLE
Fix typos in _layouts/about.html

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -18,9 +18,9 @@ layout: default
               {%- assign profile_image_path = page.profile.image | prepend: 'assets/img/' -%}
 
               {% if page.profile.image_cicular %}
-              {%- assign profile_image_class = "img-fluid z-dept-1 rounded-circle" -%}
+                {%- assign profile_image_class = "img-fluid z-depth-1 rounded-circle" -%}
               {% else %}
-              {%- assign profile_image_class = "img-fluid z-dept-1 rounded" -%}
+                {%- assign profile_image_class = "img-fluid z-depth-1 rounded" -%}
               {% endif %}
 
               {% include figure.html 


### PR DESCRIPTION
profile image on the about page had typos in the class names, which are fixed in this PR.