### PR TITLE
Fix commas in author list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -239,6 +239,8 @@ filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, select
 
 # Maximum number of authors to be shown, other authors will be visible on hover, leave blank to show all authors
 max_author_limit: 3
+# Show "and" before "more authors", otherwise before the last author
+max_author_separated: true
 
 # -----------------------------------------------------------------------------
 # Responsive WebP Images

--- a/_config.yml
+++ b/_config.yml
@@ -237,10 +237,10 @@ scholar:
 # Filter out certain bibtex entry keywords used internally from the bib output
 filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, slides, website, preview]
 
-# Maximum number of authors to be shown, other authors will be visible on hover, leave blank to show all authors
-max_author_limit: 3
-# Show "and" before "more authors", otherwise before the last author
-max_author_separated: true
+# Maximum number of authors to be shown for each publication (more authors are visible on click)
+max_author_limit: 3  # leave blank to always show all authors
+more_authors_animation_delay: 10  # more authors are revealed on click using animation; smaller delay means faster animation
+
 
 # -----------------------------------------------------------------------------
 # Responsive WebP Images

--- a/_data/venues.yml
+++ b/_data/venues.yml
@@ -1,0 +1,7 @@
+"AJP":
+  url: https://aapt.scitation.org/journal/ajp
+  color: 
+
+"PhysRev":
+  url: https://journals.aps.org/
+  color: "#00369f"

--- a/_data/venues.yml
+++ b/_data/venues.yml
@@ -1,7 +1,0 @@
-"AJP":
-  url: https://aapt.scitation.org/journal/ajp
-  color: 
-
-"PhysRev":
-  url: https://journals.aps.org/
-  color: "#00369f"

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -11,13 +11,9 @@
           {%- endif -%}
         {%- elsif entry.abbr -%}
           {%- if site.data.venues[entry.abbr] -%}
-            {%- assign venue_style = "" -%}
-            {%- if site.data.venues[entry.abbr].color -%}
-            {%- assign venue_style = venue_style | append: 'style="background-color:' | append: site.data.venues[entry.abbr].color | append: '"' -%}
-            {%- endif -%}
-            <abbr class="badge" {{venue_style}}><a href="{{site.data.venues[entry.abbr].url}}">{{entry.abbr}}</a></abbr>
+          <abbr class="badge"><a href="{{site.data.venues[entry.abbr].url}}">{{entry.abbr}}</a></abbr>
           {%- else -%}
-            <abbr class="badge">{{entry.abbr}}</abbr>
+          <abbr class="badge">{{entry.abbr}}</abbr>
           {%- endif -%}
         {%- endif -%}
         </div>

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -11,9 +11,13 @@
           {%- endif -%}
         {%- elsif entry.abbr -%}
           {%- if site.data.venues[entry.abbr] -%}
-          <abbr class="badge"><a href="{{site.data.venues[entry.abbr].url}}">{{entry.abbr}}</a></abbr>
+            {%- assign venue_style = "" -%}
+            {%- if site.data.venues[entry.abbr].color -%}
+            {%- assign venue_style = venue_style | append: 'style="background-color:' | append: site.data.venues[entry.abbr].color | append: '"' -%}
+            {%- endif -%}
+            <abbr class="badge" {{venue_style}}><a href="{{site.data.venues[entry.abbr].url}}">{{entry.abbr}}</a></abbr>
           {%- else -%}
-          <abbr class="badge">{{entry.abbr}}</abbr>
+            <abbr class="badge">{{entry.abbr}}</abbr>
           {%- endif -%}
         {%- endif -%}
         </div>

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -40,7 +40,7 @@
 
           {%- for author in entry.author_array limit: author_array_limit -%}
             {%- assign author_is_self = false -%}
-            {%- assign author_last_name = author.last | remove: "¶" | remove: "&" | remove: "*" | remove: "†" | remove: "^" -%}
+            {%- assign author_last_name = author.last | remove: "*" -%}
             {%- if author_last_name == site.scholar.last_name -%}
               {%- if site.scholar.first_name contains author.first -%}
                 {%- assign author_is_self = true -%}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -68,26 +68,19 @@
           {%- endfor -%}
           {%- assign more_authors = author_array_size | minus: author_array_limit -%}
           
-          {%- if author_array_limit == 0 -%}
-            {%- assign more_authors_hide = more_authors | append: " more author" -%}
-          {%- else -%}
-            {%- assign more_authors_hide = ", and " | append: more_authors | append: " more author" -%}
-          {%- endif -%}
+          {%- assign more_authors_hide = more_authors | append: " more author" -%}
           {%- if more_authors > 0 -%}
             {%- if more_authors > 1 -%}
               {%- assign more_authors_hide = more_authors_hide | append: "s" -%}
             {%- endif -%}
             {%- assign more_authors_show = '' -%}
             {%- for author in entry.author_array offset: author_array_limit -%}
-              {%- if forloop.first and site.max_author_separated -%}
-                {%- assign more_authors_show = more_authors_show | append: " and " -%}
-              {%- elsif forloop.last and site.max_author_separated == false -%}
-                {%- assign more_authors_show = more_authors_show | append: ", and " -%}
-              {%- else -%}
-                {%- assign more_authors_show = more_authors_show | append: ", " -%}
-              {%- endif -%}
               {%- assign more_authors_show = more_authors_show | append: author.first | append: " " | append: author.last -%}
+              {%- unless forloop.last -%}
+                {%- assign more_authors_show = more_authors_show | append: ", " -%}
+              {%- endunless -%}
             {%- endfor -%}
+            , and
             <span
                 class="more-authors"
                 title="click to view {{more_authors_hide}}"
@@ -101,7 +94,7 @@
                     if (++cursorPosition == more_authors_text.length){
                       clearInterval(textAdder);
                     }
-                  }, 15);
+                }, '{{site.more_authors_animation_delay}}');
                 "
             >{{more_authors_hide}}</span>
           {%- endif -%}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -29,10 +29,9 @@
           <div class="author">
           {% assign author_array_size = entry.author_array | size %}
 
+          {% assign author_array_limit = author_array_size %}
           {%- if site.max_author_limit and author_array_size > site.max_author_limit %}
             {% assign author_array_limit = site.max_author_limit %}
-          {% else %}
-            {% assign author_array_limit = author_array_size %}
           {% endif %}
 
           {%- for author in entry.author_array limit: author_array_limit -%}
@@ -52,53 +51,41 @@
               {%- endfor -%}
             {%- endif -%}
             
-            {%- if forloop.length == 1 -%}
-              {%- if author_is_self %}
-                <em>{{author.last}}, {{author.first}}</em>
+            {%- if forloop.length > 1 -%}
+              {%- if forloop.first == false -%},&nbsp;{%- endif -%}
+              {%- if forloop.last and author_array_limit == author_array_size -%}and&nbsp;{%- endif -%}
+            {%- endif -%}
+            {%- if author_is_self -%}
+              <em>{{author.last}}, {{author.first}}</em>
+            {%- else -%}
+              {%- if coauthor_url -%}
+                <a href="{{coauthor_url}}">{{author.last}}, {{author.first}}</a>
               {%- else -%}
                 {{author.last}}, {{author.first}}
               {%- endif -%}
-            {%- else -%}
-              {%- unless forloop.last -%}
-                {% if author_is_self %}
-                  <em>{{author.last}}, {{author.first}}</em>,&nbsp;
-                {%- else -%}
-                  {% if coauthor_url -%}
-                    <a href="{{coauthor_url}}">{{author.last}}, {{author.first}}</a>,&nbsp;
-                  {%- else -%}
-                    {{author.last}}, {{author.first}},&nbsp;
-                  {%- endif -%}
-                {%- endif -%}
-              {%- else -%}
-                {%- if author_array_limit == author_array_size %} and {% endif %}
-                {% if author_is_self -%}
-                  <em>{{author.last}}, {{author.first}}</em>
-                {% else -%}
-                  {%- if coauthor_url -%}
-                    <a href="{{coauthor_url}}">{{author.last}}, {{author.first}}</a>
-                  {% else -%}
-                    {{author.last}}, {{author.first}}
-                  {%- endif -%}
-                {%- endif -%}
-              {%- endunless -%}
             {%- endif -%}
-          {%- endfor %}
+          {%- endfor -%}
 
-          {% assign more_authors = author_array_size | minus: author_array_limit %}
-
-          {%- if more_authors > 0 %}
-            {% assign more_authors_hide = more_authors | append: " more author" %}
-            {% if more_authors > 1 %}
-              {% assign more_authors_hide = more_authors_hide | append: "s" %}
-            {% endif %}
-            {% assign more_authors_show = '' %}
+          {%- assign more_authors = author_array_size | minus: author_array_limit -%}
+          
+          {%- if author_array_limit == 0 -%}
+            {%- assign more_authors_hide = more_authors | append: " more author" -%}
+          {%- else -%}
+            {%- assign more_authors_hide = ", and " | append: more_authors | append: " more author" -%}
+          {%- endif -%}
+          {%- if more_authors > 0 -%}
+            {%- if more_authors > 1 -%}
+              {%- assign more_authors_hide = more_authors_hide | append: "s" -%}
+            {%- endif -%}
+            {%- assign more_authors_show = '' -%}
             {%- for author in entry.author_array offset: author_array_limit -%}
-              {% assign more_authors_show = more_authors_show | append: author.last | append: ", " | append: author.first %}
-              {% unless forloop.last %}
-                {% assign more_authors_show = more_authors_show | append: ",&nbsp;" %}
-              {% endunless %}
+              {%- unless forloop.last -%}
+                {%- assign more_authors_show = more_authors_show | append: ", " -%}
+              {%- else -%}
+                {%- assign more_authors_show = more_authors_show | append: ", and " -%}
+              {%- endunless -%}
+              {%- assign more_authors_show = more_authors_show | append: author.first | append: " " | append: author.last -%}
             {%- endfor -%}
-            and
             <span
                 class="more-authors"
                 title="click to view {{more_authors_hide}}"
@@ -115,7 +102,7 @@
                   }, 15);
                 "
             >{{more_authors_hide}}</span>
-          {% endif %}
+          {%- endif -%}
 
           </div>
 

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -56,16 +56,15 @@
               {%- if forloop.last and author_array_limit == author_array_size -%}and&nbsp;{%- endif -%}
             {%- endif -%}
             {%- if author_is_self -%}
-              <em>{{author.last}}, {{author.first}}</em>
+              <em>{{author.first}} {{author.last}}</em>
             {%- else -%}
               {%- if coauthor_url -%}
-                <a href="{{coauthor_url}}">{{author.last}}, {{author.first}}</a>
+                <a href="{{coauthor_url}}">{{author.first}} {{author.last}}</a>
               {%- else -%}
-                {{author.last}}, {{author.first}}
+                {{author.first}} {{author.last}}
               {%- endif -%}
             {%- endif -%}
           {%- endfor -%}
-
           {%- assign more_authors = author_array_size | minus: author_array_limit -%}
           
           {%- if author_array_limit == 0 -%}
@@ -79,11 +78,13 @@
             {%- endif -%}
             {%- assign more_authors_show = '' -%}
             {%- for author in entry.author_array offset: author_array_limit -%}
-              {%- unless forloop.last -%}
-                {%- assign more_authors_show = more_authors_show | append: ", " -%}
-              {%- else -%}
+              {%- if forloop.first and site.max_author_separated -%}
+                {%- assign more_authors_show = more_authors_show | append: " and " -%}
+              {%- elsif forloop.last and site.max_author_separated == false -%}
                 {%- assign more_authors_show = more_authors_show | append: ", and " -%}
-              {%- endunless -%}
+              {%- else -%}
+                {%- assign more_authors_show = more_authors_show | append: ", " -%}
+              {%- endif -%}
               {%- assign more_authors_show = more_authors_show | append: author.first | append: " " | append: author.last -%}
             {%- endfor -%}
             <span

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -36,14 +36,15 @@
 
           {%- for author in entry.author_array limit: author_array_limit -%}
             {%- assign author_is_self = false -%}
-            {%- if author.last == site.scholar.last_name %}
+            {%- assign author_last_name = author.last | remove: "*" -%}
+            {%- if author_last_name == site.scholar.last_name -%}
               {%- if site.scholar.first_name contains author.first -%}
                 {%- assign author_is_self = true -%}
               {%- endif -%}
             {%- endif -%}
             {%- assign coauthor_url = nil -%}
-            {%- if site.data.coauthors[author.last] -%}
-              {%- for coauthor in site.data.coauthors[author.last] -%}
+            {%- if site.data.coauthors[author_last_name] -%}
+              {%- for coauthor in site.data.coauthors[author_last_name] -%}
                 {%- if coauthor.firstname contains author.first -%}
                   {%- assign coauthor_url = coauthor.url -%}
                   {%- break -%}

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -36,7 +36,7 @@
 
           {%- for author in entry.author_array limit: author_array_limit -%}
             {%- assign author_is_self = false -%}
-            {%- assign author_last_name = author.last | remove: "*" -%}
+            {%- assign author_last_name = author.last | remove: "¶" | remove: "&" | remove: "*" | remove: "†" | remove: "^" -%}
             {%- if author_last_name == site.scholar.last_name -%}
               {%- if site.scholar.first_name contains author.first -%}
                 {%- assign author_is_self = true -%}


### PR DESCRIPTION
The current author list has an issue with commas and spaces. 
For example, the first paper in publications

>Letters on wave mechanics
Einstein, Albert, [Schrödinger, Erwin](https://en.wikipedia.org/wiki/Erwin_Schr%C3%B6dinger),  [Planck, Max](https://en.wikipedia.org/wiki/Max_Planck) and 2 more authors
1967

There are actually two spaces in front of 'Planck, Max' and a missing comma before 'and'.
Moreover, the expanded author list after clicking on the '2 more authors' does not contain the 'and' conjunction.

This PR fixes the above problems and simplifies some of the redundant codes.
In particular, it prevents liquid from printing any arbitrary whitespaces and puts the 'and' into latter phrase.
A weird boundary case (i.e., author_array_limit is zero) is also considered and handled.

Last but not least, I still think it is a bit inconvenient to have the author's last name before the first name. 
Conventionally, it should be 'A. Einstein, B. Podolsky, and N. Rosen' instead of the current 'Einstein, A., Podolsky, B., and Rosen, N.' 
Although I have not changed this in the PR, it is recommended to review the current name order.