### PR TITLE
[Bug-fix] Make custom blockquote font coloring consistent

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -71,7 +71,10 @@ blockquote {
     border-color: var(--global-tip-block);
     background-color: var(--global-tip-block-bg);
 
-    p {
+    em,
+    li,
+    p,
+    strong {
       color: var(--global-tip-block-text);
     }
 
@@ -89,7 +92,10 @@ blockquote {
     border-color: var(--global-warning-block);
     background-color: var(--global-warning-block-bg);
 
-    p {
+    em,
+    li,
+    p,
+    strong {
       color: var(--global-warning-block-text);
     }
 
@@ -107,7 +113,10 @@ blockquote {
     border-color: var(--global-danger-block);
     background-color: var(--global-danger-block-bg);
 
-    p {
+    em,
+    li,
+    p,
+    strong {
       color: var(--global-danger-block-text);
     }
 


### PR DESCRIPTION
Currently, the tip, warning, and danger custom blockquote's font color is not customized when the text is styled as bold, italics, or a list item. As a result, the text is slightly less attractive in light mode and almost illegible in dark mode. 

## Screenshot: Current

<img width="400" alt="current-darkmode" src="https://github.com/user-attachments/assets/1cdd5861-76a2-45bd-a948-99cf35f9c87e">

## Screenshot: Proposed

<img width="400" alt="proposed-darkmode" src="https://github.com/user-attachments/assets/03fbd4d3-e3f5-498a-bef6-153e1ad55289">
