### PR TITLE
Created a new layout for GitHub projects

### DIFF
--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -1,4 +1,6 @@
-{% assign img_path = include.path | remove: '.jpg' | remove: '.jpeg' | remove: '.png' | remove: '.tiff' | remove: '.gif' %}
+{% assign parts = include.path | split: '.' %}
+{% assign img_path = parts.first %}
+{% assign ext = parts.last %}
 
 <figure
   {% if include.slot %}
@@ -14,13 +16,17 @@
     {% if site.imagemagick.enabled %}
       <source
         class="responsive-img-srcset"
-        srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
+        {% if ext == '.jpg' or ext == '.jpeg' or ext == '.png' or ext == '.tiff' or ext == '.gif' %}
+          srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
+          type="image/webp"
+        {% else %}
+          srcset="{{ include.path | relative_url }}"
+        {% endif %}
         {% if include.sizes %}
           sizes="{{include.sizes}}"
         {% else %}
           sizes="95vw"
         {% endif %}
-        type="image/webp"
       >
     {% endif %}
     <img

--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -1,5 +1,5 @@
+{% assign img_path = include.path | remove: '.jpg' | remove: '.jpeg' | remove: '.png' | remove: '.tiff' | remove: '.gif' %}
 {% assign parts = include.path | split: '.' %}
-{% assign img_path = parts.first %}
 {% assign ext = parts.last %}
 
 <figure

--- a/_includes/icon.liquid
+++ b/_includes/icon.liquid
@@ -19,7 +19,7 @@
   {% if include.height %}
     height="{{ include.height }}"
   {% else %}
-    height="40"
+    height="2.5rem"
   {% endif %}
 >
 {% if include.spaceAfter %}

--- a/_includes/icon.liquid
+++ b/_includes/icon.liquid
@@ -1,0 +1,7 @@
+{% assign addIcon = include.icon %}
+{% if addIcon contains 'http' %}
+  <img src="{{ addIcon }}" height="40">
+{% else %}
+  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{ addIcon }}" height="40">
+{% endif %}
+<img width="12">

--- a/_includes/icon.liquid
+++ b/_includes/icon.liquid
@@ -1,7 +1,27 @@
 {% assign addIcon = include.icon %}
-{% if addIcon contains 'http' %}
-  <img src="{{ addIcon }}" height="40">
-{% else %}
-  <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{ addIcon }}" height="40">
+<img
+  {% if addIcon contains 'http' %}
+    src="{{ addIcon }}"
+  {% else %}
+    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{ addIcon }}"
+  {% endif %}
+  {% if include.alt %}
+    alt="{{ include.alt }}"
+  {% endif %}
+  {% if include.title %}
+    title="{{ include.title }}"
+  {% endif %}
+  {% if include.width %}
+    width="{{ include.width }}"
+  {% else %}
+    width="auto"
+  {% endif %}
+  {% if include.height %}
+    height="{{ include.height }}"
+  {% else %}
+    height="40"
+  {% endif %}
+>
+{% if include.spaceAfter %}
+  <img width="{{ include.width }}">
 {% endif %}
-<img width="12">

--- a/_layouts/github-project.liquid
+++ b/_layouts/github-project.liquid
@@ -11,10 +11,10 @@ layout: default
 <div class="post">
   <header class="post-header">
     <div>
-      <h1 class="post-title">
+      <h1 class="post-title d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
         {{ page.title }}
         {% if page.icons %}
-          <div style="display: inline-block; float : right;">
+          <div>
             {% for iconLink in page.icons %}
               {% include icon.liquid icon=iconLink %}
             {% endfor %}

--- a/_layouts/github-project.liquid
+++ b/_layouts/github-project.liquid
@@ -1,0 +1,49 @@
+---
+layout: default
+---
+{% if page._styles %}
+  <!-- Page/Post style -->
+  <style type="text/css">
+    {{ page._styles }}
+  </style>
+{% endif %}
+
+<div class="post">
+  <header class="post-header">
+    <div>
+      <h1 class="post-title">
+        {{ page.title }}
+        {% if page.icons %}
+          <div style="display: inline-block; float : right;">
+            {% for iconLink in page.icons %}
+              {% include icon.liquid icon=iconLink %}
+            {% endfor %}
+          </div>
+        {% endif %}
+      </h1>
+    </div>
+    <p class="post-description">{{ page.description }}</p>
+    {% if page.repositories %}
+      <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
+        {% for repo in page.repositories %}
+          {% include repository/repo.liquid repository=repo %}
+        {% endfor %}
+      </div>
+    {% endif %}
+  </header>
+
+  <article>
+    {{ content }}
+  </article>
+
+  {% if page.related_publications %}
+    <h2>References</h2>
+    <div class="publications">
+      {% bibliography --cited_in_order %}
+    </div>
+  {% endif %}
+
+  {% if site.giscus and page.giscus_comments %}
+    {% include giscus.liquid %}
+  {% endif %}
+</div>

--- a/_layouts/github-project.liquid
+++ b/_layouts/github-project.liquid
@@ -10,26 +10,30 @@ layout: default
 
 <div class="post">
   <header class="post-header">
-    <div>
-      <h1 class="post-title d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
-        {{ page.title }}
-        {% if page.icons %}
-          <div>
-            {% for iconLink in page.icons %}
-              {% include icon.liquid icon=iconLink %}
-            {% endfor %}
-          </div>
-        {% endif %}
-      </h1>
+    <div style="display: flex; align-items: flex-start;">
+      <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+        {% include figure.liquid path=page.img max-width="200px" max-height="200px" class="img-fluid rounded z-depth-1" %}
+      </div>
+
+      <div style="padding-left: 20px;">
+        <h1>{{ page.title }}</h1>
+        <p>{{ page.description }}</p>
+        <div style="display: flex; gap: 10px; margin-bottom: 10px;">
+          {% for icon in page.icons %}
+            {% include icon.liquid site=icon.site file=icon.file %}
+          {% endfor %}
+        </div>
+      </div>
     </div>
-    <p class="post-description">{{ page.description }}</p>
     {% if page.repositories %}
+      <hr>
       <div class="repositories d-flex flex-wrap flex-md-row flex-column justify-content-between align-items-center">
         {% for repo in page.repositories %}
           {% include repository/repo.liquid repository=repo %}
         {% endfor %}
       </div>
     {% endif %}
+    <hr>
   </header>
 
   <article>


### PR DESCRIPTION
# Preview
![Screenshot 2024-09-16 205708](https://github.com/user-attachments/assets/ac081ca3-3535-4655-8645-9b044b2fac72)
![Screenshot 2024-09-16 205724](https://github.com/user-attachments/assets/e947562a-8d0a-48d8-bef4-bfcbaa337638)
![Screenshot 2024-09-16 205832](https://github.com/user-attachments/assets/5df8bda4-4b55-4d6e-b205-928796022f9a)
![Screenshot 2024-09-16 205819](https://github.com/user-attachments/assets/0270ce0e-b89e-414a-a3f9-29bc5e9084fa)

## Additions
1. Add repositories, type you repo name in the front matter as the following
```YAML
repositories:
  - KingHowler/Arduino-Language-Support
  - KingHowler/Oscilloscope-Online
  - alshedivat/al-folio
```
2. Add icons to your title, to show which languages and tools were used
```YAML
icons:
  - https://skillicons.dev/icons?i=processing
  - javascript/javascript-original.svg # Note: You don't have to specify the full link to devicons, only the foldername and filename
  - html5/html5-original.svg
```