### PR TITLE
center footer text by default

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -426,6 +426,7 @@ footer.fixed-bottom {
     color: var(--global-footer-text-color);
     padding-top: 9px;
     padding-bottom: 8px;
+    text-align: center;
   }
 
   a {
@@ -443,6 +444,10 @@ footer.sticky-bottom {
   padding-top: 40px;
   padding-bottom: 40px;
   font-size: 0.9rem;
+
+  .container {
+    text-align: center;
+  }
 }
 
 // CV


### PR DESCRIPTION
This PR changes the footer text on the website (for both the sticky and fixed footer) to be centered by default. This change is based on the discussion post #257.