### PR TITLE
[FIX] Blog Page Navigation (#2841)

### DIFF
--- a/_includes/pagination.liquid
+++ b/_includes/pagination.liquid
@@ -3,7 +3,7 @@
     <ul class="pagination pagination-lg justify-content-center">
       <li class="page-item {% unless paginator.previous_page %}disabled{% endunless %}">
         <a class="page-link" href="{{ paginator.previous_page_path | relative_url }}" tabindex="-1" aria-disabled="{{ paginator.previous_page }}"
-          >Newer</a
+          >&lt;</a
         >
       </li>
       {% if paginator.page_trail %}
@@ -14,7 +14,7 @@
         {% endfor %}
       {% endif %}
       <li class="page-item {% unless paginator.next_page %}disabled{% endunless %}">
-        <a class="page-link" href="{{ paginator.next_page_path | relative_url }}">Older</a>
+        <a class="page-link" href="{{ paginator.next_page_path | relative_url }}">&gt;</a>
       </li>
     </ul>
   </nav>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -589,6 +589,7 @@ footer.sticky-bottom {
   .page-item {
     .page-link {
       color: var(--global-text-color);
+      padding: 0.75rem 1.15rem;
 
       &:hover {
         color: $black-color;


### PR DESCRIPTION
I tested on my Github page and it worked correctly. Then, copied here. 

Issue: Blog page navigation extends layout of the page in small screens.
Fixes: #2841