### PR TITLE
ADD More Clear Explanations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,24 +188,17 @@ Note that when you run it for the first time, it will download a docker image of
 
 Now, feel free to customize the theme however you like (don't forget to change the name!). After you are done, you can use the same command (`docker-compose up`) to render the webpage with all you changes. Also, make sure to commit your final changes.
 
-<details><summary>(click to expand) <strong>Build your own docker image (more advanced):</strong></summary>
+> To change port number, you can edit `docker-compose.yml` file.
+
+<details><summary>(click to expand) <strong>Build your own docker image:</strong></summary>
 
 > Note: this approach is only necessary if you would like to build an older or very custom version of al-folio.
 
-First, build the image locally using:
-
-```bash
-$ docker-compose -f docker-local.yml build
-```
-
-Then run it using:
+Build and run a new docker image using:
 ```bash
 $ docker-compose -f docker-local.yml up
 ```
-
-> To change port number, you can edit `docker-compose.yml` file.
-
-> If you want to update jekyll, install new ruby packages, etc., all you have to do is build the image again! It will download ruby and jekyll and install all ruby packages again from scratch.
+> If you want to update jekyll, install new ruby packages, etc., all you have to do is build the image again using `--force-recreate` argument at the end of previous command! It will download ruby and jekyll and install all ruby packages again from scratch.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -192,15 +192,13 @@ Now, feel free to customize the theme however you like (don't forget to change t
 
 > Note: this approach is only necessary if you would like to build an older or very custom version of al-folio.
 
-First, download the necessary modules and install them into a docker image called `al-folio:Dockerfile` (this command will build an image which is used to run your website afterwards. Note that you only need to do this step once. After you have the image, you no longer need to do this anymore):
-
+First, build the image locally using:
 
 ```bash
 $ docker-compose -f docker-local.yml build
 ```
 
-Run the website!
-
+Then run it using:
 ```bash
 $ docker-compose -f docker-local.yml up
 ```


### PR DESCRIPTION
The old explanation was for the old days. Now it can be done much easier. The build command is not necessary for docker-compose, it automatically creates the image if no image exists. 

Output would be like this:
![image](https://user-images.githubusercontent.com/32064808/205938579-01602009-5123-4375-bbae-2d826b7da246.png)
