### PR TITLE
[Feature] InspireHEP social and citation count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://acad.garywei.dev/" target="_blank">★</a>
 <a href="https://tonideleo.github.io/" target="_blank">★</a>
 <a href="https://alonkellner.com/" target="_blank">★</a>
-<a href="http://berylbir.github.io/" target="_blank">★</a>
-<a href="http://thefermi0n.github.io/" target="_blank">★</a>
+<a href="https://berylbir.github.io/" target="_blank">★</a>
+<a href="https://thefermi0n.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://tonideleo.github.io/" target="_blank">★</a>
 <a href="https://alonkellner.com/" target="_blank">★</a>
 <a href="http://berylbir.github.io/" target="_blank">★</a>
+<a href="http://thefermi0n.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -57,7 +57,8 @@
   video={https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ},
   additional_info={. *More Information* can be [found here](https://github.com/alshedivat/al-folio/)},
   annotation={* Example use of superscripts<br>† Albert Einstein},
-  selected={true}
+  selected={true},
+  inspirehep_id = {3255}
 }
 
 @article{einstein1905molekularkinetischen,

--- a/_config.yml
+++ b/_config.yml
@@ -96,6 +96,7 @@ publons_id: # your ID on Publons
 quora_username: # your Quora username
 research_gate_profile: # your profile on ResearchGate
 scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
+inspirehep_id: 1010907 # Inspire HEP author ID
 scopus_id: # your profile on Scopus
 semanticscholar_id: # your Semantic Scholar ID
 spotify_id: # your spotify id

--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,7 @@ flickr_id: # your flickr id
 github_username: # your GitHub user name
 gitlab_username: # your GitLab user name
 ieee_id: # your ieeexplore.ieee.org/author/id
+inspirehep_id: 1010907 # Inspire HEP author ID
 instagram_id: # your instagram id
 kaggle_id: # your kaggle id
 keybase_username: # your keybase user name
@@ -96,7 +97,6 @@ publons_id: # your ID on Publons
 quora_username: # your Quora username
 research_gate_profile: # your profile on ResearchGate
 scholar_userid: qc6CJjYAAAAJ # your Google Scholar ID
-inspirehep_id: 1010907 # Inspire HEP author ID
 scopus_id: # your profile on Scopus
 semanticscholar_id: # your Semantic Scholar ID
 spotify_id: # your spotify id

--- a/_config.yml
+++ b/_config.yml
@@ -343,6 +343,7 @@ enable_publication_badges:
   altmetric: true # Altmetric badge (Customization options: https://badge-docs.altmetric.com/index.html)
   dimensions: true # Dimensions badge (Customization options: https://badge.dimensions.ai/)
   google_scholar: true # Google Scholar badge (https://scholar.google.com/intl/en/scholar/citations.html)
+  inspirehep: true # Inspire HEP badge (https://help.inspirehep.net/knowledge-base/citation-metrics/)
 
 # Filter out certain bibtex entry keywords used internally from the bib output
 filtered_bibtex_keywords:

--- a/_includes/social.liquid
+++ b/_includes/social.liquid
@@ -13,6 +13,9 @@
 {% if site.scholar_userid %}
   <a href="https://scholar.google.com/citations?user={{ site.scholar_userid }}" title="Google Scholar"><i class="ai ai-google-scholar"></i></a>
 {% endif %}
+{% if site.inspirehep_id %}
+  <a href="https://inspirehep.net/authors/{{ site.inspirehep_id }}" title="Inspire HEP"><i class="ai ai-inspire"></i></a>
+{% endif %}
 {% if site.semanticscholar_id %}
   <a href="https://www.semanticscholar.org/author/{{ site.semanticscholar_id }}" title="Semantic Scholar"><i class="ai ai-semantic-scholar"></i></a>
 {% endif %}

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -263,7 +263,12 @@
       {% if entry.google_scholar_id %}
         {% assign entry_has_google_scholar_badge = true %}
       {% endif %}
-      {% if entry_has_altmetric_badge or entry_has_dimensions_badge or entry_has_google_scholar_badge %}
+
+      {% assign entry_has_inspirehep_badge = false %}
+      {% if entry.inspirehep_id %}
+        {% assign entry_has_inspirehep_badge = true %}
+      {% endif %}
+      {% if entry_has_altmetric_badge or entry_has_dimensions_badge or entry_has_google_scholar_badge or entry_has_inspirehep_badge %}
         <div class="badges">
           {% if site.enable_publication_badges.altmetric and entry_has_altmetric_badge %}
             <span
@@ -309,6 +314,18 @@
               <img
                 src="https://img.shields.io/badge/scholar-{% google_scholar_citations site.scholar_userid entry.google_scholar_id %}-4285F4?logo=googlescholar&labelColor=beige"
                 alt="{% google_scholar_citations site.scholar_userid entry.google_scholar_id %} Google Scholar citations"
+              >
+            </a>
+          {% endif %}
+          {% if site.enable_publication_badges.inspirehep and entry_has_inspirehep_badge %}
+            <a
+              href="https://inspirehep.net/literature/{{ entry.inspirehep_id }}"
+              aria-label="Inspirehep link"
+              role="button"
+            >
+              <img
+                src="https://img.shields.io/badge/inspire-{% inspirehep_citations entry.inspirehep_id %}-001628?logo=inspire&logoColor=001628&labelColor=beige"
+                alt="{% inspirehep_citations entry.inspirehep_id %} InspireHEP citations"
               >
             </a>
           {% endif %}

--- a/_plugins/inspirehep-citations.rb
+++ b/_plugins/inspirehep-citations.rb
@@ -1,0 +1,57 @@
+require "active_support/all"
+require 'net/http'
+require 'json'
+require 'uri'
+
+module Helpers
+  extend ActiveSupport::NumberHelper
+end
+
+module Jekyll
+  class InspireHEPCitationsTag < Liquid::Tag
+    Citations = { }
+
+    def initialize(tag_name, params, tokens)
+      super
+      @recid = params.strip
+    end
+
+    def render(context)
+      recid = context[@recid.strip]
+      api_url = "https://inspirehep.net/api/literature/?fields=citation_count&q=recid:#{recid}"
+
+      begin
+        # If the citation count has already been fetched, return it
+        if InspireHEPCitationsTag::Citations[recid]
+          return InspireHEPCitationsTag::Citations[recid]
+        end
+
+        # Fetch the citation count from the API
+        uri = URI(api_url)
+        response = Net::HTTP.get(uri)
+        data = JSON.parse(response)
+
+        # # Log the response for debugging
+        # puts "API Response: #{data.inspect}"
+
+        # Extract citation count from the JSON data
+        citation_count = data["hits"]["hits"][0]["metadata"]["citation_count"].to_i
+
+        # Format the citation count for readability
+        citation_count = Helpers.number_to_human(citation_count, format: '%n%u', precision: 2, units: { thousand: 'K', million: 'M', billion: 'B' })
+
+      rescue Exception => e
+        # Handle any errors that may occur during fetching
+        citation_count = "N/A"
+
+        # Print the error message including the exception class and message
+        puts "Error fetching citation count for #{recid}: #{e.class} - #{e.message}"
+      end
+
+      InspireHEPCitationsTag::Citations[recid] = citation_count
+      return "#{citation_count}"
+    end
+  end
+end
+
+Liquid::Template.register_tag('inspirehep_citations', Jekyll::InspireHEPCitationsTag)


### PR DESCRIPTION
[INSPIRE](http://inspirehep.net/) is a trusted community hub that facilitates the sharing and discovery of accurate scholarly information in high energy physics. By integrating the social and citation count badge, al-folio users within this community will gain significant benefits.

In continuation of #2634, I am creating this pull request.

## Details

### Social Icon
- Add your INSPIRE author ID in the `config.yml` under `inspirehep_id`.

### Citation Count
- Enable this feature by setting `inspirehep` to `true` under `enable_publication_badges` in your `config.yml` file.
- In your bibliography file (e.g., `papers.bib`), add `inspirehep_id = {the literature's recid}` under the citation of a literature source.