### PR TITLE
fix: search_enabled -> bib_search

### DIFF
--- a/_includes/bib_search.liquid
+++ b/_includes/bib_search.liquid
@@ -1,0 +1,4 @@
+{% if site.bib_search %}
+  <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
+  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+{% endif %}

--- a/_includes/scripts/misc.liquid
+++ b/_includes/scripts/misc.liquid
@@ -37,11 +37,6 @@
 <script defer src="{{ '/assets/js/common.js' | relative_url | bust_file_cache }}"></script>
 <script defer src="{{ '/assets/js/copy_code.js' | relative_url | bust_file_cache }}" type="text/javascript"></script>
 
-<!-- Bibsearch Feature -->
-{% if site.bib_search %}
-  <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
-{% endif %}
-
 <!-- Jupyter Open External Links New Tab -->
 <script defer src="{{ '/assets/js/jupyter_new_tab.js' | relative_url | bust_file_cache }}"></script>
 

--- a/_includes/scripts/misc.liquid
+++ b/_includes/scripts/misc.liquid
@@ -38,7 +38,7 @@
 <script defer src="{{ '/assets/js/copy_code.js' | relative_url | bust_file_cache }}" type="text/javascript"></script>
 
 <!-- Bibsearch Feature -->
-{% if site.search_enabled %}
+{% if site.bib_search %}
   <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
 {% endif %}
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -9,8 +9,12 @@ nav_order: 2
 
 <!-- _pages/publications.md -->
 
+<!-- Bibsearch Feature -->
+
 {% if site.bib_search %}
-<input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+
+  <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
+  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
 {% endif %}
 
 <div class="publications">

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -11,11 +11,7 @@ nav_order: 2
 
 <!-- Bibsearch Feature -->
 
-{% if site.bib_search %}
-
-  <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
-  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
-{% endif %}
+{% include bib_search.liquid %}
 
 <div class="publications">
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 <!-- _pages/publications.md -->
 
-{% if site.search_enabled %}
+{% if site.bib_search %}
 <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
 {% endif %}
 


### PR DESCRIPTION
In #2523, I did a copy&paste error with https://github.com/alshedivat/al-folio/commit/07d6e619cced7a2256bbe6de582ad68f93cd1553

I used the global `search_enabled` config key instead of the correct `bib_search` key.

This PR fixed it.