### PR TITLE
Added new feature to allow user to display individual repositories in their Projects pages

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -66,6 +66,17 @@ If you want to create blog posts that are not ready to be published, but you wan
 
 You can create new projects by adding new Markdown files in the [\_projects](_projects/) directory. The easiest way to do this is to copy an existing project and modify it.
 
+You can also display your project's GitHub Repo Card, if it has any, on the project page.
+
+You simply need to add the following to your Markdown file's Frontmatter :
+```YAML
+repo:
+  owner_username: User #The username of the owner of the repository
+  repo_name: myRepo #The name of the repository
+  display_owner: false #Boolean for whether you want to show the username of the owner or not
+  max_lines_description: 3 #Integer telling the maximum number of lines the description of the repo should have in the card
+```
+
 ## Adding some news
 
 You can add news in the about page by adding new Markdown files in the [\_news](_news/) directory. There are currently two types of news: inline news and news with a link. News with a link take you to a new page while inline news are displayed directly in the about page. The easiest way to create yours is to copy an existing news and modify it.

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -64,7 +64,7 @@ If you want to create blog posts that are not ready to be published, but you wan
 
 ## Creating new projects
 
-YYou can create new projects by adding new Markdown files in the [\_projects](_projects/) directory. The easiest way to do this is to copy an existing project and modify it.
+You can create new projects by adding new Markdown files in the [\_projects](_projects/) directory. The easiest way to do this is to copy an existing project and modify it.
 
 You can also display your project's GitHub Repo Card, if it has any, on the project page.
 

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -71,11 +71,20 @@ You can also display your project's GitHub Repo Card, if it has any, on the proj
 You simply need to add the following to your Markdown file's Frontmatter :
 
 ```YAML
-repo:
-  owner_username: User #The username of the owner of the repository
-  repo_name: myRepo #The name of the repository
-  display_owner: false #Boolean for whether you want to show the username of the owner or not
-  max_lines_description: 3 #Integer telling the maximum number of lines the description of the repo should have in the card
+repositories:
+  - Owner1UserName/Repo1
+  - Owner2UserName/Repo2
+```
+
+This way you can add as many repos as needed to the header of the page.
+
+If you want to include a repo in a location other than you header, then you need to add the following code to that location :
+
+```LIQUID
+<div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+    {% include repository/repo.liquid repository=Username1/Repo1 %}
+    {% include repository/repo.liquid repository=Username2/Repo2 %}
+</div>
 ```
 
 ## Adding some news

--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -64,11 +64,12 @@ If you want to create blog posts that are not ready to be published, but you wan
 
 ## Creating new projects
 
-You can create new projects by adding new Markdown files in the [\_projects](_projects/) directory. The easiest way to do this is to copy an existing project and modify it.
+YYou can create new projects by adding new Markdown files in the [\_projects](_projects/) directory. The easiest way to do this is to copy an existing project and modify it.
 
 You can also display your project's GitHub Repo Card, if it has any, on the project page.
 
 You simply need to add the following to your Markdown file's Frontmatter :
+
 ```YAML
 repo:
   owner_username: User #The username of the owner of the repository

--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -5,6 +5,28 @@ layout: default
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
     <p class="post-description">{{ page.description }}</p>
+    {% if page.repo %}
+      <div class="repo p-2 text-center"></div>
+      <a href="https://github.com/{{ page.repo.owner_username }}/{{ page.repo.repo_name }}">
+        <img
+          class="repo-img-light"
+          alt="{{ page.repo.owner_username }}/{{ page.repo.repo_name }}"
+          style="height: 150px;"
+          src="https://github-readme-stats.vercel.app/api/pin/?username={{ page.repo.owner_username }}&repo={{ page.repo.repo_name }}&theme={{ site.repo_theme_light }}&show_owner={{ page.repo.display_owner }}&description_lines_count={{ page.repo.max_lines_description }}&height="
+        >
+        <img
+          class="repo-img-dark"
+          alt="{{ page.repo.owner_username }}/{{ page.repo.repo_name }}"
+          style="height: 150px;"
+          src="https://github-readme-stats.vercel.app/api/pin/?username={{ page.repo.owner_username }}&repo={{ page.repo.repo_name }}&theme={{ site.repo_theme_dark }}&show_owner={{ page.repo.display_owner }}&description_lines_count={{ page.repo.max_lines_description }}"
+        >
+      </a>
+      </div>
+      <br>
+      <br>
+      <br>
+      <br>
+    {% endif %}
   </header>
 
   <article>

--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -5,27 +5,12 @@ layout: default
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
     <p class="post-description">{{ page.description }}</p>
-    {% if page.repo %}
-      <div class="repo p-2 text-center"></div>
-      <a href="https://github.com/{{ page.repo.owner_username }}/{{ page.repo.repo_name }}">
-        <img
-          class="repo-img-light"
-          alt="{{ page.repo.owner_username }}/{{ page.repo.repo_name }}"
-          style="height: 150px;"
-          src="https://github-readme-stats.vercel.app/api/pin/?username={{ page.repo.owner_username }}&repo={{ page.repo.repo_name }}&theme={{ site.repo_theme_light }}&show_owner={{ page.repo.display_owner }}&description_lines_count={{ page.repo.max_lines_description }}&height="
-        >
-        <img
-          class="repo-img-dark"
-          alt="{{ page.repo.owner_username }}/{{ page.repo.repo_name }}"
-          style="height: 150px;"
-          src="https://github-readme-stats.vercel.app/api/pin/?username={{ page.repo.owner_username }}&repo={{ page.repo.repo_name }}&theme={{ site.repo_theme_dark }}&show_owner={{ page.repo.display_owner }}&description_lines_count={{ page.repo.max_lines_description }}"
-        >
-      </a>
+    {% if page.repositories %}
+      <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+        {% for repo in page.repositories %}
+          {% include repository/repo.liquid repository=repo %}
+        {% endfor %}
       </div>
-      <br>
-      <br>
-      <br>
-      <br>
     {% endif %}
   </header>
 


### PR DESCRIPTION
# New Feature
## The user can now display individual GitHub repositories in their Project Page

The theme changes according to the site theme

Light Mode
![Light Mode](https://github.com/user-attachments/assets/8d3fa706-cb60-41b5-b730-33ecd745d990)

Dark Mode
![Dark Mode](https://github.com/user-attachments/assets/bc736cea-24f8-4d3b-a9e2-0fb17a1925c5)
