### PR TITLE
Fixed: Dates in CSV too near and too low with respect to left text #1882

### DIFF
--- a/_data/cv.yml
+++ b/_data/cv.yml
@@ -72,18 +72,18 @@
   type: time_table
   contents:
     - year: 1921
-      items: 
-        - Nobel Prize in Physics 
+      items:
+        - Nobel Prize in Physics
         - Matteucci Medal
     - year: 2029
-      items: 
+      items:
         - Max Planck Medal
 
 - title: Academic Interests
   type: nested_list
   contents:
     - title: Topic 1.
-      items: 
+      items:
         - Description 1.
         - Description 2.
     - title: Topic 2.

--- a/_includes/cv/time_table.html
+++ b/_includes/cv/time_table.html
@@ -8,7 +8,7 @@
                 <tbody>
                   <tr>
                     <td>
-                      <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px;">{{ content.year }}</span>
+                      <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px; white-space: normal;">{{ content.year }}</span>
                     </td>
                   </tr>
                   {% if content.location %}


### PR DESCRIPTION
Added _'white-space: normal;'_ to the style of the span that contains _{{ content.year }}_ on __includes/cv/time_table.html._ 

This let's the text break without being too near to the text on the right, making it able to handle any year range without looking too cluttered. 

![Screenshot 2023-12-18 at 14 51 39](https://github.com/alshedivat/al-folio/assets/119902348/b99b4851-40d8-41b1-b9f7-6f77d846b266)
