### PR TITLE
Hide the other opened box (Bib, Abs), if any

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,9 +1,11 @@
 $(document).ready(function() {
     $('a.abstract').click(function() {
         $(this).parent().parent().find(".abstract.hidden").toggleClass('open');
+        $(this).parent().parent().find(".bibtex.hidden.open").toggleClass('open');
     });
     $('a.bibtex').click(function() {
         $(this).parent().parent().find(".bibtex.hidden").toggleClass('open');
+        $(this).parent().parent().find(".abstract.hidden.open").toggleClass('open');
     });
     $('a').removeClass('waves-effect waves-light');
 });


### PR DESCRIPTION
The problem with the previous code is that whenever a box (especially abstract) is open, it is difficult to see that the other one (in the case, Bib) becomes open when one clicks on the related button.