### PR TITLE
Add support for translatable/customizable section titles in the cv page

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -48,6 +48,26 @@ There are currently 2 different ways of generating the CV page content. The firs
 
 What this means is, if there is no resume data defined in [\_config.yml](_config.yml) and loaded via a json file, it will load the contents of [\_data/cv.yml](_data/cv.yml). If you want to use the [\_data/cv.yml](_data/cv.yml) file as the source of your CV, you must delete the [assets/json/resume.json](assets/json/resume.json) file.
 
+You can customize or translate the section titles on your CV page by editing the [\_config.yml](_config.yml) file. Inside this file, there is a `sectiontitles` configuration where you can define the titles for each section. Note that these customizations will only apply when the CV is generated via the JSON file located at [assets/json/resume.json](assets/json/resume.json).
+
+Here's an example of how to customize section titles:
+
+```yaml
+sectiontitles:
+  basics: personal informations
+  work: experiences
+  education: # Leave it blank for the default title
+  publications:
+  projects:
+  volunteer:
+  awards:
+  certificates:
+  skills:
+  languages:
+  interests:
+  references:
+```
+
 ## Modifying the user and repository information
 
 The user and repository information is defined in [\_data/repositories.yml](_data/repositories.yml). You can add as many users and repositories as you want. Both informations are used in the `repositories` section.

--- a/_config.yml
+++ b/_config.yml
@@ -641,3 +641,18 @@ jsonresume:
   - languages
   - interests
   - references
+
+# Customize the section titles in the cv page, leave it blank for default
+sectiontitles:
+  basics:
+  work:
+  education:
+  publications:
+  projects:
+  volunteer:
+  awards:
+  certificates:
+  skills:
+  languages:
+  interests:
+  references:

--- a/_layouts/cv.liquid
+++ b/_layouts/cv.liquid
@@ -70,6 +70,7 @@ layout: default
     <article>
       <div class="cv">
         {% for data in site.data.resume %}
+          {% assign current_section = data[0] | downcase %}
           {% if site.jsonresume and site.jsonresume.size > 0 %}
             {% unless site.jsonresume contains data[0] %}
               {% continue %}
@@ -78,7 +79,9 @@ layout: default
           {% if data[0] == 'meta' or data[1].size == 0 %} {% continue %} {% endif %}
           <a class="anchor" id="{{ data[0] }}"></a>
           <div class="card mt-3 p-3">
-            <h3 class="card-title font-weight-medium">{{ data[0] | capitalize }}</h3>
+            <h3 class="card-title font-weight-medium">
+              {{ site.sectiontitles[current_section] | default: data[0] | capitalize }}
+            </h3>
             <div>
               {% case data[0] %}
                 {% when 'basics' %}


### PR DESCRIPTION
This PR adds support for translating or customizing section title in the resume from the `_config.yaml`file. This feature enhances the internationalization of the al-folio theme, allowing users to customize the section titles without modifying the liquid template directly.

# Modification
- added a `sectiontitle`parameter in the `_config.yml`to store translations for section titles.
- Updated `cv.liquid` to use titles from `sectiontitle`if available, defaulting to the original section name if a translation is not provided.
- Updated the documentation in `CUSTOMIZE.md` to explain how to used this new feature.

# Example (in French)

```yaml
# _config.yml 
sectiontitles:
  basics: Informations personnelles
  work: experiences
  education: # Leave it blank for the default title
  publications:
  projects: projets
  volunteer:
  awards:
  certificates:
  skills: Compétences
  languages: langues
  interests: hobbits
  references:
```