### PR TITLE
Fixed weird bib btn behavior

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -386,6 +386,11 @@ mathjax:
 masonry:
   version: "4.2.2"
   integrity: "sha256-Nn1q/fx0H7SNLZMQ5Hw5JLaTRZp0yILA/FRexe19VdI="
+mdb:
+  version: "4.20.0"
+  integrity:
+    css: "sha256-jpjYvU3G3N6nrrBwXJoVEYI/0zw8htfFnhT9ljN3JJw="
+    js: "sha256-NdbiivsvWt7VYCt6hYNT3h/th9vSTL4EDWeGs5SN3DA="
 medium_zoom:
   version: "1.0.8"
   integrity: "sha256-7PhEpEWEW0XXQ0k6kQrPKwuoIomz8R8IYyuU1Qew4P8="

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,8 @@
 
     <!-- Bootstrap & MDB -->
     <link rel="stylesheet" href="{{ '/assets/css/bootstrap.min.css' | relative_url | bust_file_cache }}">
-    <link rel="stylesheet" href="{{ '/assets/css/mdb.min.css' | relative_url | bust_file_cache }}">
+    <!-- <link rel="stylesheet" href="{{ '/assets/css/mdb.min.css' | relative_url | bust_file_cache }}"> -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/css/mdb.min.css" integrity="{{ site.mdb.integrity.css }}" crossorigin="anonymous" />
 
     <!-- Bootstrap Table -->
     <link defer rel="stylesheet" href="https://unpkg.com/bootstrap-table@{{ site.bootstrap-table.version }}/dist/bootstrap-table.min.css">

--- a/_includes/scripts/bootstrap.html
+++ b/_includes/scripts/bootstrap.html
@@ -1,3 +1,4 @@
 <!-- Bootsrap & MDB scripts -->
   <script src="{{ '/assets/js/bootstrap.bundle.min.js' | relative_url }}"></script>
-  <script src="{{ '/assets/js/mdb.min.js' | relative_url }}"></script>
+  <!-- <script src="{{ '/assets/js/mdb.min.js' | relative_url }}"></script> -->
+  <script src="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/js/mdb.min.js" integrity="{{ site.mdb.integrity.js }}" crossorigin="anonymous"></script>


### PR DESCRIPTION
Fixes #1774 by reverting mdb usage to cdn. Weirdly enough, when using from local file it triggers a ripple effect when using `btn` class. It states in the [official docs](https://mdbootstrap.com/docs/standard/methods/ripple/) that:

> By default, ripple is added to every button (via .btn class)

Using [this solution](https://mdbootstrap.com/support/standard/disable-waves-ripple-effect/) only make this flicking happens faster. Also this does seem to be [an issue](https://mdbootstrap.com/support/standard/how-to-disable-ripple-effect/) still in the [latest version](https://github.com/mdbootstrap/mdb-ui-kit/issues/1505) (even though we are using an older one).





