### PR TITLE
fix: blog highlighted in nav for child pages

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -95,7 +95,8 @@
                   </div>
                 </li>
               {% else %}
-                <li class="nav-item {% if page.url contains p.permalink %}active{% endif %}">
+              {% assign parent_link = p.permalink | remove: 'index.html' %}
+                <li class="nav-item {% if page.url contains parent_link %}active{% endif %}">
                   {% if p.permalink contains '/blog/' %}{% assign url = '/blog/' %} {% else %}{% assign url = p.url %}{% endif %}
                   <a class="nav-link" href="{{ url | relative_url }}">
                     {{- p.title }}

--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -95,7 +95,7 @@
                   </div>
                 </li>
               {% else %}
-              {% assign parent_link = p.permalink | remove: 'index.html' %}
+                {% assign parent_link = p.permalink | remove: 'index.html' %}
                 <li class="nav-item {% if page.url contains parent_link %}active{% endif %}">
                   {% if p.permalink contains '/blog/' %}{% assign url = '/blog/' %} {% else %}{% assign url = p.url %}{% endif %}
                   <a class="nav-link" href="{{ url | relative_url }}">


### PR DESCRIPTION
Currently, in all blog posts, or any child page under /blog, the "blog" in nav is not highlighted. 

In all other child pages for a parent in nav, the parent is highlighted. For example, in a sub page of projects, projects in nav is highlighted. 

This fix creates a consistent behavior for nav and highlights the blog in nav if in a blog post.

BEFORE:
<img width="1427" alt="image" src="https://github.com/alshedivat/al-folio/assets/52665298/fc79727c-dc22-4af7-8c16-80efa216ecbc">

AFTER:
<img width="1434" alt="image" src="https://github.com/alshedivat/al-folio/assets/52665298/6b32e7f9-e421-4b08-b86e-813b20ac058e">
