### PR TITLE
Include bootstrap bundle to replace popperjs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -317,9 +317,6 @@ mdb:
   integrity:
     css: "sha256-jpjYvU3G3N6nrrBwXJoVEYI/0zw8htfFnhT9ljN3JJw="
     js: "sha256-NdbiivsvWt7VYCt6hYNT3h/th9vSTL4EDWeGs5SN3DA="
-popper:
-  version: "2.11.2"
-  integrity: "sha256-l/1pMF/+J4TThfgARS6KwWrk/egwuVvhRzfLAMQ6Ds4="
 medium_zoom:
   version: "1.0.6"
   integrity: "sha256-EdPgYcPk/IIrw7FYeuJQexva49pVRZNmt3LculEr7zM="

--- a/_includes/scripts/bootstrap.html
+++ b/_includes/scripts/bootstrap.html
@@ -1,4 +1,3 @@
 <!-- Bootsrap & MDB scripts -->
-  <script async src="https://cdn.jsdelivr.net/npm/@popperjs/core@{{ site.popper.version }}/dist/umd/popper.min.js" integrity="{{ site.popper.integrity }}" crossorigin="anonymous"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/bootstrap@{{ site.bootstrap.version }}/dist/js/bootstrap.min.js" integrity="{{ site.bootstrap.integrity.js }}" crossorigin="anonymous"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/js/mdb.min.js" integrity="{{ site.mdb.integrity.js }}" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@{{ site.bootstrap.version }}/dist/js/bootstrap.bundle.min.js" integrity="{{ site.bootstrap.integrity.js }}" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/js/mdb.min.js" integrity="{{ site.mdb.integrity.js }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
Bootstrap bundle include popperjs.

References:

- https://getbootstrap.com/docs/5.2/getting-started/introduction/#cdn-links
- https://www.jsdelivr.com/package/npm/bootstrap (Looks like the bundle is used more often than the separate scripts)