### PR TITLE
apple-touch-icon support-issue-#2774

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ og_image: # The site-wide (default for all links) Open Graph preview image
 # -----------------------------------------------------------------------------
 
 acm_id: # your dl.acm.org/profile/id
+apple-touch-icon: "assets/img/prof_pic_color.png" #your apple-touch-icon
 blogger_url: # your blogger URL
 bluesky_url: # your bluesky URL
 dblp_url: # your DBLP profile url


### PR DESCRIPTION
Add apple-touch-icon to create iOS home screen shortcuts.

Issue https://github.com/alshedivat/al-folio/issues/2774