### PR TITLE
Add Docker-compose file for windows compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ $ cd <your-repo-name>
 Finally, run the following command that will pull a pre-built image from DockerHub and will run your website.
 
 ```bash
-$ ./bin/dockerhub_run.sh
+$ docker-compose up
 ```
 
 Note that when you run it for the first time, it will download a docker image of size 300MB or so.
 
-Now, feel free to customize the theme however you like (don't forget to change the name!). After you are done, you can use the same command (`bin/dockerhub_run.sh`) to render the webpage with all you changes. Also, make sure to commit your final changes.
+Now, feel free to customize the theme however you like (don't forget to change the name!). After you are done, you can use the same command (`docker-compose up`) to render the webpage with all you changes. Also, make sure to commit your final changes.
 
 <details><summary>(click to expand) <strong>Build your own docker image (more advanced):</strong></summary>
 
@@ -154,18 +154,18 @@ First, download the necessary modules and install them into a docker image calle
   
 
 ```bash
-$ ./bin/docker_build_image.sh  
+$ docker-compose -f docker-local.yml build
 ```
 
 Run the website!
 
 ```bash
-$ ./bin/docker_run.sh
+$ docker-compose -f docker-local.yml up
 ```
 
-> To change port number, you can edit `docker_run.sh` file.
+> To change port number, you can edit `docker-compose.yml` file.
 
-> If you want to update jekyll, install new ruby packages, etc., all you have to do is build the image again using `docker_build_image.sh`! It will download ruby and jekyll and install all ruby packages again from scratch.
+> If you want to update jekyll, install new ruby packages, etc., all you have to do is build the image again! It will download ruby and jekyll and install all ruby packages again from scratch.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For a hands-on walkthrough of al-folio installation, check out [this cool video 
 
 You need to take the following steps to get `al-folio` up and running in your local machine:
 
-- First, [install docker](https://docs.docker.com/get-docker/)
+- First, install [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/).
 - Then, clone this repository to your machine:
 
 ```bash

--- a/bin/docker_build_image.sh
+++ b/bin/docker_build_image.sh
@@ -1,1 +1,5 @@
-docker-compose -f docker-local.yml build
+  FILE=Gemfile.lock
+if [ -f "$FILE" ]; then
+    rm $FILE
+fi
+  docker build -t "al-folio:latest" . 

--- a/bin/docker_build_image.sh
+++ b/bin/docker_build_image.sh
@@ -1,5 +1,1 @@
-  FILE=Gemfile.lock
-if [ -f "$FILE" ]; then
-    rm $FILE
-fi
-  docker build -t "al-folio:latest" . 
+docker-compose -f docker-local.yml build

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -4,4 +4,5 @@ if [ -f "$FILE" ]; then
 fi
 docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
                     -it al-folio:latest bundler  \
-                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 
+                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 \
+                    --verbose --livereload

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -1,1 +1,1 @@
-docker-compose -f docker-local.yml up --remove-orphans
+docker-compose -f docker-local.yml up

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -1,1 +1,7 @@
-docker-compose -f docker-local.yml up
+FILE=Gemfile.lock
+if [ -f "$FILE" ]; then
+    rm $FILE
+fi
+docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
+                    -it al-folio:latest bundler  \
+                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 

--- a/bin/docker_run.sh
+++ b/bin/docker_run.sh
@@ -1,7 +1,1 @@
-FILE=Gemfile.lock
-if [ -f "$FILE" ]; then
-    rm $FILE
-fi
-docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
-                    -it al-folio:latest bundler  \
-                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 
+docker-compose -f docker-local.yml up --remove-orphans

--- a/bin/dockerhub_run.sh
+++ b/bin/dockerhub_run.sh
@@ -4,4 +4,5 @@ if [ -f "$FILE" ]; then
 fi
 docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
                     -it amirpourmand/al-folio bundler  \
-                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 
+                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 \
+                    --verbose --livereload

--- a/bin/dockerhub_run.sh
+++ b/bin/dockerhub_run.sh
@@ -1,1 +1,1 @@
-docker-compose up --remove-orphans
+docker-compose up

--- a/bin/dockerhub_run.sh
+++ b/bin/dockerhub_run.sh
@@ -1,1 +1,7 @@
-docker-compose up
+FILE=Gemfile.lock
+if [ -f "$FILE" ]; then
+    rm $FILE
+fi
+docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
+                    -it amirpourmand/al-folio bundler  \
+                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 

--- a/bin/dockerhub_run.sh
+++ b/bin/dockerhub_run.sh
@@ -1,7 +1,1 @@
-FILE=Gemfile.lock
-if [ -f "$FILE" ]; then
-    rm $FILE
-fi
-docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
-                    -it amirpourmand/al-folio bundler  \
-                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 
+docker-compose up --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  jekyll:
+    image: amirpourmand/al-folio
+    command: bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose
+    ports:
+      - 8080:8080
+    volumes:
+      - .:/srv/jekyll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: amirpourmand/al-folio
     command: bash -c "
       rm -f Gemfile.lock
-      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose"
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose"
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3"
-
+# this file uses prebuilt image in dockerhub
 services:
   jekyll:
     image: amirpourmand/al-folio
-    command: bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose
+    command: bash -c "
+      rm -f Gemfile.lock
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose"
     ports:
       - 8080:8080
     volumes:

--- a/docker-local.yml
+++ b/docker-local.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  jekyll_custom:
+    build: .
+    command: bash -c "
+      rm -f Gemfile.lock
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose"
+    ports:
+      - 8080:8080
+    volumes:
+      - .:/srv/jekyll

--- a/docker-local.yml
+++ b/docker-local.yml
@@ -5,7 +5,7 @@ services:
     build: .
     command: bash -c "
       rm -f Gemfile.lock
-      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --verbose"
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose"
     ports:
       - 8080:8080
     volumes:


### PR DESCRIPTION
This file makes it easier for windows users to use docker. (Closes #829)

Previous to this commit, those who used Windows had to install Ubuntu inside windows (via WSL) and run our commands. Now they can run it by just typing `docker-compose up`. 

> The main problem was that `./bin/dockerhub_run.sh` command was written with `Bash` in mind and you had to change it a little bit to make it compatible with windows `Powershell`. We shouldn't have two scripts. This is why adding a `docker-compose.yml` file is necessary. 