### PR TITLE
Fix no github_users titling in repositories.md

### DIFF
--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -7,9 +7,9 @@ nav: true
 nav_order: 4
 ---
 
-## GitHub users
-
 {% if site.data.repositories.github_users %}
+
+## GitHub users
 
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for user in site.data.repositories.github_users %}

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -35,9 +35,9 @@ nav_order: 4
 {% endif %}
 {% endif %}
 
-## GitHub Repositories
-
 {% if site.data.repositories.github_repos %}
+
+## GitHub Repositories
 
 <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
   {% for repo in site.data.repositories.github_repos %}


### PR DESCRIPTION
Inverted order of title and {% if site.data.repositories.github_users %}, so that if there is no github_users, the "GitHub users" title does not appear.