### PR TITLE
bring back `repo_id` and `category_id` in `giscus` section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -138,9 +138,9 @@ related_blog_posts:
 # the information below.
 giscus:
   repo:                          # <your-github-user-name>/<your-github-repo-name>
-  repo_id: MDEwOlJlcG9zaXRvcnk2MDAyNDM2NQ==
+  repo_id:                       # leave empty or specify your repo_id (see https://giscus.app/) 
   category: Comments             # name of the category under which discussions will be created
-  category_id: DIC_kwDOA5PmLc4CTBt6
+  category_id:                   # leave empty or specify your category_id (see https://giscus.app/) 
   mapping: title                 # identify discussions by post title
   strict: 1                      # use strict identification mode
   reactions_enabled: 1           # enable (1) or disable (0) emoji reactions

--- a/_config.yml
+++ b/_config.yml
@@ -138,7 +138,9 @@ related_blog_posts:
 # the information below.
 giscus:
   repo:                          # <your-github-user-name>/<your-github-repo-name>
+  repo_id: MDEwOlJlcG9zaXRvcnk2MDAyNDM2NQ==
   category: Comments             # name of the category under which discussions will be created
+  category_id: DIC_kwDOA5PmLc4CTBt6
   mapping: title                 # identify discussions by post title
   strict: 1                      # use strict identification mode
   reactions_enabled: 1           # enable (1) or disable (0) emoji reactions


### PR DESCRIPTION
After deploying my website (Cloudflare Pages), my Giscus did not work, I realized these two paramesters are removed. After adding them again, my Giscus worked correctly.
These new values are values from previous commits of original repository