### PR TITLE
Add Image Version to Docker-Compose to pull the relevant image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # this file uses prebuilt image in dockerhub
 services:
   jekyll:
-    image: amirpourmand/al-folio:latest
+    image: amirpourmand/al-folio:v0.12.0
     build: .
     ports:
       - 8080:8080


### PR DESCRIPTION
This is to address 
- #2733 

Since a lot of times, the only problem is that docker image is not consistent with the build. We have to somehow incorporate image version into repository. 

I don't insist to provide it this way. Maybe there are other automatic ways which are better. 

We can also calculate the relevant tag from git. 