### PR TITLE
Added related_posts false to the announcements front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,15 @@ If you have a different question, please ask using [Discussions](https://github.
   RSS Feed plugin works with these correctly set up fields: `title`, `url`, `description` and `author`.
   Make sure to fill them in an appropriate way and try again.
 
+5. **Q:** My site doesn't work when I enable `related_blog_posts`. Why?
+   **A:** This is probably due to the [classifier reborn](https://github.com/jekyll/classifier-reborn) plugin, which is used to calculate
+   related posts. If the error states `Liquid Exception: Zero vectors can not be normalized...`, it means that it could not calculate related
+   posts for a specific post. This is usually caused by [empty or really small blog posts](https://github.com/jekyll/classifier-reborn/issues/64)
+   without meaningful words (i.e. only [stop words](https://en.wikipedia.org/wiki/Stop_words)) or even 
+   [specific characters](https://github.com/jekyll/classifier-reborn/issues/194) you used in your posts. Also, the calculus for similar posts are
+   made for every `post`, which means every page that uses `layout: post`, including the announcements. To change this behavior, simply add
+   `related_posts: false` to the front matter of the page you don't want to display related posts on.
+   
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ If you have a different question, please ask using [Discussions](https://github.
   RSS Feed plugin works with these correctly set up fields: `title`, `url`, `description` and `author`.
   Make sure to fill them in an appropriate way and try again.
 
-5. **Q:** My site doesn't work when I enable `related_blog_posts`. Why?
+5. **Q:** My site doesn't work when I enable `related_blog_posts`. Why? <br>
    **A:** This is probably due to the [classifier reborn](https://github.com/jekyll/classifier-reborn) plugin, which is used to calculate
    related posts. If the error states `Liquid Exception: Zero vectors can not be normalized...`, it means that it could not calculate related
    posts for a specific post. This is usually caused by [empty or really small blog posts](https://github.com/jekyll/classifier-reborn/issues/64)

--- a/_news/announcement_1.md
+++ b/_news/announcement_1.md
@@ -2,6 +2,7 @@
 layout: post
 date: 2015-10-22 15:59:00-0400
 inline: true
+related_posts: false
 ---
 
 A simple inline announcement.

--- a/_news/announcement_2.md
+++ b/_news/announcement_2.md
@@ -3,6 +3,7 @@ layout: post
 title: A long announcement with details
 date: 2015-11-07 16:11:00-0400
 inline: false
+related_posts: false
 ---
 
 Announcements and news can be much longer than just quick inline posts. In fact, they can have all the features available for the standard blog posts. See below.

--- a/_news/announcement_3.md
+++ b/_news/announcement_3.md
@@ -2,6 +2,7 @@
 layout: post
 date: 2016-01-15 07:59:00-0400
 inline: true
+related_posts: false
 ---
 
 A simple inline announcement with Markdown emoji! :sparkles: :smile:


### PR DESCRIPTION
Added `related_posts: false` to the announcements front matter to avoid errors like #1203. Also included explanation in README FAQ section.