### PR TITLE
Added video button to bib entries

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -303,7 +303,7 @@ enable_publication_badges:
   dimensions: true # Dimensions badge (https://badge.dimensions.ai/)
 
 # Filter out certain bibtex entry keywords used internally from the bib output
-filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, slides, website, preview, altmetric]
+filtered_bibtex_keywords: [abbr, abstract, arxiv, bibtex_show, html, pdf, selected, supp, blog, code, poster, video, slides, website, preview, altmetric]
 
 # Maximum number of authors to be shown for each publication (more authors are visible on click)
 max_author_limit: 3  # leave blank to always show all authors

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -164,6 +164,9 @@
             <a href="{{ entry.supp | prepend: '/assets/pdf/' | relative_url }}" class="btn btn-sm z-depth-0" role="button">Supp</a>
             {%- endif %}
           {%- endif %}
+          {%- if entry.video %}
+            <a class="abstract btn btn-sm z-depth-0" role="button">Video</a>
+          {%- endif %}
           {%- if entry.blog %}
             <a href="{{ entry.blog }}" class="btn btn-sm z-depth-0" role="button">Blog</a>
           {%- endif %}
@@ -236,5 +239,13 @@
             {% highlight bibtex %}{{ entry.bibtex | hideCustomBibtex }}{% endhighlight %}
           </div>
           {%- endif %}
+
+          {% if entry.video -%}
+          <!-- Hidden video block -->
+          <div class="abstract hidden">
+            <div style="text-align: center;">{% include video.html path=entry.video class="img-fluid rounded z-depth-1" controls=true %}</div>
+          </div>
+          {%- endif -%}
+
         </div>
       </div>


### PR DESCRIPTION
When the video entry is added to bib:

e.g.,

```
{
...
video={https://www.youtube.com/embed/jNQXAC9IVRw}
...
}
```
A dedicated button appears for videos. When clicked, a playable video appears under the research article (like abstracts and bibtex)