### PR TITLE
Update Tag Deploys to Support M1 Macbooks

### DIFF
--- a/.github/workflows/deploy-docker-tag.yml
+++ b/.github/workflows/deploy-docker-tag.yml
@@ -14,9 +14,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2 
+      
     - name: Buildx
-      uses: docker/setup-buildx-action@v1
-
+      uses: docker/setup-buildx-action@v2
+      
     -
       name: Docker meta
       id: meta
@@ -25,7 +29,7 @@ jobs:
         images: amirpourmand/al-folio
 
     - name: Login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -34,6 +38,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
+        platforms: linux/amd64,linux/arm64/v8
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I should merge this whenever normal deploy is well-tested for Mac computers.