### PR TITLE
Fix repo card heigth for different repo descriptions

### DIFF
--- a/_data/repositories.yml
+++ b/_data/repositories.yml
@@ -2,11 +2,13 @@ github_users:
   - torvalds
   - alshedivat
 
+repo_description_lines_max: 2
+
 github_repos:
   - alshedivat/al-folio
-  - twbs/bootstrap
   - jekyll/jekyll
+  - twbs/bootstrap
   - jquery/jquery
   - FortAwesome/Font-Awesome
-  - jpswalsh/academicons
   - mathjax/MathJax
+  - jpswalsh/academicons

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -5,17 +5,23 @@
   {% assign show_owner = true %}
 {% endif %}
 
+{% if site.data.repositories.repo_description_lines_max %}
+  {% assign max_lines = site.data.repositories.repo_description_lines_max %}
+{% else %}
+  {% assign max_lines = 2 %}
+{% endif %}
+
 <div class="repo p-2 text-center">
   <a href="https://github.com/{{ include.repository }}">
     <img
       class="repo-img-light w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&show_owner={{ show_owner }}"
+      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
     <img
       class="repo-img-dark w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&show_owner={{ show_owner }}"
+      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
   </a>
 </div>


### PR DESCRIPTION
Hello! I had this minor issue on my website and I saw few other people using this template and having the same issue.

**Brief**
if two repo's in the same row has different number of lines for the descriptions, heights of the cards will not be the same if we don't force the number of lines to be displayed.

**Solution**
By looking at [This issue](https://github.com/anuraghazra/github-readme-stats/issues/2900) I could see that they solved it by adding an new option, `description_lines_count`. This was used on the API request in order to fix the issue.

---

## Issue reproduced:

![before](https://github.com/alshedivat/al-folio/assets/15076325/238931f5-8a0e-45c5-a9bb-e9c6e4c0f04b)

---

## Issue fixed after the commit:

![after](https://github.com/alshedivat/al-folio/assets/15076325/a0e79cdf-fd6a-4765-b21f-279540ae88fe)
