### PR TITLE
Zotero ID Bugfix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ instagram_id: # your instagram id
 facebook_id: # your facebook id
 youtube_id: # your youtube channel id (youtube.com/@<youtube_id>)
 discord_id: # your discord id (18-digit unique numerical identifier)
-zotero: # your zotero username
+zotero_username: # your zotero username
 
 contact_note: >
   You can even add a little note about which of these is the best way to reach you.


### PR DESCRIPTION
#1569  Fixed mismatch between zotero-id in _config.yml and the zotero-id called upon in the socials html file introduced by #1572 (sorry about that; slipped in when I had to reset my zotero-branch)