### PR TITLE
Make publication badges always visible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -338,7 +338,7 @@ scholar:
 
 # Display different badges withs stats for your publications
 enable_publication_badges:
-  altmetric: true # Altmetric badge (https://www.altmetric.com/products/altmetric-badges/)
+  altmetric: true # Altmetric badge (https://badge-docs.altmetric.com/index.html)
   dimensions: true # Dimensions badge (https://badge.dimensions.ai/)
   google_scholar: true # Google Scholar badge (https://scholar.google.com/intl/en/scholar/citations.html)
 

--- a/_config.yml
+++ b/_config.yml
@@ -337,9 +337,10 @@ scholar:
   group_order: descending
 
 # Display different badges withs stats for your publications
+# Customize badge behavior in _layouts/bib.liquid
 enable_publication_badges:
-  altmetric: true # Altmetric badge (https://badge-docs.altmetric.com/index.html)
-  dimensions: true # Dimensions badge (https://badge.dimensions.ai/)
+  altmetric: true # Altmetric badge (Customization options: https://badge-docs.altmetric.com/index.html)
+  dimensions: true # Dimensions badge (Customization options: https://badge.dimensions.ai/)
   google_scholar: true # Google Scholar badge (https://scholar.google.com/intl/en/scholar/citations.html)
 
 # Filter out certain bibtex entry keywords used internally from the bib output

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -295,7 +295,6 @@
               {% else %}
                 data-pmid="{{ entry.pmid }}"
               {% endif %}
-              data-hide-zero-citations="true"
               data-style="small_rectangle"
               data-legend="hover-right"
               style="margin-bottom: 3px;"

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -268,7 +268,6 @@
           {% if site.enable_publication_badges.altmetric and entry_has_altmetric_badge %}
             <span
               class="altmetric-embed"
-              data-hide-less-than="15"
               data-badge-type="2"
               data-badge-popover="right"
               {% if entry.altmetric != blank and entry.altmetric != 'true' %}

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -268,7 +268,6 @@
           {% if site.enable_publication_badges.altmetric and entry_has_altmetric_badge %}
             <span
               class="altmetric-embed"
-              data-hide-no-mentions="true"
               data-hide-less-than="15"
               data-badge-type="2"
               data-badge-popover="right"


### PR DESCRIPTION
## The issue
Currently Altmetric and Dimension publication badge elements have non-obvious attributes that hide badges when some conditions are not met ,e.g.:
```
data-hide-no-mentions="true"
data-hide-less-than="15"
```
resulting in seemingly strange behavior where badges are enabled in `config.yml` but don't show up consistently, as reported in #2443 : Altmetric badges don't display for some pubs.

## This PR
- removes these hidden nondisplay conditions in favor of more predictable website behavior;
- adds documentation links to point users interested in customizing badge behavior to the right resources.