### PR TITLE
Fix .webp SrcSet Creation Filter

### DIFF
--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -16,7 +16,7 @@
     {% if site.imagemagick.enabled %}
       <source
         class="responsive-img-srcset"
-        {% if ext == '.jpg' or ext == '.jpeg' or ext == '.png' or ext == '.tiff' or ext == '.gif' %}
+        {% if ext == 'jpg' or ext == 'jpeg' or ext == 'png' or ext == 'tiff' or ext == 'gif' %}
           srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
           type="image/webp"
         {% else %}

--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -16,7 +16,7 @@
     {% if site.imagemagick.enabled %}
       <source
         class="responsive-img-srcset"
-        {% if ext == 'jpg' or ext == 'jpeg' or ext == 'png' or ext == 'tiff' or ext == 'gif' %}
+        {% if ext == 'gif' or ext == 'jpeg' or ext == 'jpg' or ext == 'png' or ext == 'tiff' %}​⬤
           srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
           type="image/webp"
         {% else %}

--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -16,7 +16,7 @@
     {% if site.imagemagick.enabled %}
       <source
         class="responsive-img-srcset"
-        {% if ext == 'gif' or ext == 'jpeg' or ext == 'jpg' or ext == 'png' or ext == 'tiff' %}​⬤
+        {% if ext == 'gif' or ext == 'jpeg' or ext == 'jpg' or ext == 'png' or ext == 'tiff' %}​
           srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
           type="image/webp"
         {% else %}

--- a/_includes/figure.liquid
+++ b/_includes/figure.liquid
@@ -16,7 +16,8 @@
     {% if site.imagemagick.enabled %}
       <source
         class="responsive-img-srcset"
-        {% if ext == 'gif' or ext == 'jpeg' or ext == 'jpg' or ext == 'png' or ext == 'tiff' %}​
+        {% if ext == 'gif' or ext == 'jpeg' or ext == 'jpg' or ext == 'png' or ext == 'tiff' %}
+          ​
           srcset="{% for i in site.imagemagick.widths %}{{ img_path | relative_url }}-{{ i }}.webp {{i}}w,{% endfor %}"
           type="image/webp"
         {% else %}


### PR DESCRIPTION
### Pull Request: Fix .webp SrcSet Creation Filter

#### Description

This PR addresses an issue with the filter for creating `.webp` srcsets introduced in PR #2698. The original filter incorrectly searched for extensions with a leading period (e.g., ".jpg" and ".png"). As a result, no matches were found, preventing the srcset from being added to any figures. This occurred because the split operation removes the period from the file extensions.

#### Changes Made

- Updated the filter to search for file extensions without the leading period (e.g., "jpg" and "png").
- Ensured that the resource sets are now correctly created for the respective file extensions, allowing the `.webp` srcset to function as intended.

#### Impact

With this change, responsive images will now correctly generate their srcsets for the appropriate file types, improving image loading performance and supporting better responsiveness.

#### Fixes

- Fixes #2777

Please review the changes and let me know if there are any further adjustments needed. Thank you!