### PR TITLE
Fix navigation on the header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
       <nav id="navbar" class="navbar navbar-light navbar-expand-sm {% if site.navbar_fixed %}fixed-top{% else %}sticky-top{% endif %}">
         <div class="container">
           {% if page.permalink != '/' -%}
-          <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl }}/">
+          <a class="navbar-brand title font-weight-lighter" href="{{ site.url }}/">
             {%- if site.title == "blank" -%}
               {%- if site.first_name -%}
                 <span class="font-weight-bold">{{- site.first_name -}}&nbsp;</span>


### PR DESCRIPTION
When on page other than about; the title is shown as a clickable object. But when clicked nothing happens. Fixed this issue by redirecting to the main page.