### PR TITLE
Fix regex to limit keyword scope to fields

### DIFF
--- a/_plugins/hideCustomBibtex.rb
+++ b/_plugins/hideCustomBibtex.rb
@@ -4,7 +4,7 @@
 	  keywords = @context.registers[:site].config['filtered_bibtex_keywords']
 
 	  keywords.each do |keyword|
-		input = input.gsub(/^.*#{keyword}.*$\n/, '')
+		input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')
 	  end
 
       return input


### PR DESCRIPTION
This fix in https://github.com/alshedivat/al-folio/pull/1429 is not perfect.
`input = input.gsub(/^.*#{keyword}.*$\n/, '')` will fail but return true for cases like looking for "code" from "coder"

The following is the real fix
`input = input.gsub(/^.*\b#{keyword}\b *= *\{.*$\n/, '')`

The `\b` in the regex expression is a word boundary. This means it will not match substrings in other words.
The ` *= *\{` will ensure that the keyword is a field name because bib should follows `<field name> = {<value>}`.