### PR TITLE
Remove imagemagick strip

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -346,7 +346,7 @@ imagemagick:
     - ".tiff"
     - ".gif"
   output_formats:
-    webp: "-quality 85 -strip"
+    webp: "-quality 85"
 
 # -----------------------------------------------------------------------------
 # Jekyll Diagrams


### PR DESCRIPTION
I had added -strip arg to the imagemagick call as it is generally desirable to strip metadata from images before publishing them, however it seems to occasionally cause issues with jekyll-imagemagick auto-regeneration, regenerating images even when they have not changed.