### PR TITLE
Fixed missing year in title when in blog archive

### DIFF
--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -21,7 +21,11 @@
     {% if page.url == '/blog/index.html' %}
         {{ site.blog_nav_title }} | {{ title }}
     {%- elsif page.title != "blank" and page.url != "/" -%}
-        {{ page.title }} | {{ title }}
+        {%- if page.title == nil or page.title == "" -%}
+            {{ page.date | date: "%Y" }} | {{ title }}
+        {%- else -%}
+            {{ page.title }} | {{ title }}
+        {%- endif -%}
     {%- else -%}
         {{ title }}
     {%- endif -%}


### PR DESCRIPTION
Fixed missing year in title when visualizing blog archive filtered by year