### PR TITLE
remove the space in names of "site"

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -8,12 +8,10 @@
             {% if site.first_name %}
               <span class="font-weight-bold">
                 {{- site.first_name -}}
-                &nbsp;</span
-              >
+              </span>
             {% endif %}
             {% if site.middle_name %}
               {{- site.middle_name -}}
-              &nbsp;
             {% endif %}
             {% if site.last_name %}
               {{- site.last_name -}}


### PR DESCRIPTION
I removed the spaces between the first, middle and last names in the header.

It's just my preference, I don't know if it would be accepted but I have done this for my own page using this repository as a template.