### PR TITLE
add two buttons: "award" and "dataset" for publications

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -55,7 +55,8 @@
   number={8},
   pages={549--560},
   year={1905},
-  publisher={Wiley Online Library}
+  publisher={Wiley Online Library},
+  award={Nobel Prize}
 }
 
 @article{einstein1905movement,

--- a/_config.yml
+++ b/_config.yml
@@ -314,7 +314,7 @@ enable_publication_badges:
 
 # Filter out certain bibtex entry keywords used internally from the bib output
 filtered_bibtex_keywords:
-  [abbr, abstract, altmetric, arxiv, bibtex_show, blog, code, html, pdf, poster, preview, selected, slides, supp, video, website]
+  [abbr, abstract, altmetric, arxiv, bibtex_show, blog, code, html, pdf, poster, preview, selected, slides, supp, video, website, award, dataset]
 
 # Maximum number of authors to be shown for each publication (more authors are visible on click)
 max_author_limit: 3 # leave blank to always show all authors

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -207,6 +207,14 @@
       {% if entry.website %}
         <a href="{{ entry.website }}" class="btn btn-sm z-depth-0" role="button">Website</a>
       {% endif %}
+      {% if entry.dataset %}
+        <a href="{{ entry.dataset }}" class="btn btn-sm z-depth-0" role="button">Dataset</a>
+      {% endif %}
+
+      {% if entry.award %}
+        <a class="btn btn-sm z-depth-0 btn-success" role="button">{{entry.award}}</a>
+      {% endif %}
+
     </div>
     {% if site.enable_publication_badges %}
       {% assign entry_has_altmetric_badge = entry.altmetric or entry.doi or  entry.eprint or entry.pmid or entry.isbn %}


### PR DESCRIPTION
Two new fields ("dataset", "award") could be added in the bib to show buttons for a publicartion.
"dataset" button is for some links to the dataset of the paper, e.g., huggingface.
"award" button could be used to show the something like "Distinguished Paper Award".
For example:
@article{einstein1905molekularkinetischen,
  title={{\"U}ber die von der molekularkinetischen Theorie der W{\"a}rme geforderte Bewegung von in ruhenden Fl{\"u}ssigkeiten suspendierten Teilchen},
  author={Einstein, A.},
  journal={Annalen der physik},
  volume={322},
  number={8},
  pages={549--560},
  year={1905},
  publisher={Wiley Online Library},
  award={Nobel Prize},
  dataset={https://huggingface.co/datasets/XXXXX}
}