### PR TITLE
Fix conditional rendering of tag and category section

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -29,7 +29,7 @@ pagination:
   </div>
   {% endif %}
 
-{% if site.display_tags or site.display_categories %}
+{% if site.display_tags.size > 0 or site.display_categories.size > 0 %}
 
   <div class="tag-category-list">
     <ul class="p-0 m-0">

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -29,7 +29,7 @@ pagination:
   </div>
   {% endif %}
 
-{% if site.display_tags.size > 0 or site.display_categories.size > 0 %}
+{% if site.display_tags and site.display_tags.size > 0 or site.display_categories and site.display_categories.size > 0 %}
 
   <div class="tag-category-list">
     <ul class="p-0 m-0">


### PR DESCRIPTION
### Overview
This PR fixes an issue where unnecessary horizontal lines were displayed when there were no tags or categories present. The tag and category container is now conditionally rendered, ensuring it only appears when there are tags or categories to display.

no tags meaning, in _config.yml
```
display_tags: []
display_categories: []
```

### Before and After
The difference is illustrated in the images below:
- **First Image (Fixed)**: Shows the correct behavior with no extra lines when tags or categories are absent.
- **Second Image (Current)**: Demonstrates the issue with unwanted horizontal lines appearing when no tags or categories are present.

![image](https://github.com/user-attachments/assets/08becad5-9a34-4b6c-8a69-25206d9097da)
![image](https://github.com/user-attachments/assets/e36390cc-3104-4aa2-a047-a7fa8289e664)

### Impact
This change improves the visual consistency and cleanliness of the theme by preventing unnecessary elements from being rendered, particularly in cases where there are no tags or categories defined.
