### PR TITLE
Add academic community example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://www.zla.app/" target="_blank">★</a>
 <a href="https://stavros.github.io" target="_blank">★</a>
 <a href="https://ericslyman.com" target="_blank">★</a>
+<a href="https://ztjona.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Adds [https://ztjona.github.io/](https://ztjona.github.io/) to the list of academic community examples.