### PR TITLE
Right to left writting is now possible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -228,7 +228,7 @@ jekyll-archives:
     tag: '/blog/tag/:name/'
     category: '/blog/category/:name/'
 
-display_tags: ['formatting', 'images', 'links', 'math', 'code'] # this tags will be dispalyed on the front page of your blog
+display_tags: ['formatting', 'images', 'links', 'math', 'code', 'internationalization'] # this tags will be dispalyed on the front page of your blog
 
 # -----------------------------------------------------------------------------
 # Jekyll Scholar

--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,12 @@ discord_id: # your discord id (18-digit unique numerical identifier)
 contact_note: >
   You can even add a little note about which of these is the best way to reach you.
 
+
+# -----------------------------------------------------------------------------
+# Right-to-left scripts
+# -----------------------------------------------------------------------------
+rtl_langs: ["ar","arc","az","dv","he","ku","fa","ur"]
+
 # -----------------------------------------------------------------------------
 # Analytics and search engine verification
 # -----------------------------------------------------------------------------

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,8 @@
     {%- include header.html %}
 
     <!-- Content -->
-    <div class="container mt-5">
+    <div class="container mt-5" {% if site.rtl_langs contains page.lang %}dir="rtl" align="right"{% endif %}
+>
       {{ content }}
     </div>
 

--- a/_posts/2022-10-15-rtl.md
+++ b/_posts/2022-10-15-rtl.md
@@ -1,0 +1,74 @@
+---
+layout: post
+title: Right to left scripting
+date: 2022-10-15 
+description: you can also write from right to left
+lang: fa
+tags: internationalization formatting math code
+category: internationalization
+---
+
+# عنوان
+این یک پست نمونه برای سنجش نوشتارهای راست‌به‌چپ است.
+
+
+## فرمول‌نویسی
+فرمول‌ها هم مانند کد به درستی به نمایش در‌خواهند آمد:
+
+
+$$
+\sum_{k=1}^\infty |\langle x, e_k \rangle|^2 \leq \|x\|^2
+$$
+
+## کد
+کدها هم‌چنان مانند قبل از چپ‌به‌راست خواهند بود.
+
+```python
+if lang=="rtl"
+    print("I am a right-to-left script!")
+```
+
+## بلاک
+بلاک‌ها همواره چپ‌چین خواهند ماند:
+
+    ---
+    layout: page
+    title: project
+    description: a project with a background image
+    img: /assets/img/12.jpg
+    ---
+    
+حتی اگر به زبان‌های راست‌به‌چپ نوشته شوند:
+    
+    ---
+    صفحه‌بندی: صفحه
+    عنوان: پروژه
+    توضیحات: یک پروژه با تصویر زمینه
+    ---
+    
+## نقل‌قول
+> نقل‌قول‌ها به این شکل به نمایش درخواهند آمد.
+
+زیباتر خواهد بود اگر خط عمودی به راست انتقال داده شود. این کار با ویرایش _base.scss امکان‌پذیر است:
+
+```scss
+blockquote {
+  background: var(--global-bg-color);
+  border-left: 2px solid var(--global-theme-color); // change to border-right:
+  margin: 1.5em 10px;
+  padding: 0.5em 10px;
+  font-size: 1.2rem;
+}
+
+...
+
+
+.post-content{
+  blockquote {
+    border-left: 5px solid var(--global-theme-color); // change to border-right: ...
+    padding: 8px;
+  }
+}
+```
+
+منطقا باید بتوان با توجه به جهت‌گیری متن (rtl یا ltr) صفت مناسب را تعریف کرد. اما من چندان به sass مسلط نیستم. امیدوارم فرد مسلط‌تری این مشکل کوچک را رفع کند.

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -605,6 +605,8 @@ pre {
   background-color: var(--global-code-bg-color);
   border-radius: 6px;
   padding: 6px 12px;
+  text-align: left;
+  direction: ltr;
   pre, code {
     background-color: transparent;
     border-radius: 0;

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -6,7 +6,9 @@ body {
   padding-bottom: 70px;
   color: var(--global-text-color);
   background-color: var(--global-bg-color);
-
+  unicode-bidi: bidi-override !important;
+  direction: unset !important;
+  
   h1, h2, h3, h4, h5, h6 {
     scroll-margin-top: 66px;
   }


### PR DESCRIPTION
This branch helps the template's internationalization by providing right-to-left (rtl) scripting. 

The `default` layout and all its derivates now automatically change their direction and alignment if a language with right-to-left scripting is specified in the front matter. The feature detects the following right-to-left languages (can be extended in `_config.yml`):

- Arabic (ar)
- Aramaic (arc)
- Azeri (az)
- Dhivehi/Maldivian (dv)
- Hebrew (he)
- Kurdish (ku)
- Persian (fa)
- Urdu (ur)

An example post is also provided in the Blog.