### PR TITLE
Fixes "General Information" section of CV in dark mode.

### DIFF
--- a/_includes/cv/map.html
+++ b/_includes/cv/map.html
@@ -1,8 +1,8 @@
-<table class="table table-sm table-borderless table-responsive">
-    {% for content in entry.contents %}
-      <tr>
-        <td class="p-1 pr-2 font-weight-bold"><b>{{ content.name }}</b></td>
-        <td class="p-1 pl-2 font-weight-light text">{{ content.value }}</td>
-      </tr>
-    {% endfor %}
+<table class="table table-sm table-borderless table-responsive" style="background-color: transparent; border: none; color: var(--global-text-color);">
+  {% for content in entry.contents %}
+    <tr>
+      <td class="p-1 pr-2 font-weight-bold"><b>{{ content.name }}</b></td>
+      <td class="p-1 pl-2 font-weight-light text">{{ content.value }}</td>
+    </tr>
+  {% endfor %}
 </table>

--- a/_includes/cv/map.html
+++ b/_includes/cv/map.html
@@ -1,4 +1,4 @@
-<table class="table table-sm table-borderless table-responsive" style="background-color: transparent; border: none; color: var(--global-text-color);">
+<table class="table table-sm table-borderless table-responsive table-cv-map">
   {% for content in entry.contents %}
     <tr>
       <td class="p-1 pr-2 font-weight-bold"><b>{{ content.name }}</b></td>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -376,6 +376,12 @@ footer.sticky-bottom {
   }
 }
 
+.table-cv-map {
+  background-color: transparent;
+  border: none;
+  color: var(--global-text-color);
+}
+
 // Repositories
 
 @media (min-width: 768px) {

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,10 +1,10 @@
 // Has to be in the head tag, otherwise a flicker effect will occur.
 
 let toggleTheme = (theme) => {
-  if (theme == "dark") {
-    setTheme("light");
+  if (theme == 'dark') {
+    setTheme('light');
   } else {
-    setTheme("dark");
+    setTheme('dark');
   }
 };
 
@@ -14,48 +14,48 @@ let setTheme = (theme) => {
   setGiscusTheme(theme);
 
   if (theme) {
-    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.setAttribute('data-theme', theme);
 
     // Add class to tables.
-    let tables = document.getElementsByTagName("table");
+    let tables = document.getElementsByTagName('table');
     for (let i = 0; i < tables.length; i++) {
-      if (theme == "dark") {
-        tables[i].classList.add("table-dark");
+      if (theme == 'dark') {
+        tables[i].classList.add('table-dark');
       } else {
-        tables[i].classList.remove("table-dark");
+        tables[i].classList.remove('table-dark');
       }
     }
   } else {
-    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute('data-theme');
   }
-  localStorage.setItem("theme", theme);
+  localStorage.setItem('theme', theme);
 
   // Updates the background of medium-zoom overlay.
-  if (typeof medium_zoom !== "undefined") {
+  if (typeof medium_zoom !== 'undefined') {
     medium_zoom.update({
       background:
         getComputedStyle(document.documentElement).getPropertyValue(
-          "--global-bg-color"
-        ) + "ee", // + 'ee' for trasparency.
+          '--global-bg-color'
+        ) + 'ee', // + 'ee' for trasparency.
     });
   }
 };
 
 let setHighlight = (theme) => {
-  if (theme == "dark") {
-    document.getElementById("highlight_theme_light").media = "none";
-    document.getElementById("highlight_theme_dark").media = "";
+  if (theme == 'dark') {
+    document.getElementById('highlight_theme_light').media = 'none';
+    document.getElementById('highlight_theme_dark').media = '';
   } else {
-    document.getElementById("highlight_theme_dark").media = "none";
-    document.getElementById("highlight_theme_light").media = "";
+    document.getElementById('highlight_theme_dark').media = 'none';
+    document.getElementById('highlight_theme_light').media = '';
   }
 };
 
 let setGiscusTheme = (theme) => {
   function sendMessage(message) {
-    const iframe = document.querySelector("iframe.giscus-frame");
+    const iframe = document.querySelector('iframe.giscus-frame');
     if (!iframe) return;
-    iframe.contentWindow.postMessage({ giscus: message }, "https://giscus.app");
+    iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
   }
 
   sendMessage({
@@ -66,24 +66,24 @@ let setGiscusTheme = (theme) => {
 };
 
 let transTheme = () => {
-  document.documentElement.classList.add("transition");
+  document.documentElement.classList.add('transition');
   window.setTimeout(() => {
-    document.documentElement.classList.remove("transition");
+    document.documentElement.classList.remove('transition');
   }, 500);
 };
 
 let initTheme = (theme) => {
-  if (theme == null || theme == "null") {
+  if (theme == null || theme == 'null') {
     const userPref = window.matchMedia;
-    if (userPref && userPref("(prefers-color-scheme: dark)").matches) {
-      theme = "dark";
+    if (userPref && userPref('(prefers-color-scheme: dark)').matches) {
+      theme = 'dark';
     }
   }
 
   // Wait for the DOM to finish loading before setting theme
-  document.addEventListener("DOMContentLoaded", function () {
+  document.addEventListener('DOMContentLoaded', function () {
     setTheme(theme);
   });
 };
 
-initTheme(localStorage.getItem("theme"));
+initTheme(localStorage.getItem('theme'));

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,10 +1,10 @@
 // Has to be in the head tag, otherwise a flicker effect will occur.
 
 let toggleTheme = (theme) => {
-  if (theme == 'dark') {
-    setTheme('light');
+  if (theme == "dark") {
+    setTheme("light");
   } else {
-    setTheme('dark');
+    setTheme("dark");
   }
 };
 
@@ -14,48 +14,48 @@ let setTheme = (theme) => {
   setGiscusTheme(theme);
 
   if (theme) {
-    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute("data-theme", theme);
 
     // Add class to tables.
-    let tables = document.getElementsByTagName('table');
+    let tables = document.getElementsByTagName("table");
     for (let i = 0; i < tables.length; i++) {
-      if (theme == 'dark') {
-        tables[i].classList.add('table-dark');
+      if (theme == "dark") {
+        tables[i].classList.add("table-dark");
       } else {
-        tables[i].classList.remove('table-dark');
+        tables[i].classList.remove("table-dark");
       }
     }
   } else {
-    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute("data-theme");
   }
-  localStorage.setItem('theme', theme);
+  localStorage.setItem("theme", theme);
 
   // Updates the background of medium-zoom overlay.
-  if (typeof medium_zoom !== 'undefined') {
+  if (typeof medium_zoom !== "undefined") {
     medium_zoom.update({
       background:
         getComputedStyle(document.documentElement).getPropertyValue(
-          '--global-bg-color'
-        ) + 'ee', // + 'ee' for trasparency.
+          "--global-bg-color"
+        ) + "ee", // + 'ee' for trasparency.
     });
   }
 };
 
 let setHighlight = (theme) => {
-  if (theme == 'dark') {
-    document.getElementById('highlight_theme_light').media = 'none';
-    document.getElementById('highlight_theme_dark').media = '';
+  if (theme == "dark") {
+    document.getElementById("highlight_theme_light").media = "none";
+    document.getElementById("highlight_theme_dark").media = "";
   } else {
-    document.getElementById('highlight_theme_dark').media = 'none';
-    document.getElementById('highlight_theme_light').media = '';
+    document.getElementById("highlight_theme_dark").media = "none";
+    document.getElementById("highlight_theme_light").media = "";
   }
 };
 
 let setGiscusTheme = (theme) => {
   function sendMessage(message) {
-    const iframe = document.querySelector('iframe.giscus-frame');
+    const iframe = document.querySelector("iframe.giscus-frame");
     if (!iframe) return;
-    iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
+    iframe.contentWindow.postMessage({ giscus: message }, "https://giscus.app");
   }
 
   sendMessage({
@@ -66,24 +66,24 @@ let setGiscusTheme = (theme) => {
 };
 
 let transTheme = () => {
-  document.documentElement.classList.add('transition');
+  document.documentElement.classList.add("transition");
   window.setTimeout(() => {
-    document.documentElement.classList.remove('transition');
+    document.documentElement.classList.remove("transition");
   }, 500);
 };
 
 let initTheme = (theme) => {
-  if (theme == null || theme == 'null') {
+  if (theme == null || theme == "null") {
     const userPref = window.matchMedia;
-    if (userPref && userPref('(prefers-color-scheme: dark)').matches) {
-      theme = 'dark';
+    if (userPref && userPref("(prefers-color-scheme: dark)").matches) {
+      theme = "dark";
     }
   }
 
   // Wait for the DOM to finish loading before setting theme
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener("DOMContentLoaded", function () {
     setTheme(theme);
   });
 };
 
-initTheme(localStorage.getItem('theme'));
+initTheme(localStorage.getItem("theme"));

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -80,10 +80,7 @@ let initTheme = (theme) => {
     }
   }
 
-  // Wait for the DOM to finish loading before setting theme
-  document.addEventListener("DOMContentLoaded", function () {
-    setTheme(theme);
-  });
+  setTheme(theme);
 };
 
 initTheme(localStorage.getItem("theme"));

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -6,10 +6,9 @@ let toggleTheme = (theme) => {
   } else {
     setTheme("dark");
   }
-}
+};
 
-
-let setTheme = (theme) =>  {
+let setTheme = (theme) => {
   transTheme();
   setHighlight(theme);
   setGiscusTheme(theme);
@@ -18,12 +17,12 @@ let setTheme = (theme) =>  {
     document.documentElement.setAttribute("data-theme", theme);
 
     // Add class to tables.
-    let tables = document.getElementsByTagName('table');
-    for(let i = 0; i < tables.length; i++) {
+    let tables = document.getElementsByTagName("table");
+    for (let i = 0; i < tables.length; i++) {
       if (theme == "dark") {
-        tables[i].classList.add('table-dark');
+        tables[i].classList.add("table-dark");
       } else {
-        tables[i].classList.remove('table-dark');
+        tables[i].classList.remove("table-dark");
       }
     }
   } else {
@@ -32,14 +31,15 @@ let setTheme = (theme) =>  {
   localStorage.setItem("theme", theme);
 
   // Updates the background of medium-zoom overlay.
-  if (typeof medium_zoom !== 'undefined') {
+  if (typeof medium_zoom !== "undefined") {
     medium_zoom.update({
-      background: getComputedStyle(document.documentElement)
-          .getPropertyValue('--global-bg-color') + 'ee',  // + 'ee' for trasparency.
-    })
+      background:
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--global-bg-color"
+        ) + "ee", // + 'ee' for trasparency.
+    });
   }
 };
-
 
 let setHighlight = (theme) => {
   if (theme == "dark") {
@@ -49,44 +49,41 @@ let setHighlight = (theme) => {
     document.getElementById("highlight_theme_dark").media = "none";
     document.getElementById("highlight_theme_light").media = "";
   }
-}
-
+};
 
 let setGiscusTheme = (theme) => {
-
   function sendMessage(message) {
-    const iframe = document.querySelector('iframe.giscus-frame');
+    const iframe = document.querySelector("iframe.giscus-frame");
     if (!iframe) return;
-    iframe.contentWindow.postMessage({ giscus: message }, 'https://giscus.app');
+    iframe.contentWindow.postMessage({ giscus: message }, "https://giscus.app");
   }
 
   sendMessage({
     setConfig: {
-      theme: theme
-    }
+      theme: theme,
+    },
   });
-
-}
-
+};
 
 let transTheme = () => {
   document.documentElement.classList.add("transition");
   window.setTimeout(() => {
     document.documentElement.classList.remove("transition");
-  }, 500)
-}
-
+  }, 500);
+};
 
 let initTheme = (theme) => {
-  if (theme == null || theme == 'null') {
+  if (theme == null || theme == "null") {
     const userPref = window.matchMedia;
-    if (userPref && userPref('(prefers-color-scheme: dark)').matches) {
-        theme = 'dark';
+    if (userPref && userPref("(prefers-color-scheme: dark)").matches) {
+      theme = "dark";
     }
   }
 
-  setTheme(theme);
-}
-
+  // Wait for the DOM to finish loading before setting theme
+  document.addEventListener("DOMContentLoaded", function () {
+    setTheme(theme);
+  });
+};
 
 initTheme(localStorage.getItem("theme"));


### PR DESCRIPTION
## Problem

When the dark mode is default, or if you set the page to dark mode and then refresh, the content in "General Information" can't be seen.

<img width="711" alt="Screen Shot 2023-05-18 at 10 46 23 AM" src="https://github.com/alshedivat/al-folio/assets/6997460/ba1f11cf-49bf-4eaa-ba9e-a019be80b257">

## Solution

This PR fixes the problem.


