### PR TITLE
Update work.liquid to show the location of work experience under cv page

### DIFF
--- a/_includes/resume/work.liquid
+++ b/_includes/resume/work.liquid
@@ -12,7 +12,25 @@
           {% else %}
             {% assign date = '' %}
           {% endif %}
-          <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px"> {{ date }} </span>
+          <table class="table-cv">
+            <tbody>
+              <tr>
+                <td>
+                  <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px"> {{ date }} </span>
+                </td>
+              </tr>
+              {% if content.location %}
+                <tr>
+                  <td>
+                    <p class="location">
+                      <i class="fa-solid fa-location-dot iconlocation"></i>
+                      {{ content.location }}
+                    </p>
+                  </td>
+                </tr>
+              {% endif %}
+            </tbody>
+          </table>
         </div>
         <div class="col-xs-10 cl-sm-10 col-md-10 mt-2 mt-md-0">
           <h6 class="title font-weight-bold ml-1 ml-md-4">


### PR DESCRIPTION
adding "location" element when location object is added to work experience. Location icon and the entered value will appear on the CV page under the work experience section. This feature already exists for education section, but not for work. The change is made to make the experiece more consistent.

![image](https://github.com/alshedivat/al-folio/assets/158527033/9b55e139-1078-4655-8a18-56ac43da4d74)
