### PR TITLE
Fixed broken latex in _posts/2015-10-20-math.md

### DIFF
--- a/_posts/2015-10-20-math.md
+++ b/_posts/2015-10-20-math.md
@@ -21,7 +21,7 @@ MathJax will automatically number equations:
 
 \begin{equation}
 \label{eq:cauchy-schwarz}
-\left( \sum*{k=1}^n a_k b_k \right)^2 \leq \left( \sum*{k=1}^n a*k^2 \right) \left( \sum*{k=1}^n b_k^2 \right)
+\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
 \end{equation}
 
 and by adding `\label{...}` inside the equation environment, we can now refer to the equation using `\eqref`.


### PR DESCRIPTION
Latex math is currently broken in [_posts/2015-10-20-math.md](https://alshedivat.github.io/al-folio/blog/2015/math/) . Fixed it by replacing starts with underscore