### PR TITLE
Display booktitle for publications of type incollection.

### DIFF
--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -108,7 +108,7 @@
           <!-- Journal/Book title and date -->
           {% if entry.type == "article" -%}
             {%- capture entrytype -%}<em>{{entry.journal}}</em>{%- endcapture -%}
-          {%- elsif entry.type == "inproceedings" -%}
+          {%- elsif ["inproceedings", "incollection"] contains entry.type -%}
             {%- capture entrytype -%}<em>In {{entry.booktitle}}</em> {%- endcapture -%}
           {%- else -%}
             {%- capture entrytype -%}{%- endcapture -%}


### PR DESCRIPTION
Until now, only publications of type `inproceedings` have the `booktitle` attribute shown, although `incollection` would benefit from it as well.