### PR TITLE
Upate docker-compose to be easier to use for permission bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,7 @@ services:
   jekyll:
     image: amirpourmand/al-folio:v0.12.1
     build: .
-    # uncomment these if you are having this issue with the build:
-    # /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)
-    # and fill the args values with the output of the commands on the right
-    # build:
-    #   args:
-    #     GROUPID: # id -g
-    #     GROUPNAME: # id -gn
-    #     USERID: # id -u
-    #     USERNAME: # echo $USER
+    user: root
     ports:
       - 8080:8080
       - 35729:35729


### PR DESCRIPTION
Hey @george-gca ,

I am thinking about what you've done in `docker-compose.yaml`. 

Does it solve the problem if we just do this change in docker-compose?

- https://stackoverflow.com/questions/48727548/how-to-configure-docker-compose-yml-to-up-a-container-as-root
