### PR TITLE
Link checks on deploy

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -1,4 +1,4 @@
-name: Deploy site
+name: Check for broken links on site
 
 on:
   push:
@@ -31,8 +31,7 @@ jobs:
         with:
           commitChange: false
           valueFile: "_config.yml"
-          propertyPath: "giscus.repo"
-          value: ${{ github.repository }}
+          changes: {"giscus.repo":"${{ github.repository }}","baseurl":""}
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter
@@ -41,8 +40,9 @@ jobs:
           export JEKYLL_ENV=production
           bundle exec jekyll build --lsi
           purgecss -c purgecss.config.js
-      - name: Deploy 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Link Checker 🔗
+        uses: lycheeverse/lychee-action@v1.9.0
         with:
-          folder: _site
+          fail: true
+          # only check local links
+          args: --offline --remap '_site(/?.*)/assets/(.*) _site/assets/$2' --verbose --no-progress '_site/**/*.html'

--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -31,7 +31,11 @@ jobs:
         with:
           commitChange: false
           valueFile: "_config.yml"
-          changes: {"giscus.repo":"${{ github.repository }}","baseurl":""}
+          changes: |
+            {
+              "giscus.repo": "${{ github.repository }}",
+              "baseurl": ""
+            }
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: deploy
+name: Deploy site
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,12 @@ jobs:
           export JEKYLL_ENV=production
           bundle exec jekyll build --lsi
           purgecss -c purgecss.config.js
+      - name: Link Checker 🔗
+        uses: lycheeverse/lychee-action@v1.9.0
+        with:
+          fail: true
+          # only check local links
+          args: --offline --verbose --no-progress '_site/**/*.html'
       - name: Deploy 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fail: true
           # only check local links
-          args: --offline --remap "/al-folio/(.*) _site/$1" --verbose --no-progress '_site/**/*.html'
+          args: --offline --remap '/al-folio/(.*) _site/$1' --verbose --no-progress '_site/**/*.html'
       - name: Deploy 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fail: true
           # only check local links
-          args: --offline --verbose --no-progress '_site/**/*.html'
+          args: --offline --remap "/al-folio/(.*) _site/$1" --verbose --no-progress '_site/**/*.html'
       - name: Deploy 🚀
         if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,4 @@
-name: prettier
+name: Prettier code formatter
 
 on:
   push:


### PR DESCRIPTION
Added another GitHub action to check for broken local links on version of the site that will be deployed.

The `broken-links` action check for broken links considering documentation files (like INSTALLING.md) and also pages like [_pages/about.md](https://github.com/alshedivat/al-folio/blob/master/_pages/about.md), but it can't check for broken links when the link will be handled by jekyll tags (like in [_pages/blog.md](https://github.com/alshedivat/al-folio/blob/master/_pages/blog.md).

With `broken-links-site` we can check if all the links that will be used on the final site that refer to local files are correct. Focusing only on local files since this would end up calling too many checks for library files, like `https://unpkg.com/bootstrap-table@1.22.1/dist/bootstrap-table.min.css`.