### PR TITLE
feat: search.liquid over all collections

### DIFF
--- a/_includes/scripts/search.liquid
+++ b/_includes/scripts/search.liquid
@@ -89,7 +89,7 @@
           {
             {%- assign title = item.title | escape -%}
             id: "{{ collection.label }}-{{ title | slugify }}",
-            title: "{{ title}}",
+            title: "{{ title }}",
             description: "{{ item.description | strip_html | strip_newlines | escape }}",
             section: "{{ collection.label | capitalize }}",
             handler: () => {

--- a/_includes/scripts/search.liquid
+++ b/_includes/scripts/search.liquid
@@ -88,10 +88,10 @@
         {%- for item in collection.docs -%}
           {
             {%- assign title = item.title | escape -%}
-            id: "{{collection.label}}-{{ title | slugify }}",
+            id: "{{ collection.label }}-{{ title | slugify }}",
             title: "{{ title}}",
             description: "{{ item.description | strip_html | strip_newlines | escape }}",
-            section: "{{collection.label | capitalize }}",
+            section: "{{ collection.label | capitalize }}",
             handler: () => {
               window.location.href = "{{ item.url | relative_url }}";
             },

--- a/_includes/scripts/search.liquid
+++ b/_includes/scripts/search.liquid
@@ -84,18 +84,20 @@
           },
         },
       {%- endfor -%}
-      {%- for project in site.projects -%}
-        {
-          {%- assign title = project.title | escape -%}
-          id: "project-{{ title | slugify }}",
-          title: "{{ title }}",
-          description: "{{ project.description | strip_html | strip_newlines | escape }}",
-          section: "Projects",
-          handler: () => {
-            window.location.href = "{{ project.url | relative_url }}";
+      {% for collection in site.collections %}
+        {%- for item in collection.docs -%}
+          {
+            {%- assign title = item.title | escape -%}
+            id: "{{collection.label}}-{{ title | slugify }}",
+            title: "{{ title}}",
+            description: "{{ item.description | strip_html | strip_newlines | escape }}",
+            section: "{{collection.label | capitalize }}",
+            handler: () => {
+              window.location.href = "{{ item.url | relative_url }}";
+            },
           },
-        },
-      {%- endfor -%}
+        {%- endfor -%}
+      {% endfor %}
       {%- if site.socials_in_search -%}
         {%- if site.email -%}
           {


### PR DESCRIPTION
Thank you @george-gca for the awesome work. on #2415.

This PR generalizes the search on all collections. Currently, only projects are added to the search.
This PR uses all of them, such as news. On my personal website, I use a teaching collection which is then also automatically searched.