### PR TITLE
Fixed "All contributors not showing on README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Our most active contributors are welcome to join the maintainers team. If you ar
 ### All Contributors
 
 <a href="https://contrib.rocks">
-  <img src="https://contrib.rocks/image?repo=alshedivat/al-folio" />
+  <img src="https://contrib.rocks/image?repo=alshedivat/al-folio&max=500" />
 </a>
 
 ## Star History


### PR DESCRIPTION
# In README.md
## All Contributors Section

**Out of the 216 contributors, the page only shows around 100**
By adding an additional parameter ```max``` It now shows all of them.