### PR TITLE
[Tweak] Update "search filters" displayed on the blog's front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -292,8 +292,8 @@ jekyll-archives:
     tag: "/blog/tag/:name/"
     category: "/blog/category/:name/"
 
-display_tags: ["formatting", "images", "links", "math", "code"] # these tags will be displayed on the front page of your blog
-display_categories: ["blockquotes"] # these categories will be displayed on the front page of your blog
+display_tags: ["formatting", "images", "links", "math", "code", "blockquotes"] # these tags will be displayed on the front page of your blog
+display_categories: ["external-services"] # these categories will be displayed on the front page of your blog
 
 # -----------------------------------------------------------------------------
 # Jekyll Scholar

--- a/_posts/2023-05-12-custom-blockquotes.md
+++ b/_posts/2023-05-12-custom-blockquotes.md
@@ -4,7 +4,7 @@ title: a post with custom blockquotes
 date: 2023-05-12 15:53:00-0400
 description: an example of a blog post with custom blockquotes
 tags: formatting blockquotes
-categories: sample-posts
+categories: sample-posts blockquotes
 giscus_comments: true
 related_posts: true
 ---

--- a/_posts/2023-05-12-custom-blockquotes.md
+++ b/_posts/2023-05-12-custom-blockquotes.md
@@ -4,7 +4,7 @@ title: a post with custom blockquotes
 date: 2023-05-12 15:53:00-0400
 description: an example of a blog post with custom blockquotes
 tags: formatting blockquotes
-categories: sample-posts blockquotes
+categories: sample-posts
 giscus_comments: true
 related_posts: true
 ---


### PR DESCRIPTION
# [Tweak] Update "search filters" on blog's front page

## Current Behavior

```
1. Go to `blog/`
2. Select "🏷️ Blockquotes" "search filter"

=> `blog/category/blockquotes/` returns 404
```

<img width="400" alt="current-01-blog-filters" src="https://github.com/alshedivat/al-folio/assets/5504473/dae7f061-864d-49f3-9af1-1ef30c8056cd">
<img width="400" alt="current-02-category-blockquotes" src="https://github.com/alshedivat/al-folio/assets/5504473/c09422a9-a2c7-4f81-8534-1f310c4f9876">

<hr>

## Resolution in PR

1. Append 'blockquotes' to [`display_tags`](https://github.com/alshedivat/al-folio/pull/2480/files#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883R295)  
2. Replace 'blockquotes' with 'external-services' in `display_categories`  

=> Display 'blockquotes' tag and 'external-services' category on blog's front page

<img width="400" alt="v2-01" src="https://github.com/alshedivat/al-folio/assets/5504473/c2f62a12-578d-44e0-ae8c-d6998fe8e2cb">
<br>  
<img width="300" alt="v2-02" src="https://github.com/alshedivat/al-folio/assets/5504473/8df86ea0-46d6-4389-904d-24965d74ace9">
<img width="300" alt="v2-03" src="https://github.com/alshedivat/al-folio/assets/5504473/6407812a-2052-4e0c-88bf-0d70d1c03ed8">
