### PR TITLE
Fix Docker Problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM bitnami/minideb:latest
 Label MAINTAINER Amir Pourmand
 RUN apt-get update -y
 RUN apt-get install --no-install-recommends ruby-full build-essential zlib1g-dev -y \
+    && apt-get install imagemagick -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/
 ENV GEM_HOME='$HOME/gems' \
     PATH="$HOME/gems/bin:${PATH}"
-RUN apt-get install imagemagick -y
 RUN gem install jekyll bundler
 RUN mkdir /srv/jekyll
 ADD Gemfile /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM bitnami/minideb:latest
 Label MAINTAINER Amir Pourmand
 RUN apt-get update -y
-RUN apt-get install ruby-full build-essential zlib1g-dev -y
+RUN apt-get install --no-install-recommends ruby-full build-essential zlib1g-dev -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/
+ENV GEM_HOME='$HOME/gems' \
+    PATH="$HOME/gems/bin:${PATH}"
 RUN apt-get install imagemagick -y
 RUN gem install jekyll bundler
 RUN mkdir /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM bitnami/minideb:latest
 Label MAINTAINER Amir Pourmand
 RUN apt-get update -y
-RUN apt-get install --no-install-recommends ruby-full build-essential zlib1g-dev -y \
-    && apt-get install imagemagick -y \
-    && apt-get clean \
+RUN apt-get install --no-install-recommends ruby-full build-essential zlib1g-dev -y 
+RUN apt-get install imagemagick -y 
+RUN apt-get clean \
     && rm -rf /var/lib/apt/lists/
-ENV GEM_HOME='$HOME/gems' \
-    PATH="$HOME/gems/bin:${PATH}"
+# ENV GEM_HOME='root/gems' \
+#     PATH="root/gems/bin:${PATH}"
 RUN gem install jekyll bundler
 RUN mkdir /srv/jekyll
 ADD Gemfile /srv/jekyll

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM bitnami/minideb:latest
 Label MAINTAINER Amir Pourmand
 RUN apt-get update -y
+# add locale
+RUN apt-get -y install locales
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8  
+
+# add ruby and jekyll
 RUN apt-get install --no-install-recommends ruby-full build-essential zlib1g-dev -y 
 RUN apt-get install imagemagick -y 
 RUN apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM jekyll/jekyll
+FROM bitnami/minideb:latest
 Label MAINTAINER Amir Pourmand
-#install imagemagick tool for convert command
-RUN apk add --no-cache --virtual .build-deps \
-        libxml2-dev \
-        shadow \
-        autoconf \
-        g++ \
-        make \
-    && apk add --no-cache imagemagick-dev imagemagick
+RUN apt-get update -y
+RUN apt-get install ruby-full build-essential zlib1g-dev -y
+RUN apt-get install imagemagick -y
+RUN gem install jekyll bundler
+RUN mkdir /srv/jekyll
+ADD Gemfile /srv/jekyll
 WORKDIR /srv/jekyll
-ADD Gemfile /srv/jekyll/
 RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: al-folio-website
     command: bash -c "
       rm -f Gemfile.lock
-      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose"
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose --trace"
     ports:
       - 8080:8080
     volumes:

--- a/docker-local.yml
+++ b/docker-local.yml
@@ -6,7 +6,7 @@ services:
     container_name: al-folio-local-website
     command: bash -c "
       rm -f Gemfile.lock
-      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose"
+      && bundler exec jekyll serve --watch --port=8080 --host=0.0.0.0 --livereload --verbose --trace"
     ports:
       - 8080:8080
     volumes:

--- a/docker-local.yml
+++ b/docker-local.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   jekyll_custom:
     build: .
+    image: al-folio-local-docker
     container_name: al-folio-local-website
     command: bash -c "
       rm -f Gemfile.lock


### PR DESCRIPTION
Resolves #1052. I want to get rid of `jekyll` base docker image as it doesn't update regularly and clearly some packages do not support it. 

It gives this error when trying to build website using docker:
```
Liquid Exception: invalid byte sequence in US-ASCII in /srv/jekyll/_layouts/about.html
al-folio-local-website | bundler: failed to load command: jekyll (/usr/local/bin/jekyll)
al-folio-local-website | /var/lib/gems/3.0.0/gems/bibtex-ruby-6.0.0/lib/bibtex/lexer.rb:220:in `scan_until': invalid byte sequence in US-ASCII (ArgumentError)
```

Also this warning comes up when installing jekyll:
```
unable to convert "\xDB" from ASCII-8BIT to UTF-8 for lib/google/protobuf/descriptor_pb.rb, skipping       
 => => # unknown encoding name "chunked\r\n\r\n25" for ext/ruby_http_parser/vendor/http-parser-java/tools/parse_test
 => => # s.rb, skipping  
```

Also this error happen in `ubuntu` base package.

This was fixed after adding locale `utf-8` to the `dockerfile`. I leave this lines for documentation purposes in case someone sees the exact same problem. 