### PR TITLE
Fix docker compose command using the slimmed docker image

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ Note that when you run it for the first time, it will download a docker image of
 
 Now, feel free to customize the theme however you like (don't forget to change the name!). Also, your changes should be automatically rendered in real-time (or maybe after a few seconds).
 
-> Beta: You can also use the slimmed docker image with a size below 100MBs and exact same functionality. Just use `docker compose up -f docker-compose-slim.yml`
+> Beta: You can also use the slimmed docker image with a size below 100MBs and exact same functionality. Just use `docker compose -f docker-compose-slim.yml up`
 
 ### Build your own docker image
 


### PR DESCRIPTION
Fixing the docker command based on `docker compose [-f <arg>...] [options] [COMMAND] [ARGS...]` format on the [website](https://docs.docker.com/compose/reference/#command-options-overview-and-help).  
Because the old command would give error: `unknown shorthand flag: 'f' in -f`