### PR TITLE
improved redirect mapping

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -3,7 +3,14 @@
   <!-- Head -->
   <head>
     {% if page.redirect %}
-      <meta http-equiv="refresh" content="3; url={{ site.baseurl }}/">
+      {% if page.redirect == true %}
+        {% assign redirect = site.baseurl | append: '/' %}
+      {% elsif page.redirect contains '://' %}
+        {% assign redirect = page.redirect %}
+      {% else %}
+        {% assign redirect = page.redirect | relative_url %}
+      {% endif %}
+      <meta http-equiv="refresh" content="3; url={{ redirect }}">
     {% endif %}
     {% include head.liquid %}
   </head>


### PR DESCRIPTION
In reference to issue: https://github.com/alshedivat/al-folio/discussions/1818

Redirect cases were only happening on the surface level, essentially just affecting the links on [blog index](https://alshedivat.github.io/al-folio/blog/page/4/index.htm) and [year tag](https://alshedivat.github.io/al-folio/blog/2022/). However, from the actual [site](https://alshedivat.github.io/al-folio/blog/2022/redirect/), it would automatically redirect to the `base_url` rather than the actual `redirect`. 

In my update, if `redirect: true`, like it is in `404.md`, redirect behavior is the same, redirecting to the `base_url`. If it is an external link, then the redirect is external. And finally if it is an internal redirect, like it is in https://alshedivat.github.io/al-folio/blog/2022/redirect/, than the redirect is `page.redirect | relative_url`