### PR TITLE
Fix assets sitemap exclusion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -224,7 +224,7 @@ plugins:
 # Sitemap settings
 defaults:
   - scope:
-      path: "assets/**/*.*"
+      path: "assets"
     values:
       sitemap: false
 


### PR DESCRIPTION
Double-star globbing is not allowed:
https://jekyllrb.com/docs/configuration/front-matter-defaults/#glob-patterns-in-front-matter-defaults.