### PR TITLE
Make latest post redirect if the blog post redirects

### DIFF
--- a/_includes/latest_posts.html
+++ b/_includes/latest_posts.html
@@ -16,15 +16,13 @@
                   <td>
                     {% if item.redirect == blank %}
                       <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                    {% elsif item.redirect contains '://' %}
+                      <a class="news-title" href="{{ item.redirect }}" target="_blank">{{ item.title }}</a>
+                      <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+                      </svg>
                     {% else %}
-                      {% if item.redirect contains '://' %}
-                        <a class="news-title" href="{{ item.redirect }}" target="_blank">{{ item.title }}</a>
-                        <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
-                        </svg>
-                      {% else %}
-                        <a class="news-title" href="{{ item.redirect | relative_url }}">{{ item.title }}</a>
-                      {% endif %}
+                      <a class="news-title" href="{{ item.redirect | relative_url }}">{{ item.title }}</a>
                     {% endif %}
                   </td>
                 </tr>

--- a/_includes/latest_posts.html
+++ b/_includes/latest_posts.html
@@ -14,7 +14,18 @@
                 <tr>
                   <th scope="row">{{ item.date | date: "%b %-d, %Y" }}</th>
                   <td>
-                    <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                    {% if item.redirect == blank %}
+                      <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                    {% else %}
+                      {% if item.redirect contains '://' %}
+                        <a class="news-title" href="{{ item.redirect }}" target="_blank">{{ item.title }}</a>
+                        <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+                          <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+                        </svg>
+                      {% else %}
+                        <a class="news-title" href="{{ item.redirect | relative_url }}">{{ item.title }}</a>
+                      {% endif %}
+                    {% endif %}
                   </td>
                 </tr>
               {%- endfor %}

--- a/blog/index.html
+++ b/blog/index.html
@@ -60,15 +60,13 @@ pagination:
         <h3>
         {% if post.redirect == blank %}
           <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        {% elsif post.redirect contains '://' %}
+          <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>
+          <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+            <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
         {% else %}
-          {% if post.redirect contains '://' %}
-            <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>
-            <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-              <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-          {% else %}
-            <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
-          {% endif %}
+          <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
         {% endif %}
       </h3>
       <p>{{ post.description }}</p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -59,7 +59,7 @@ pagination:
 {%- endif -%}
         <h3>
         {% if post.redirect == blank %}
-          <a class="post-title" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
         {% else %}
           {% if post.redirect contains '://' %}
             <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>


### PR DESCRIPTION
Fixes #1450, and the behavior of the site with this "new" code is shown in the Expected behavior screenshots there.

I copy-pasted the redirect logic from `blog/index.html` into `_includes/latest_posts.html`, with minor name changes.

I also cleaned up a line in `blog/index.html`.