### PR TITLE
adding null check to external-posts.rb to avoid parsing failure

### DIFF
--- a/_plugins/external-posts.rb
+++ b/_plugins/external-posts.rb
@@ -12,6 +12,7 @@ module ExternalPosts
         site.config['external_sources'].each do |src|
           p "Fetching external posts from #{src['name']}:"
           xml = HTTParty.get(src['rss_url']).body
+          return if xml.nil?
           feed = Feedjira.parse(xml)
           feed.entries.each do |e|
             p "...fetching #{e.url}"


### PR DESCRIPTION
Adjusting issue #2343 by adding null check.