### PR TITLE
fix distill hyperlink color

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -19,14 +19,17 @@ d-byline a, d-article d-byline a {
 
 d-article {
   border-top-color: var(--global-divider-color) !important;
-  a, p, h1, h2, h3, h4, h5, h6, li, table {
+  p, h1, h2, h3, h4, h5, h6, li, table {
     color: var(--global-text-color) !important;
   }
-  a, h1, h2, hr, table, table th, table td {
+  h1, h2, hr, table, table th, table td {
     border-bottom-color: var(--global-divider-color) !important;
   }
-  a:hover {
-    border-bottom-color: var(--global-hover-color) !important;
+  a {
+    color: var(--global-theme-color) !important;
+    &:hover {
+      color: var(--global-theme-color) !important;
+    }
   }
   b i {
     display: inline;


### PR DESCRIPTION
Make distill hyperlink color logic consistent with rest of the theme.

fixes #1105 