### PR TITLE
Bugfix: Collapse the navbar on mobile when the user selects search

### DIFF
--- a/_includes/scripts/search.liquid
+++ b/_includes/scripts/search.liquid
@@ -13,9 +13,9 @@
 
     const openSearchModal = () => {
       // collapse navbarNav if expanded on mobile
-      const navbarNav = document.querySelector('.navbar-collapse');
-      if (navbarNav.classList.contains('show')) {
-        navbarNav.classList.remove('show');
+      const $navbarNav = $('#navbarNav');
+      if ($navbarNav.hasClass('show')) {
+        $navbarNav.collapse('hide');
       }
       ninjaKeys.open();
     };


### PR DESCRIPTION
This PR addresses #2438 by programmatically collapsing the navbar if the user clicks on search on mobile. 

## Behavior before
![ToggleBehaviorBefore](https://github.com/alshedivat/al-folio/assets/16251412/562765b2-57eb-4a3d-bf41-eee4fcfddd5f)


## Behavior after
![ToggleBehaviorAfter](https://github.com/alshedivat/al-folio/assets/16251412/78bb917b-d7b3-4e58-bd76-f422b8ab7fd5)
