### PR TITLE
Remove repeated layout template of cv.html

### DIFF
--- a/_layouts/cv.html
+++ b/_layouts/cv.html
@@ -4,45 +4,6 @@ layout: default
 <!-- _layouts/cv.html -->
 {% unless site.data.resume %}
 <div class="post">
-        <div class="post">
-
-          <header class="post-header">
-            <h1 class="post-title">{{ page.title }} {% if page.cv_pdf %}<a href="{{ page.cv_pdf | prepend: 'assets/pdf/' | relative_url}}" target="_blank" rel="noopener noreferrer" class="float-right"><i class="fas fa-file-pdf"></i></a>{% endif %}</h1>
-             {% if page.description %}<p class="post-description">{{ page.description }}</p>{% endif %}
-          </header>
-
-          <h4>Table of contents</h4>
-          <ul class="timeline">
-          {% for entry in site.data.cv %}
-            <li><a href="#{{ entry.title }}"><span class="badge-toc">{{ entry.title }}</span></a></li>
-          {% endfor %}
-          </ul>
-
-          <article>
-            <div class="cv">
-              {% for entry in site.data.cv %}
-                <a class="anchor" id="{{ entry.title }}"></a>
-                <div class="card mt-3 p-3">
-                  <h3 class="card-title font-weight-medium">{{ entry.title }}</h3>
-                  <div>
-                  {% if entry.type == "list" %}
-                    {% include cv/list.html %}
-                  {% elsif entry.type == "map" %}
-                    {% include cv/map.html %}
-                  {% elsif entry.type == "nested_list" %}
-                    {% include cv/nested_list.html %}
-                  {% elsif entry.type == "time_table" %}
-                   {% include cv/time_table.html %}
-                  {% elsif entry.type == "list_groups" %}
-                   {% include cv/list_groups.html %}
-                  {% else %}
-                    {{ entry.contents }}
-                  {% endif %}
-                  </div>
-                </div>
-              {% endfor %}
-              </div>
-          </article>
 
   <header class="post-header">
     <h1 class="post-title">{{ page.title }} {% if page.cv_pdf %}<a href="{{ page.cv_pdf | prepend: 'assets/pdf/' | relative_url}}" target="_blank" rel="noopener noreferrer" class="float-right"><i class="fas fa-file-pdf"></i></a>{% endif %}</h1>


### PR DESCRIPTION
The layout template of cv.html has repeated parts. When site.data.resume is not defined, the cv page will be rendered incorrectly.