### PR TITLE
Lighthouse Badger token as secret

### DIFF
--- a/.github/workflows/lighthouse-badger.yml
+++ b/.github/workflows/lighthouse-badger.yml
@@ -12,10 +12,10 @@ name: "Lighthouse Badger"
 # DEFINE YOUR INPUTS AND TRIGGERS IN THE FOLLOWING
 ########################################################################
 
-# INPUTS as environmental variables (env) for not manually triggered workflows
+# INPUTS as Secrets (env) for not manually triggered workflows
 env:
   URLS: https://alshedivat.github.io/al-folio/
-  TOKEN_NAME: LIGHTHOUSE_BADGER_TOKEN
+  TOKEN_NAME: ${{ secrets.LIGHTHOUSE_BADGER_TOKEN }}
   # If any of the following env is blank, a default value is used instead
   REPO_BRANCH: "${{ github.repository }} master" # target repository & branch e.g. 'dummy/mytargetrepo main'
   MOBILE_LIGHTHOUSE_PARAMS: "--only-categories=performance,accessibility,best-practices,seo --throttling.cpuSlowdownMultiplier=2"

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -152,3 +152,15 @@ You can add your social media links by adding the specified information at the `
 You can add a newsletter subscription form by adding the specified information at the `newsletter` section in the [\_config.yml](_config.yml) file. To set up a newsletter, you can use a service like [Loops.so](https://loops.so/), which is the current supported solution. Once you have set up your newsletter, you can add the form [endpoint](https://loops.so/docs/forms/custom-form) to the `endpoint` field in the `newsletter` section of the [\_config.yml](_config.yml) file.
 
 Depending on your specified footer behavior, the sign up form either will appear at the bottom of the `About` page and at the bottom of blogposts if `related_posts` are enabled, or in the footer at the bottom of each page.
+
+## Adding Token for Lighthouse Badger
+
+To add secrets for [lighthouse-badger], create a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and add it as a [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-encrypted-secrets-for-a-repository) named `LIGHTHOUSE_BADGER_TOKEN` to your repository. The [lighthouse-badger documentation](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml) specifies using an environment variable, but using it as a secret is more secure and appropriate for a PAT.
+
+Also In case you face the error: "Input required and not supplied: token" in the Lighthouse Badger action, this solution resolves it.
+
+#### Personal Access Token (fine-grained) Permissions for Lighthouse Badger:
+- **contents**: access: read and write
+- **metadata**: access: read-only
+
+Due to the necessary permissions (PAT and others mentioned above), it is recommended to use it as a secret rather than an environment variable.

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -155,7 +155,7 @@ Depending on your specified footer behavior, the sign up form either will appear
 
 ## Adding Token for Lighthouse Badger
 
-To add secrets for [lighthouse-badger], create a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and add it as a [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-encrypted-secrets-for-a-repository) named `LIGHTHOUSE_BADGER_TOKEN` to your repository. The [lighthouse-badger documentation](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml) specifies using an environment variable, but using it as a secret is more secure and appropriate for a PAT.
+To add secrets for [lighthouse-badger](https://github.com/alshedivat/al-folio/actions/workflows/lighthouse-badger.yml), create a [personal access token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and add it as a [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-encrypted-secrets-for-a-repository) named `LIGHTHOUSE_BADGER_TOKEN` to your repository. The [lighthouse-badger documentation](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml) specifies using an environment variable, but using it as a secret is more secure and appropriate for a PAT.
 
 Also In case you face the error: "Input required and not supplied: token" in the Lighthouse Badger action, this solution resolves it.
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -160,6 +160,7 @@ To add secrets for [lighthouse-badger](https://github.com/alshedivat/al-folio/ac
 Also In case you face the error: "Input required and not supplied: token" in the Lighthouse Badger action, this solution resolves it.
 
 #### Personal Access Token (fine-grained) Permissions for Lighthouse Badger:
+
 - **contents**: access: read and write
 - **metadata**: access: read-only
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,10 +29,6 @@ The recommended approach for using **al-folio** is to first create your own site
 4. Wait until the GitHub actions finish (check your repository **Actions** tab). Now, in addition to the master branch, your repository has a newly built gh-pages branch.
 5. Finally, in the repository page go to `Settings -> Pages -> Build and deployment`, make sure that `Source` is set to `Deploy from a branch` and set the branch to `gh-pages` (NOT to master).
 6. Wait until the GitHub actions finish (check your repository **Actions** tab), then simply navigate to `https://<your-github-username>.github.io` in your browser. At this point you should see a copy of the theme's [demo website](https://alshedivat.github.io/al-folio/).
-
-In case you face the error: "Input required and not supplied: token" in the Lighthouse Badger action, follow the instructions below:
-
-Add secrets for [lighthouse-badger],it may fail with the error: "Input required and not supplied: token." To fix this, create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and add it as a [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-encrypted-secrets-for-a-repository) named `LIGHTHOUSE_BADGER_TOKEN` to your repository. Refer to the [lighthouse-badger documentation](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml) for more details.
 After everything is set up, you can download the repository to your machine and start customizing it. To do so, run the following commands:
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,6 +30,9 @@ The recommended approach for using **al-folio** is to first create your own site
 5. Finally, in the repository page go to `Settings -> Pages -> Build and deployment`, make sure that `Source` is set to `Deploy from a branch` and set the branch to `gh-pages` (NOT to master).
 6. Wait until the GitHub actions finish (check your repository **Actions** tab), then simply navigate to `https://<your-github-username>.github.io` in your browser. At this point you should see a copy of the theme's [demo website](https://alshedivat.github.io/al-folio/).
 
+In case you face the error: "Input required and not supplied: token" in the Lighthouse Badger action, follow the instructions below:
+
+Add secrets for [lighthouse-badger],it may fail with the error: "Input required and not supplied: token." To fix this, create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) and add it as a [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-encrypted-secrets-for-a-repository) named `LIGHTHOUSE_BADGER_TOKEN` to your repository. Refer to the [lighthouse-badger documentation](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml) for more details.
 After everything is set up, you can download the repository to your machine and start customizing it. To do so, run the following commands:
 
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ The recommended approach for using **al-folio** is to first create your own site
 4. Wait until the GitHub actions finish (check your repository **Actions** tab). Now, in addition to the master branch, your repository has a newly built gh-pages branch.
 5. Finally, in the repository page go to `Settings -> Pages -> Build and deployment`, make sure that `Source` is set to `Deploy from a branch` and set the branch to `gh-pages` (NOT to master).
 6. Wait until the GitHub actions finish (check your repository **Actions** tab), then simply navigate to `https://<your-github-username>.github.io` in your browser. At this point you should see a copy of the theme's [demo website](https://alshedivat.github.io/al-folio/).
-After everything is set up, you can download the repository to your machine and start customizing it. To do so, run the following commands:
+   After everything is set up, you can download the repository to your machine and start customizing it. To do so, run the following commands:
 
 ```bash
 $ git clone git@github.com:<your-username>/<your-repo-name>.git


### PR DESCRIPTION
In the [FAQ](https://github.com/alshedivat/al-folio/blob/master/FAQ.md#my-webpage-works-locally-but-after-deploying-it-is-not-displayed-correctly-css-and-js-are-not-loaded-properly-how-do-i-fix-that), it is mentioned to "add it as a secret". However, the Lighthouse Badger documentation specifies using an environment variable. I've updated this to use secrets instead, as it is more secure and appropriate for using a Personal Access Token (PAT).

#### Personal Access Token (fine-grained) Permissions:
- **contents**: access: read and write
- **metadata**: access: read-only

#### Personal Access Token (classic) Permissions:
- **repo**

[refer](https://github.com/MyActionWay/lighthouse-badger-workflows#lighthouse-badger-easyyml:~:text=and%20permissions%20required-,PAT%20(fine%2Dgrained)%3A%20repository%20permissions,-contents%20%3D%3E%20access%3A%20read)

For more information, refer to the [GitHub documentation on using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
