### PR TITLE
Fixed hard-coded bib files in templates

### DIFF
--- a/_includes/selected_papers.html
+++ b/_includes/selected_papers.html
@@ -1,4 +1,4 @@
 
           <div class="publications">
-            {% bibliography -f papers -q @*[selected=true]* %}
+            {% bibliography -f {{ site.scholar.bibliography }} -q @*[selected=true]* %}
           </div>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -12,7 +12,7 @@ nav_order: 1
 
 {%- for y in page.years %}
   <h2 class="year">{{y}}</h2>
-  {% bibliography -f papers -q @*[year={{y}}]* %}
+  {% bibliography -f {{ site.scholar.bibliography }} -q @*[year={{y}}]* %}
 {% endfor %}
 
 </div>


### PR DESCRIPTION
The bibliography filename `papers.bib` is hard coded in templates, and the equivalent setting in `_config.yml` is not used anywhere. So changing the bib filename in `_config.yml` won't have any effects.

This PR replaces hard-coded filenames with the value from `_config.yml`.