### PR TITLE
Correct config variable for enabling latest_posts on about page

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -49,7 +49,7 @@ layout: default
     {% endif %}
 
     <!-- Latest posts -->
-    {% if page.latest_posts %}
+    {% if site.latest_posts.enabled %}
       <h2>
         <a href="{{ '/blog/' | relative_url }}" style="color: inherit">latest posts</a>
       </h2>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -14,7 +14,6 @@ profile:
     <p>Your City, State 12345</p>
 
 news: true # includes a list of news items
-latest_posts: true # includes a list of the newest posts
 selected_papers: true # includes a list of papers marked as "selected={true}"
 social: true # includes social icons at the bottom of the page
 ---


### PR DESCRIPTION
I noticed disabling latest_posts in `_config.yml` didn't work because the variable in the liquid template was seemingly incorrect. This should fix that.