### PR TITLE
Update README.md to encourage people to use `Use this template` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ $ docker-compose -f docker-local.yml up
 
 #### Local Setup (Standard)
 
-Assuming you have [Ruby](https://www.ruby-lang.org/en/downloads/) and [Bundler](https://bundler.io/) installed on your system (*hint: for ease of managing ruby gems, consider using [rbenv](https://github.com/rbenv/rbenv)*), first [fork](https://guides.github.com/activities/forking/) the theme from `github.com:alshedivat/al-folio` to `github.com:<your-username>/<your-repo-name>` and do the following:
+Assuming you have [Ruby](https://www.ruby-lang.org/en/downloads/) and [Bundler](https://bundler.io/) installed on your system (*hint: for ease of managing ruby gems, consider using [rbenv](https://github.com/rbenv/rbenv)*), first click [Use this template](https://docs.github.com/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) above the file list, create a new repository at `github.com:<your-username>/<your-repo-name>` from `github.com:alshedivat/al-folio` and do the following:
 
 ```bash
 $ git clone git@github.com:<your-username>/<your-repo-name>.git
@@ -329,7 +329,7 @@ If rebasing is too complicated, we recommend to re-install the new version of th
 Here are some frequently asked questions.
 If you have a different question, please ask using [Discussions](https://github.com/alshedivat/al-folio/discussions/categories/q-a).
 
-1. **Q:** After I fork and setup the repo, I get a deployment error.
+1. **Q:** After I fork or create a new repository from this template and setup the repo, I get a deployment error.
    Isn't the website supposed to correctly deploy automatically? <br>
    **A:** Yes, if you are using release `v0.3.5` or later, the website will automatically and correctly re-deploy right after your first commit.
    Please make some changes (e.g., change your website info in `_config.yml`), commit, and push.


### PR DESCRIPTION
This PR changes README.md to encourage people to use `Use this template` rather than `fork`.

### Differences between `Use this template` and fork
> - A new fork includes the entire commit history of the parent repository, while a repository created from a template starts with a single commit.
> - Commits to a fork don't appear in your contributions graph, while commits to a repository created from a template do appear in your contribution graph.
> - A fork can be a temporary way to contribute code to an existing project, while creating a repository from a template starts a new project quickly. [Ref](https://docs.github.com/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)

### Cons
Possible con would be that it is harder to pull the new changes from this repo to the users' repos. It does not seem like impossible to do so but it will require additonal actions on the users end.
- https://github.com/orgs/community/discussions/23528
- https://stackoverflow.com/questions/56577184/github-pull-changes-from-a-template-repository