### PR TITLE
Removed blog header-bar when title and description are empty

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -15,10 +15,15 @@ pagination:
 
 <div class="post">
 
+  {% assign blog_name_size = site.blog_name | size %}
+  {% assign blog_description_size = site.blog_description | size %}
+
+  {% if blog_name_size > 0 or blog_description_size > 0 %}
   <div class="header-bar">
     <h1>{{ site.blog_name }}</h1>
     <h2>{{ site.blog_description }}</h2>
   </div>
+  {% endif %}
 
   {% if site.display_tags %}
   <div class="tag-list">


### PR DESCRIPTION
When blog title and description are empty, go from this

![image](https://user-images.githubusercontent.com/31376482/234630799-f4c2cd46-7ad0-4d45-a0f6-2badcf0da558.png)

to this

![image](https://user-images.githubusercontent.com/31376482/234630683-f11c8a88-438a-4db3-974e-ba9184d5516f.png)
