### PR TITLE
feat: make video embeddings optional.

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -53,6 +53,7 @@
   altmetric={248277},
   dimensions={true},
   google_scholar_id={qyhmnyLat1gC},
+  video={https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ},
   selected={true}
 }
 

--- a/_config.yml
+++ b/_config.yml
@@ -390,6 +390,7 @@ enable_navbar_social: false # enables displaying social links in the navbar on t
 enable_project_categories: true # enables categorization of projects into multiple categories
 enable_medium_zoom: true # enables image zoom feature (as on medium.com)
 enable_progressbar: true # enables a horizontal progress bar linked to the vertical scroll position
+enable_video_embedding: false # enables video embedding for bibtex entries. If false, the button opens a the video link in a new window.
 
 # -----------------------------------------------------------------------------
 # Library versions

--- a/_config.yml
+++ b/_config.yml
@@ -390,7 +390,7 @@ enable_navbar_social: false # enables displaying social links in the navbar on t
 enable_project_categories: true # enables categorization of projects into multiple categories
 enable_medium_zoom: true # enables image zoom feature (as on medium.com)
 enable_progressbar: true # enables a horizontal progress bar linked to the vertical scroll position
-enable_video_embedding: false # enables video embedding for bibtex entries. If false, the button opens a the video link in a new window.
+enable_video_embedding: false # enables video embedding for bibtex entries. If false, the button opens the video link in a new window.
 
 # -----------------------------------------------------------------------------
 # Library versions

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -189,8 +189,10 @@
           <a href="{{ entry.supp | prepend: '/assets/pdf/' | relative_url }}" class="btn btn-sm z-depth-0" role="button">Supp</a>
         {% endif %}
       {% endif %}
-      {% if entry.video %}
+      {% if entry.video and site.enable_video_embedding %}
         <a class="abstract btn btn-sm z-depth-0" role="button">Video</a>
+      {% elsif entry.video %}
+        <a href="{{ entry.video }}" class="btn btn-sm z-depth-0" role="button">Video</a>
       {% endif %}
       {% if entry.blog %}
         <a href="{{ entry.blog }}" class="btn btn-sm z-depth-0" role="button">Blog</a>
@@ -297,7 +299,7 @@
       </div>
     {% endif %}
 
-    {% if entry.video %}
+    {% if entry.video and site.enable_video_embedding %}
       <!-- Hidden video block -->
       <div class="abstract hidden">
         <div style="text-align: center;">{% include video.liquid path=entry.video class="img-fluid rounded z-depth-1" controls=true %}</div>


### PR DESCRIPTION
As discussed in #1181, I suggest to make embedding videos an optional feature.

This behavior aligns well with recently merged PR #2312.

Open questions:

1. I added a youtube link to `papers.bib`. Is this link okay?
2. I set `enable_video_embedding: false` as the default. I argue that privacy settings should be the default. Also, the current implementation of `video.liquid` only works for some very specific video URLs. For example, to embed youtube, specialized links must be used to avoid `X-Frame-Option` issues. This behavior can lead to a broken embedding, which would not look very nice.

Feedback welcome.