### PR TITLE
Add CogSci workshop to list of workshops in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ ML Retrospectives (NeurIPS: <a href="https://ml-retrospectives.github.io/neurips
 HAMLETS (NeurIPS: <a href="https://hamlets-workshop.github.io/" target="_blank">2020</a>) <br>
 ICBINB (NeurIPS: <a href="https://i-cant-believe-its-not-better.github.io/" target="_blank">2020</a>, <a href="https://i-cant-believe-its-not-better.github.io/neurips2021/" target="_blank">2021</a>) <br>
 Neural Compression (ICLR: <a href="https://neuralcompression.github.io/" target="_blank">2021</a>) <br>
-Score Based Methods (NeurIPS: <a href="https://score-based-methods-workshop.github.io/" target="_blank">2022</a>)
+Score Based Methods (NeurIPS: <a href="https://score-based-methods-workshop.github.io/" target="_blank">2022</a>)<br>
+Images2Symbols (CogSci: <a href="https://images2symbols.github.io/" target="_blank"> 2022</a>)
 </td>
 </tr>
 </table>


### PR DESCRIPTION
created a new row in the 'Workshops' section to add a workshop at Cogsci 2022 where we used this awesome template!
Thanks!