### PR TITLE
Add interactive plotly example to distill post

### DIFF
--- a/_posts/2018-12-22-distill.md
+++ b/_posts/2018-12-22-distill.md
@@ -35,6 +35,7 @@ toc:
   - name: Citations
   - name: Footnotes
   - name: Code Blocks
+  - name: Interactive Plots
   - name: Layouts
   - name: Other Typography?
 
@@ -72,7 +73,6 @@ $$
 $$
 
 Note that MathJax 3 is [a major re-write of MathJax](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html) that brought a significant improvement to the loading and rendering speed, which is now [on par with KaTeX](http://www.intmath.com/cg5/katex-mathjax-comparison.php).
-
 
 ***
 
@@ -118,6 +118,39 @@ var x = 25;
 function(x) {
   return x * x;
 }
+{% endhighlight %}
+
+***
+
+## Interactive Plots
+
+You can add interative plots using plotly + iframes :framed_picture:
+
+<div class="l-page">
+  <iframe src="{{ '/assets/plotly/demo.html' | relative_url }}" frameborder='0' scrolling='no' height="500px" width="100%" style="border: 1px dashed grey;"></iframe>
+</div>
+
+The plot must be generated separately and saved into an HTML file.
+To generate the plot that you see above, you can use the following code snippet:
+
+{% highlight python %}
+import pandas as pd
+import plotly.express as px
+df = pd.read_csv(
+  'https://raw.githubusercontent.com/plotly/datasets/master/earthquakes-23k.csv'
+)
+fig = px.density_mapbox(
+  df,
+  lat='Latitude',
+  lon='Longitude',
+  z='Magnitude',
+  radius=10,
+  center=dict(lat=0, lon=180),
+  zoom=0,
+  mapbox_style="stamen-terrain",
+)
+fig.show()
+fig.write_html('assets/plotly/demo.html')
 {% endhighlight %}
 
 ***
@@ -180,7 +213,7 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 1. First ordered list item
 2. Another item
-⋅⋅* Unordered sub-list. 
+⋅⋅* Unordered sub-list.
 1. Actual numbers don't matter, just that it's a number
 ⋅⋅1. Ordered sub-list
 4. And another item.
@@ -207,8 +240,8 @@ Strikethrough uses two tildes. ~~Scratch this.~~
 
 Or leave it empty and use the [link text itself].
 
-URLs and URLs in angle brackets will automatically get turned into links. 
-http://www.example.com or <http://www.example.com> and sometimes 
+URLs and URLs in angle brackets will automatically get turned into links.
+http://www.example.com or <http://www.example.com> and sometimes
 example.com (but not on Github, for example).
 
 Some text to show that the reference links can follow later.
@@ -219,10 +252,10 @@ Some text to show that the reference links can follow later.
 
 Here's our logo (hover to see the title text):
 
-Inline-style: 
+Inline-style:
 ![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")
 
-Reference-style: 
+Reference-style:
 ![alt text][logo]
 
 [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 2"
@@ -233,14 +266,14 @@ Inline `code` has `back-ticks around` it.
 var s = "JavaScript syntax highlighting";
 alert(s);
 ```
- 
+
 ```python
 s = "Python syntax highlighting"
 print s
 ```
- 
+
 ```
-No language indicated, so no syntax highlighting. 
+No language indicated, so no syntax highlighting.
 But let's throw in a <b>tag</b>.
 ```
 
@@ -253,7 +286,7 @@ Colons can be used to align columns.
 | zebra stripes | are neat      |    $1 |
 
 There must be at least 3 dashes separating each header cell.
-The outer pipes (|) are optional, and you don't need to make the 
+The outer pipes (|) are optional, and you don't need to make the
 raw Markdown line up prettily. You can also use inline Markdown.
 
 Markdown | Less | Pretty
@@ -266,7 +299,7 @@ Markdown | Less | Pretty
 
 Quote break.
 
-> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote. 
+> This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can *put* **Markdown** into a blockquote.
 
 
 Here's a line for us to start with.


### PR DESCRIPTION
resolves #1023.

shows how to embed an interactive plotly chart using iframe (as suggested in #523 workaround).

how it looks:
<img width="1200" alt="Screenshot 2022-12-11 at 1 57 01 PM" src="https://user-images.githubusercontent.com/2126561/206931222-e6ca556e-2f43-42ab-a302-07e06652ebb4.png">
