### PR TITLE
A suggest to set right margin for profile picture

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -94,6 +94,7 @@ blockquote {
 
 .profile {
   margin-left: 1rem;
+  margin-right: 1rem;
   width: 100%;
 
   .address {


### PR DESCRIPTION
setting profile picture in left side, cause touching content box and the picture without padding. 
I found no better why that doesn't effect on the right state option, but it could apply by condition.

thanks for your amazing project.