### PR TITLE
[bug-fix] Add padding to default markdown table cells

### DIFF
--- a/_posts/2023-03-21-tables.md
+++ b/_posts/2023-03-21-tables.md
@@ -10,7 +10,20 @@ related_posts: true
 pretty_table: true
 ---
 
-Using markdown to display tables is easy. Just use the following syntax:
+Using markdown to display tables is easy. 
+
+
+## Simple Example
+
+First, add the following to the post's front matter
+
+
+```yml
+pretty_table: true
+```
+
+
+Then, the following syntax
 
 ```markdown
 | Left aligned | Center aligned | Right aligned |
@@ -20,7 +33,7 @@ Using markdown to display tables is easy. Just use the following syntax:
 | Left 3       |    center 3    |       right 3 |
 ```
 
-That will generate:
+will generate
 
 | Left aligned | Center aligned | Right aligned |
 | :----------- | :------------: | ------------: |
@@ -29,6 +42,9 @@ That will generate:
 | Left 3       |    center 3    |       right 3 |
 
 <p></p>
+
+
+## HTML Example
 
 It is also possible to use HTML to display tables. For example, the following HTML code will display a table with [Bootstrap Table](https://bootstrap-table.com/), loaded from a JSON file:
 
@@ -61,6 +77,9 @@ It is also possible to use HTML to display tables. For example, the following HT
 </table>
 
 <p></p>
+
+
+## More Complex Example
 
 By using [Bootstrap Table](https://bootstrap-table.com/) it is possible to create pretty complex tables, with pagination, search, and more. For example, the following HTML code will display a table, loaded from a JSON file, with pagination, search, checkboxes, and header/content alignment. For more information, check the [documentation](https://examples.bootstrap-table.com/index.html).
 

--- a/_posts/2023-03-21-tables.md
+++ b/_posts/2023-03-21-tables.md
@@ -10,18 +10,15 @@ related_posts: true
 pretty_table: true
 ---
 
-Using markdown to display tables is easy. 
-
+Using markdown to display tables is easy.
 
 ## Simple Example
 
 First, add the following to the post's front matter
 
-
 ```yml
 pretty_table: true
 ```
-
 
 Then, the following syntax
 
@@ -42,7 +39,6 @@ will generate
 | Left 3       |    center 3    |       right 3 |
 
 <p></p>
-
 
 ## HTML Example
 
@@ -77,7 +73,6 @@ It is also possible to use HTML to display tables. For example, the following HT
 </table>
 
 <p></p>
-
 
 ## More Complex Example
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -27,6 +27,7 @@ table {
   td,
   th {
     font-size: 1rem;
+    padding: 1px 1rem 1px 0;
   }
 
   th {


### PR DESCRIPTION
Default, meaning `pretty_table: false`

## Sample code

```md
|   First Column   |  Second Column  |  Third Column  |
|------------------|-----------------|----------------|
| Sed in.          | Sed non.        | Morbi egestas. |
| Donec facilisis. | Suspendisse eu. | Nulla porta.   |
| Praesent a.      | Interdum et.    | Sed nec.       |
```

### Current result 

<img width="369" alt="current-default" src="https://github.com/user-attachments/assets/7dc74cfd-ed60-46eb-a1c1-bf3df74bac59">

### Proposed result

<img width="378" alt="updated-default" src="https://github.com/user-attachments/assets/2bf83fb5-f7b1-4d4b-88aa-e55d3420aeaf">
