### PR TITLE
fix: remove 'index.html' in pagination

### DIFF
--- a/_includes/pagination.liquid
+++ b/_includes/pagination.liquid
@@ -9,7 +9,7 @@
       {% if paginator.page_trail %}
         {% for trail in paginator.page_trail %}
           <li class="page-item {% if page.url == trail.path %}active{% endif %}">
-            <a class="page-link" href="{{ trail.path | relative_url }}" title="{{trail.title}}">{{ trail.num }}</a>
+            <a class="page-link" href="{{ trail.path | relative_url | remove: 'index.html' }}" title="{{trail.title}}">{{ trail.num }}</a>
           </li>
         {% endfor %}
       {% endif %}


### PR DESCRIPTION
Currently, on the [blog](https://alshedivat.github.io/al-folio/blog/) page, clicking "older" and "newer" on the pagination at the bottom direct you forward to links like `/al-folio/blog/page/2/` and backward to `/al-folio/blog/`. 

However, if you click on the `1`, `2`.. etc buttons, there is a different behavior. The links now contain an `index.html`. For example, clicking `2` leads you to `/al-folio/blog/page/2/index.html`. It is the same content, just with a messier hyper link. Same with clicking `1`, you are brought to `/al-folio/blog/`.

This fix creates a consistency among the hyper links in pagination.