### PR TITLE
Fixing bootstrap table table-dark top border

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -50,6 +50,7 @@ table.table a {
 
 .table-dark {
   background-color: transparent;
+  border: 1px solid var(--global-divider-color) !important;
 }
 
 figure,


### PR DESCRIPTION
This addresses #1425.

Contributions:
- Added border attribute to `.table-dark` within `_base.scss` to override bootstrap theme border settings. Displays top border in dark mode