### PR TITLE
Fixing bootstrap dark-table top border

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -50,6 +50,9 @@ table.table a {
 
 .table-dark {
   background-color: transparent;
+  &.table-bordered{
+    border: 1px solid var(--global-divider-color) !important;
+  }
 }
 
 figure,


### PR DESCRIPTION
This addresses https://github.com/alshedivat/al-folio/issues/1425.

Contributions:
- Added border attribute to `.table-dark` within `_base.scss` to override bootstrap theme border settings for `.tabled-bordered`. Displays top border in dark mode for only those tables that are bordered