### PR TITLE
Add Pre-commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer


### PR DESCRIPTION
It is nice to have some pre-commit hooks for checking of spelling and things like this. If you want to see more information take a look at [here](https://calmcode.io/pre-commit/the-problem.html).

Notice that I have just created one file called `.pre-commit-config.yaml` and run `pre-commit install` and then created a commit. All other files are staged automatically for changes. 

There is also a [bot in github marketplace](https://github.com/marketplace/pre-commit-ci) which takes care of this pre-commit hooks in every pull request. So, we do not need to check for spelling errors and formatting styles. However, I can not install it to this repo, the owner himself should install it. To see an example of how it works take a look at one of my PRs at [yolov5](https://github.com/ultralytics/yolov5/pull/8766). 

[Here](https://pre-commit.com/hooks.html) is the list of pre-commit hooks we can add. We can add spelling and lots of others if you want.