### PR TITLE
Only filter keywords in attributes

### DIFF
--- a/_plugins/hideCustomBibtex.rb
+++ b/_plugins/hideCustomBibtex.rb
@@ -4,7 +4,7 @@
 	  keywords = @context.registers[:site].config['filtered_bibtex_keywords']
 
 	  keywords.each do |keyword|
-		input = input.gsub(/^.*#{keyword}.*$\n/, '')
+		input = input.gsub(/^\s*#{keyword}.*$\n/, '')
 	  end
 
       return input


### PR DESCRIPTION
I ran into the same issue as #1249 because one of my titles included "En*code*rs".

This PR fixes the problem that the keywords match any line that includes those and only considers the beginning of the line instead (i.e., the attribute in a properly formatted BibTeX file).

If this is not the expected behavior, I'm happy to adapt this minimalistic PR. 😄 
Any feedback is welcome.