### PR TITLE
Encoded email in CV using jekyll-email-protect

### DIFF
--- a/_includes/resume/basics.liquid
+++ b/_includes/resume/basics.liquid
@@ -2,8 +2,7 @@
   {% assign skip_basics = 'image,profiles,location' | split: ',' %}
   {% for content in data[1] %}
     {%
-      if (content[1] == "") or (skip_basics contains
-      content[0])
+      if (content[1] == "" ) or (skip_basics contains content[0])
     %}
       {% continue %}
     {% endif %}
@@ -14,9 +13,12 @@
       </td>
       <td class="p-1 pl-2 font-weight-light text">
         {% if content[0] == 'url' %}
-          <a href="{{ content[1] }}" target="_blank" rel="noopener noreferrer">{{ content[1] }}</a>
+          <a
+            href="{{ content[1] }}"
+            target="_blank"
+            rel="noopener noreferrer">{{ content[1] }}</a>
         {% elsif content[0] == 'email' %}
-          <a href="mailto:{{ content[1] }}" target="_blank">{{ content[1] }}</a>
+          <a href="mailto:{{ content[1][0] | encode_email }}" target="_blank">{{ content[1][1] }}</a>
         {% elsif content[0] == 'phone' %}
           <a href="tel:{{ content[1] }}">{{ content[1] }}</a>
         {% else %}

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -3,7 +3,7 @@
     "name": "Albert Einstein",
     "label": "Scientist",
     "image": "",
-    "email": "albert@einstein.de",
+    "email": ["albert@einstein.de","Contact me"],
     "phone": "(912) 123-4567",
     "url": "https://alshedivat.github.io/al-folio/",
     "summary": "A German-born theoretical physicist, widely ranked among the greatest and most influential scientists of all time",


### PR DESCRIPTION
I added a simple solution where the email provided in the json CV file can also be obfuscated using jekyll-email-protect. In the json file, the email field has now two entries, the first one being the email address and the second being the string to cover up the email.