### PR TITLE
Feature: Dynamically sets the search shortcut key based on the user's platform

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -13,7 +13,6 @@
       <meta http-equiv="refresh" content="3; url={{ redirect }}">
     {% endif %}
     {% include head.liquid %}
-    <script src="{{ '/assets/js/shortcut-key.js' | relative_url }}"></script>
   </head>
 
   <!-- Body -->
@@ -74,5 +73,6 @@
     {% include scripts/jekyll_tabs.liquid %}
     {% include scripts/back_to_top.liquid %}
     {% include scripts/search.liquid %}
+    <script src="{{ '/assets/js/shortcut-key.js' | relative_url }}"></script>
   </body>
 </html>

--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -13,6 +13,7 @@
       <meta http-equiv="refresh" content="3; url={{ redirect }}">
     {% endif %}
     {% include head.liquid %}
+    <script src="{{ '/assets/js/shortcut-key.js' | relative_url }}"></script>
   </head>
 
   <!-- Body -->

--- a/assets/js/shortcut-key.js
+++ b/assets/js/shortcut-key.js
@@ -1,6 +1,6 @@
 // Check if the user is on a Mac and update the shortcut key for search accordingly
 (function () {
-  var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  let isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   document.addEventListener('readystatechange', function () {
     if (document.readyState === 'interactive') {
       let shortcutKeyElement = document.querySelector('#search-toggle .nav-link');

--- a/assets/js/shortcut-key.js
+++ b/assets/js/shortcut-key.js
@@ -1,0 +1,12 @@
+// Check if the user is on a Mac and update the shortcut key for search accordingly
+
+var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+document.addEventListener('readystatechange', function () {
+  if (document.readyState === 'interactive') {
+    var shortcutKeyElement = document.querySelector('#search-toggle .nav-link');
+    if (shortcutKeyElement && isMac) {
+        // use the unicode for command key
+        shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
+    }
+  }
+});

--- a/assets/js/shortcut-key.js
+++ b/assets/js/shortcut-key.js
@@ -1,12 +1,13 @@
 // Check if the user is on a Mac and update the shortcut key for search accordingly
-
-var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-document.addEventListener('readystatechange', function () {
-  if (document.readyState === 'interactive') {
-    var shortcutKeyElement = document.querySelector('#search-toggle .nav-link');
-    if (shortcutKeyElement && isMac) {
-        // use the unicode for command key
-        shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
+(function () {
+  var isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  document.addEventListener('readystatechange', function () {
+    if (document.readyState === 'interactive') {
+      let shortcutKeyElement = document.querySelector('#search-toggle .nav-link');
+      if (shortcutKeyElement && isMac) {
+          // use the unicode for command key
+          shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
+      }
     }
-  }
-});
+  });
+})();

--- a/assets/js/shortcut-key.js
+++ b/assets/js/shortcut-key.js
@@ -1,12 +1,12 @@
 // Check if the user is on a Mac and update the shortcut key for search accordingly
 (function () {
-  let isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-  document.addEventListener('readystatechange', function () {
-    if (document.readyState === 'interactive') {
-      let shortcutKeyElement = document.querySelector('#search-toggle .nav-link');
+  let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  document.addEventListener("readystatechange", function () {
+    if (document.readyState === "interactive") {
+      let shortcutKeyElement = document.querySelector("#search-toggle .nav-link");
       if (shortcutKeyElement && isMac) {
-          // use the unicode for command key
-          shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
+        // use the unicode for command key
+        shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
       }
     }
   });

--- a/assets/js/shortcut-key.js
+++ b/assets/js/shortcut-key.js
@@ -1,13 +1,11 @@
 // Check if the user is on a Mac and update the shortcut key for search accordingly
-(function () {
-  let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-  document.addEventListener("readystatechange", function () {
-    if (document.readyState === "interactive") {
-      let shortcutKeyElement = document.querySelector("#search-toggle .nav-link");
-      if (shortcutKeyElement && isMac) {
-        // use the unicode for command key
-        shortcutKeyElement.innerHTML = "&#x2318; k <i class='ti ti-search'></i>";
-      }
+document.onreadystatechange = () => {
+  if (document.readyState === "interactive") {
+    let isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+    let shortcutKeyElement = document.querySelector("#search-toggle .nav-link");
+    if (shortcutKeyElement && isMac) {
+      // use the unicode for command key
+      shortcutKeyElement.innerHTML = '&#x2318; k <i class="ti ti-search"></i>';
     }
-  });
-})();
+  }
+};


### PR DESCRIPTION
This addresses issue #2437 by:
- Adding a new script that dynamically sets the search keyboard shortcut by checking what platform the user is currently using
- Loading this script in `default.liquid`

<img width="1150" alt="SCR-20240529-cdfe" src="https://github.com/alshedivat/al-folio/assets/16251412/7c4125fc-5028-422f-97d5-0df729e30fa7">
