### PR TITLE
Allow URLs in bib award field

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -185,9 +185,15 @@
     <!-- Links/Buttons -->
     <div class="links">
       {% if entry.award %}
-        <a class="award btn btn-sm z-depth-0" role="button">
-          {%- if entry.award_name %}{{ entry.award_name }}{% else %}Awareded{% endif -%}
-        </a>
+        {% if entry.award contains '://' %}
+          <a href="{{ entry.award }}" class="award btn btn-sm z-depth-0" role="button">
+            {%- if entry.award_name %}{{ entry.award_name }}{% else %}Awarded{% endif -%}
+          </a>
+        {% else %}
+          <a class="award btn btn-sm z-depth-0" role="button">
+            {%- if entry.award_name %}{{ entry.award_name }}{% else %}Awarded{% endif -%}
+          </a>
+        {% endif %}
       {% endif %}
       {% if entry.abstract %}
         <a class="abstract btn btn-sm z-depth-0" role="button">Abs</a>

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
     $(this).parent().parent().find(".award.hidden.open").toggleClass("open");
     $(this).parent().parent().find(".bibtex.hidden.open").toggleClass("open");
   });
-  $("a.award").click(function () {
+  $("a.award:not([href])").click(function () {
     $(this).parent().parent().find(".abstract.hidden.open").toggleClass("open");
     $(this).parent().parent().find(".award.hidden").toggleClass("open");
     $(this).parent().parent().find(".bibtex.hidden.open").toggleClass("open");


### PR DESCRIPTION
If the `award` field in a bib entry is an URL, then link to it directly instead of opening an abstract-like text box.