### PR TITLE
add last updated date to posts

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -18,9 +18,9 @@ layout: default
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
     <p class="post-meta">
-      Created: {{ page.date | date: '%B %d, %Y' }}
+      Created in {{ page.date | date: '%B %d, %Y' }}
       {% if page.author %}• {{ page.author }}{% endif %}
-      {% if page.last_updated %} &nbsp; | &nbsp; Last Updated: {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
+      {% if page.last_updated %}, last updated in {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
       {% if page.meta %}• {{ page.meta }}{% endif %}
     </p>
     <p class="post-tags">

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -19,7 +19,7 @@ layout: default
     <h1 class="post-title">{{ page.title }}</h1>
     <p class="post-meta">
       Created in {{ page.date | date: '%B %d, %Y' }}
-      {% if page.author %}• {{ page.author }}{% endif %}
+      {% if page.author %}by {{ page.author }}{% endif %}
       {% if page.last_updated %}, last updated in {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
       {% if page.meta %}• {{ page.meta }}{% endif %}
     </p>

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -18,8 +18,9 @@ layout: default
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
     <p class="post-meta">
-      {{ page.date | date: '%B %d, %Y' }}
+      Created: {{ page.date | date: '%B %d, %Y' }}
       {% if page.author %}• {{ page.author }}{% endif %}
+      {% if page.last_updated %} &nbsp; | &nbsp; Last Updated: {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
       {% if page.meta %}• {{ page.meta }}{% endif %}
     </p>
     <p class="post-tags">

--- a/_posts/2024-01-27-vega-lite.md
+++ b/_posts/2024-01-27-vega-lite.md
@@ -2,6 +2,7 @@
 layout: post
 title: a post with vega lite
 date: 2024-01-27 00:20:00
+last_updated: 2024-04-14 04:30:00
 description: this is what included vega lite code could look like
 tags: formatting charts
 categories: sample-posts


### PR DESCRIPTION
This PR is related to #2309. I added an optional `last_updated` field. This new field represents the timestamp for when the post was last updated. Consequently, the existing `date` metadata should now be interpreted as the creation date of the post. 

The formatting for displaying these dates has been standardized as follows:

```text
Created: July 11, 2023   |   Last Updated: April 14, 2024
```

For a practical implementation example, please refer to [this post](https://torydeng.github.io/blog/2023/deploying-server/) on my website, where I have applied these changes.

---

Any feedback is wellcome.