### PR TITLE
Added github 🏆 section in repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,8 @@ Easily create beautiful grids within your blog posts and project pages:
 ### Other features
 
 #### GitHub repositories and user stats
-**al-folio** uses [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) to display GitHub repositories and user stats on the the `/repositories/` page.
+**al-folio** uses [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) and [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy)
+to display GitHub repositories and user stats on the the `/repositories/` page.
 
 Edit the `_data/repositories.yml` and change the `github_users` and `github_repos` lists to include your own GitHub profile and repositories to the the `/repositories/` page.
 
@@ -501,6 +502,18 @@ You may also use the following codes for displaying this in any other pages.
     {% include repository/repo_user.html username=user %}
   {% endfor %}
 </div>
+{% endif %}
+
+<!-- code for Github trophies -->
+{% if site.repo_trophies.enabled %}
+{% for user in site.data.repositories.github_users %}
+  {% if site.data.repositories.github_users.size > 1 %}
+  <h4>{{ user }}</h4>
+  {% endif %}
+  <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+  {% include repository/repo_trophies.html username=user %}
+  </div>
+{% endfor %}
 {% endif %}
 
 <!-- code for GitHub repositories -->

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,10 @@ highlight_theme_dark: native    # https://github.com/jwarby/jekyll-pygments-them
 # repo color theme
 repo_theme_light: default       # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
 repo_theme_dark: dark           # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
+repo_trophies:
+  enabled: true
+  theme_light: flat    # https://github.com/ryo-ma/github-profile-trophy
+  theme_dark: gitdimmed  # https://github.com/ryo-ma/github-profile-trophy
 
 # -----------------------------------------------------------------------------
 # RSS Feed

--- a/_includes/repository/repo_trophies.html
+++ b/_includes/repository/repo_trophies.html
@@ -1,0 +1,6 @@
+<div class="repo p-2 text-center">
+  <a href="https://github.com/ryo-ma/github-profile-trophy">
+    <img class="repo-img-light w-200" alt="{{ include.username }}" src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C">
+    <img class="repo-img-dark w-200" alt="{{ include.username }}" src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C">
+  </a>
+</div>

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -15,9 +15,23 @@ nav_order: 3
     {% include repository/repo_user.html username=user %}
   {% endfor %}
 </div>
-{% endif %}
 
 ---
+
+{% if site.repo_trophies.enabled %}
+{% for user in site.data.repositories.github_users %}
+  {% if site.data.repositories.github_users.size > 1 %}
+  <h4>{{ user }}</h4>
+  {% endif %}
+  <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+  {% include repository/repo_trophies.html username=user %}
+  </div>
+
+  ---
+
+{% endfor %}
+{% endif %}
+{% endif %}
 
 ## GitHub Repositories
 


### PR DESCRIPTION
Basically, created a new section with your [user trophies](https://github.com/ryo-ma/github-profile-trophy#about-rank) under `repositories`, that looks like this:

![image](https://user-images.githubusercontent.com/31376482/222922023-20586ee5-bd8e-4da3-b716-09e894e768a6.png)

It only displays the github user above when there is more than one.

![image](https://user-images.githubusercontent.com/31376482/222922979-79b938fd-b94c-45eb-ac35-45afe9599a0a.png)

Since there is room for [a lot of customization](https://github.com/ryo-ma/github-profile-trophy#optional-request-parameters) in the trophies, I decided to set some defaults. I set to only display trophies that are above than C level and used some margins that just felt right.

Also, I was shocked to see how many trophies @alshedivat has 🏆.