### PR TITLE
fix inconsistent alignment for latest posts

### DIFF
--- a/_includes/latest_posts.html
+++ b/_includes/latest_posts.html
@@ -12,7 +12,7 @@
               {% endif %}
               {% for item in latest_posts limit: latest_posts_limit %}
                 <tr>
-                  <th scope="row">{{ item.date | date: "%b %-d, %Y" }}</th>
+                  <th scope="row" style="width: 20%">{{ item.date | date: "%b %-d, %Y" }}</th>
                   <td>
                     {% if item.redirect == blank %}
                       <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -11,7 +11,7 @@
               {% endif %}
               {% for item in news limit: news_limit %}
                 <tr>
-                  <th scope="row">{{ item.date | date: "%b %-d, %Y" }}</th>
+                  <th scope="row" style="width: 20%">{{ item.date | date: "%b %-d, %Y" }}</th>
                   <td>
                     {% if item.inline -%}
                       {{ item.content | remove: '<p>' | remove: '</p>' | emojify }}


### PR DESCRIPTION
This is a quick fix of issue #1499. The widths of the date and the title are by default dynamically determined by their lengths. I manually set the width of date as 20% of the table's width, so the alignment can be consistent.