### PR TITLE
Added citation examples, simplified citation code

### DIFF
--- a/_includes/selected_papers.html
+++ b/_includes/selected_papers.html
@@ -1,4 +1,4 @@
 
           <div class="publications">
-            {% bibliography -f {{ site.scholar.bibliography }} --group_by none --query @*[selected=true]* %}
+            {% bibliography --group_by none --query @*[selected=true]* %}
           </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,11 +13,10 @@ layout: default
     {{ content }}
   </article>
 
-  {%- if page.related_publications != null and page.related_publications.size > 0 -%}
-  {% assign publications = page.related_publications | replace: ", ", "," | split: "," | join: "|" %}
+  {%- if page.related_publications -%}
   <h2>References</h2>
   <div class="publications">
-    {% bibliography -f {{ site.scholar.bibliography }} -q @*[key^={{ publications }}]* %}
+    {% bibliography --cited_in_order %}
   </div>
   {%- endif %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -64,11 +64,10 @@ layout: default
     </div>
   </article>
 
-  {%- if page.related_publications != null and page.related_publications.size > 0 -%}
-  {% assign publications = page.related_publications | replace: ", ", "," | split: "," | join: "|" %}
+  {%- if page.related_publications -%}
   <h2>References</h2>
   <div class="publications">
-    {% bibliography -f {{ site.scholar.bibliography }} -q @*[key^={{ publications }}]* %}
+    {% bibliography --cited_in_order %}
   </div>
   {%- endif %}
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -9,6 +9,6 @@ nav_order: 2
 <!-- _pages/publications.md -->
 <div class="publications">
 
-{% bibliography -f {{ site.scholar.bibliography }} %}
+{% bibliography %}
 
 </div>

--- a/_posts/2023-07-12-post-bibliography.md
+++ b/_posts/2023-07-12-post-bibliography.md
@@ -7,6 +7,15 @@ tags: formatting bib
 categories: sample-posts
 giscus_comments: true
 related_posts: false
-related_publications: einstein1950meaning, einstein1905movement
+related_publications: true
 ---
-This post shows how to add bibliography to simple blog posts. If you would like something more academic, check the [distill style post]({% post_url 2018-12-22-distill %}).
+This post shows how to add bibliography to simple blog posts. We support every citation style that [jekyll-scholar](https://github.com/inukshuk/jekyll-scholar) does. That means simple citation like {% cite einstein1950meaning %}, multiple citations like {% cite einstein1950meaning einstein1905movement %}, long references like {% reference einstein1905movement %} or also quotes:
+
+{% quote einstein1905electrodynamics %}
+Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+sed do eiusmod tempor.
+
+Lorem ipsum dolor sit amet, consectetur adipisicing.
+{% endquote %}
+
+If you would like something more academic, check the [distill style post]({% post_url 2018-12-22-distill %}).

--- a/_projects/1_project.md
+++ b/_projects/1_project.md
@@ -5,7 +5,7 @@ description: a project with a background image
 img: assets/img/12.jpg
 importance: 1
 category: work
-related_publications: einstein1956investigations, einstein1950meaning
+related_publications: true
 ---
 
 Every project has a beautiful feature showcase page.
@@ -44,8 +44,8 @@ To give your project a background in the portfolio page, just add the img tag to
     This image can also have a caption. It's like magic.
 </div>
 
-You can also put regular text between your rows of images.
-Say you wanted to write a little bit about your project before you posted the rest of the images.
+You can also put regular text between your rows of images, even citations {% cite einstein1950meaning %}.
+Say you wanted to write a bit about your project before you posted the rest of the images.
 You describe how you toiled, sweated, *bled* for your project, and then... you reveal its glory in the next row of images.
 
 


### PR DESCRIPTION
Since the citation file and other stuff is already defined in `_config.yml`, removed them when calling `{% bibliography %}`. Also realized that `jekyll-scholar` helps in displaying only the papers cited in page, changed to use that.