### PR TITLE
fix(style): remove whitespace before comma

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -92,8 +92,8 @@
               {{ author.last -}}
             </a>
           {%- else -%}
-            {{ author.first }}
-            {{ author.last }}
+            {{- author.first }}
+            {{ author.last -}}
           {% endif %}
         {%- endif -%}
       {% endfor %}


### PR DESCRIPTION
This PR fixes a very niche bug.

If there is a co-author that is not *me* (=`<em>` tagged) and does not have a `coauthor_url` (=`<a>` tagged), there will be a leading whitespace before the separating comma. If the author list is split into multiple lines (due to long author lists or a small view), the whitespace can lead to a line beginning with a comma.

As I said, very niche, but interestingly, the other cases already did the same whitespace handling. Just the case not-me/no-url was mising.

Currently, we do not have this case on vanilla al-folio, but you can see it for example on [my website](https://christianmainka.de/publications/) if the view is small (e.g., 430px).

Related to #1502.