### PR TITLE
Set the margin according to the alignment selected

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -93,7 +93,6 @@ blockquote {
 // Profile
 
 .profile {
-  margin-left: 1rem;
   width: 100%;
 
   .address {
@@ -105,6 +104,12 @@ blockquote {
       margin: 0;
     }
   }
+}
+.profile.float-right{
+  margin-left: 1rem;
+}
+.profile.float-left{
+  margin-right: 1rem;
 }
 
 @media (min-width: 576px) {


### PR DESCRIPTION
As reported in #927, the style of the profile class only considers a left-margin regardless of the alignment option selected.
Thus, when the user changes the default alignment there is no corresponding margin to match their selection.
My commit addresses this by enabling the corresponding margin for the left or right alignment options