### PR TITLE
Remove bootstrap-table from archive tables

### DIFF
--- a/_layouts/archive-category.liquid
+++ b/_layouts/archive-category.liquid
@@ -7,7 +7,7 @@ layout: default
     <p class="post-description">an archive of posts in this category</p>
   </header>
 
-  <article>
+  <article class="archive">
     <div class="table-responsive">
       <table class="table table-sm table-borderless">
         {% for post in page.posts %}

--- a/_layouts/archive-tag.liquid
+++ b/_layouts/archive-tag.liquid
@@ -7,7 +7,7 @@ layout: default
     <p class="post-description">an archive of posts with this tag</p>
   </header>
 
-  <article>
+  <article class="archive">
     <div class="table-responsive">
       <table class="table table-sm table-borderless">
         {% for post in page.posts %}

--- a/_layouts/archive-year.liquid
+++ b/_layouts/archive-year.liquid
@@ -7,7 +7,7 @@ layout: default
     <p class="post-description">an archive of posts from this year</p>
   </header>
 
-  <article>
+  <article class="archive">
     <div class="table-responsive">
       <table class="table table-sm table-borderless">
         {% for post in page.posts %}

--- a/assets/js/no_defer.js
+++ b/assets/js/no_defer.js
@@ -8,7 +8,7 @@ $(document).ready(function () {
     }
 
     // only select tables that are not inside an element with "news" (about page) or "card" (cv page) class
-    if ($(this).parents('[class*="news"]').length == 0 && $(this).parents('[class*="card"]').length == 0 && $(this).parents("code").length == 0) {
+    if ($(this).parents('[class*="news"]').length == 0 && $(this).parents('[class*="card"]').length == 0 && $(this).parents('[class*="archive"]').length == 0 && $(this).parents("code").length == 0) {
       // make table use bootstrap-table
       $(this).attr("data-toggle", "table");
       // add some classes to make the table look better

--- a/assets/js/no_defer.js
+++ b/assets/js/no_defer.js
@@ -8,7 +8,12 @@ $(document).ready(function () {
     }
 
     // only select tables that are not inside an element with "news" (about page) or "card" (cv page) class
-    if ($(this).parents('[class*="news"]').length == 0 && $(this).parents('[class*="card"]').length == 0 && $(this).parents('[class*="archive"]').length == 0 && $(this).parents("code").length == 0) {
+    if (
+      $(this).parents('[class*="news"]').length == 0 &&
+      $(this).parents('[class*="card"]').length == 0 &&
+      $(this).parents('[class*="archive"]').length == 0 &&
+      $(this).parents("code").length == 0
+    ) {
       // make table use bootstrap-table
       $(this).attr("data-toggle", "table");
       // add some classes to make the table look better


### PR DESCRIPTION
The blog archive page tables have `table-borderless`, but bootstrap-table JS adds `table-bordered` by default and this forces an `!important` border.
Since these tables are also supposed to be borderless, this PR excludes them from bootstrap-table, just like the news and CV table are.