### PR TITLE
Fix default highlighting

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:100,300,400,500,700|Material+Icons">
 
     <!-- Code Syntax Highlighting -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jwarby/jekyll-pygments-themes@master/{{ site.highlight_theme_light | append: '.css' }}" media="none" id="highlight_theme_light" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jwarby/jekyll-pygments-themes@master/{{ site.highlight_theme_light | append: '.css' }}" media="" id="highlight_theme_light" />
 
     <!-- Styles -->
     {% if site.icon.size < 3 %}


### PR DESCRIPTION
The default setting `media="none"` disables code highlighting. This works OK when we have `enable_darkmode: true` in `config.yml` as the code handling the dark/light theme switching takes care of setting `media=""` for the preferred theme.
However, setting `enable_darkmode: false` prevents importing `theme.js` which in turn prevents said change thus the default highlighting stays disabled.
Setting `media=""` by default enables the default highlighting when `enable_darkmode` is false.

Fixes #929