### PR TITLE
Move news and 404 to pages

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -5,4 +5,5 @@ title: "Page not found"
 description: "Looks like there has been a mistake. Nothing exists here."
 redirect: true
 ---
-<p>You will be redirected to the main page within 3 seconds. If not redirected, please go back to the <a href="{{ site.baseurl }}/">home page</a>.</p>
+
+You will be redirected to the main page within 3 seconds. If not redirected, please go back to the [home page]({{ site.baseurl | prepend: site.url }}).

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -3,4 +3,5 @@ layout: page
 title: news
 permalink: /news/
 ---
+
 {% include news.liquid %}


### PR DESCRIPTION
moves news and 404 from repo root dir to `_pages/` where they are supposed to be + changes their extensions to `.md`