### PR TITLE
Fix custom blockquotes

### DIFF
--- a/_posts/2023-05-12-custom-blockquotes.md
+++ b/_posts/2023-05-12-custom-blockquotes.md
@@ -89,39 +89,39 @@ These custom styles can be used by adding the specific class to the blockquote, 
 >
 > A tip can be used when you want to give advice
 > related to a certain content.
-> {: .block-tip }
+{: .block-tip }
 ```
 
 > ##### TIP
 >
 > A tip can be used when you want to give advice
 > related to a certain content.
-> {: .block-tip }
+{: .block-tip }
 
 ```markdown
 > ##### WARNING
 >
 > This is a warning, and thus should
 > be used when you want to warn the user
-> {: .block-warning }
+{: .block-warning }
 ```
 
 > ##### WARNING
 >
 > This is a warning, and thus should
 > be used when you want to warn the user
-> {: .block-warning }
+{: .block-warning }
 
 ```markdown
 > ##### DANGER
 >
 > This is a danger zone, and thus should
 > be used carefully
-> {: .block-danger }
+{: .block-danger }
 ```
 
 > ##### DANGER
 >
 > This is a danger zone, and thus should
 > be used carefully
-> {: .block-danger }
+{: .block-danger }

--- a/_posts/2023-05-12-custom-blockquotes.md
+++ b/_posts/2023-05-12-custom-blockquotes.md
@@ -84,6 +84,8 @@ A regular blockquote can be used as following:
 
 These custom styles can be used by adding the specific class to the blockquote, as follows:
 
+<!-- prettier-ignore-start -->
+
 ```markdown
 > ##### TIP
 >
@@ -125,3 +127,5 @@ These custom styles can be used by adding the specific class to the blockquote, 
 > This is a danger zone, and thus should
 > be used carefully
 {: .block-danger }
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
Fixed issue #2066. Removed `>` in front of `{: .block-tip }` which was introduced by prettier in the example post. Maybe add /_post/*.md into .prettierignore to prevent similar breaks in the future.