### PR TITLE
Clarify property type for `google_site_verification`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,8 @@ contact_note: >
 google_analytics:  # your Google Analytics measurement ID (format: G-XXXXXXXXXX)
 panelbear_analytics:  # panelbear analytics site ID (format: XXXXXXXXX)
 
-google_site_verification:  # your google-site-verification ID (Google Search Console)
+google_site_verification:  # your google-site-verification ID (HTML tag for URL
+                           # prefix property in Google Search Console)
 bing_site_verification:  # out your bing-site-verification ID (Bing Webmaster)
 
 # -----------------------------------------------------------------------------

--- a/_config.yml
+++ b/_config.yml
@@ -115,8 +115,13 @@ contact_note: >
 google_analytics:  # your Google Analytics measurement ID (format: G-XXXXXXXXXX)
 panelbear_analytics:  # panelbear analytics site ID (format: XXXXXXXXX)
 
-google_site_verification:  # your google-site-verification ID (HTML tag for URL
-                           # prefix property in Google Search Console)
+google_site_verification:  # your google-site-verification ID
+                           # Open Google Search Console, add a new URL prefix 
+                           # property, select HTML tag verification, and copy
+                           # the value of `content` to here. Also make sure to
+                           # set `enable_google_verification` to `true` in the
+                           # end of this file.
+
 bing_site_verification:  # out your bing-site-verification ID (Bing Webmaster)
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Domain property verification is the first (and more complete) option in [Google Search Console](https://search.google.com/search-console/welcome) to add a website property and it also calls the verification code "`google-site-verification`".

It took me a few days before realizing that `google_site_verification` in `_config.yml`
https://github.com/alshedivat/al-folio/blob/6e01a61a4ac1f39a8cef41d8bc249c54ef5187c5/_config.yml#L118
refers to the **HTML tag for URL prefix** property verification in Google Search Console:
https://github.com/alshedivat/al-folio/blob/6e01a61a4ac1f39a8cef41d8bc249c54ef5187c5/_includes/metadata.html#L4

This pull request expands `google_site_verification` comment to clarify Google Search Console property type.

