### PR TITLE
Replace bin/deploy with GitHub Action

### DIFF
--- a/.github/workflows/deploy-docker-tag.yml
+++ b/.github/workflows/deploy-docker-tag.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Buildx
       uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Buildx
       uses: docker/setup-buildx-action@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,24 +11,26 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    - name: Checkout 🛎️
       uses: actions/checkout@v3
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2.1'
         bundler-cache: true
-    - name: Install deps
+    - name: Install and Build 🔧
       run: |
         npm install -g mermaid.cli
-    - name: Build site
-      run: |
         bundle exec jekyll build
-    - name: Deploy website
+    - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: _site
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         npm install -g mermaid.cli
         bundle exec jekyll build
     - name: Deploy 🚀
+      if: github.event_name != 'pull_request'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: _site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,19 +25,10 @@ jobs:
     - name: Install deps
       run: |
         npm install -g mermaid.cli
-    - name: Setup deploy options
-      id: setup
+    - name: Build site
       run: |
-        git config --global user.name "GitHub Action"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        if [[ ${GITHUB_REF} = refs/pull/*/merge ]]; then # pull request
-          echo "SRC_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
-          echo "NO_PUSH=--no-push" >> $GITHUB_OUTPUT
-        elif [[ ${GITHUB_REF} = refs/heads/* ]]; then # branch, e.g. master, source etc
-          echo "SRC_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-        fi
-        echo "DEPLOY_BRANCH=gh-pages" >> $GITHUB_OUTPUT
-    - name: Deploy website 
-      run:  yes | bash bin/deploy --verbose ${{ steps.setup.outputs.NO_PUSH }}
-                    --src ${{ steps.setup.outputs.SRC_BRANCH }} 
-                    --deploy ${{ steps.setup.outputs.DEPLOY_BRANCH }} 
+        bundle exec jekyll build
+    - name: Deploy website
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: _site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0.2'
+        ruby-version: '3.2.1'
         bundler-cache: true
     - name: Install deps
       run: |

--- a/README.md
+++ b/README.md
@@ -250,11 +250,7 @@ Starting version [v0.3.5](https://github.com/alshedivat/al-folio/releases/tag/v0
 
 <details><summary>(click to expand) <strong>Manual deployment to GitHub Pages:</strong></summary>
 
-If you need to manually re-deploy your website to GitHub pages, run the deploy script from the root directory of your repository:
-```bash
-$ ./bin/deploy
-```
-uses the `master` branch for the source code and deploys the webpage to `gh-pages`.
+If you need to manually re-deploy your website to GitHub pages, go to Actions, click "Deploy" in the left sidebar, then "Run workflow."
 
 </details>
 


### PR DESCRIPTION
### tl;dr
**This PR updates `deploy.yml` to use the GitHub Action [Deploy to GitHub Pages](https://github.com/marketplace/actions/deploy-to-github-pages).**

### Current setup
Currently, `deploy.yml` uses the deploy script `bin/deploy` to build and deploy the site. 

This script has worked well so far, but:
- (from experience!) is harder to read, and thus, customize;
- is another non-core script for maintainers to upkeep.

### Proposed setup
This Action replicates the default behavior of the deploy script: it clears the `gh-pages` branch, then pushes the contents of `_site` to it.

#### Changes:
- Replace `bin/deploy` with [Deploy to GitHub Pages](https://github.com/marketplace/actions/deploy-to-github-pages) Action.
- Create build step (`bundle exec jekyll build`) in `deploy.yml`.
- Enable deploy workflow to be manually triggered.
- _(Minor)_ Bump Checkout action from v2 to v3.
- _(Minor)_ Bump ruby version.

#### Benefits:
- Both automatic **and** manual deployment no longer depend on `bin/deploy`.
- Deploy logic is more explicit and easier to follow.
- Customization of deploy behavior (e.g., change branch site is served from) is now a matter of editing YAML, not shell scripts.

Thank you for this wonderful theme! I hope this PR helps even more folks use it. 😄 🚀 