### PR TITLE
Add academic community example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://jonaruthardt.github.io" target="_blank">★</a>
 <a href="https://www.zla.app/" target="_blank">★</a>
 <a href="https://stavros.github.io" target="_blank">★</a>
+<a href="https://ericslyman.com" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Adds [https://ericslyman.com/](https://ericslyman.com/) to the list of academic community examples.