### PR TITLE
Bugfix: Updates ninja keys text input color so it is always visible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 assets/libs/
 node_modules/
 vendor
+.idea

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1119,7 +1119,9 @@ ninja-keys {
   --ninja-modal-background: var(--global-bg-color);
   --ninja-z-index: 1031;
 }
-
+ninja-keys::part(ninja-input) {
+  color: var(--ninja-selected-text-color);
+}
 ninja-keys::part(ninja-input-wrapper) {
   background: var(--global-bg-color);
 }


### PR DESCRIPTION
This PR fixes an issue where the search input is not visible in the light theme. This is because `ninja-header-min.js` defaults the text color to white. 

This style change will ensure that the text is always visible regardless of theme selection

## Before Style Change
<img width="1435" alt="SCR-20240530-cnxd" src="https://github.com/alshedivat/al-folio/assets/16251412/dbbc04c6-6e23-4bb5-8278-218d4e0e1329">

## After Style Change
<img width="1434" alt="SCR-20240530-coqb" src="https://github.com/alshedivat/al-folio/assets/16251412/182df8e5-8f54-4eca-a255-b8efbf52db9d">
