### PR TITLE
fix live-reloading in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,6 @@ services:
     build: .
     ports:
       - 8080:8080
+      - 35729:35729
     volumes:
       - .:/srv/jekyll


### PR DESCRIPTION
Fix #2021 : The webpage hosted by docker would not be automatically reloaded because the port used for live-reloading (port 35729) is not forwarded. 