### PR TITLE
Fix to display references in order of citation

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -80,7 +80,7 @@ layout: default
   {% if page.related_publications %}
     <h2>References</h2>
     <div class="publications">
-      {% bibliography --cited_in_order %}
+      {% bibliography --group_by none --cited_in_order %}
     </div>
   {% endif %}
 


### PR DESCRIPTION
"cite_in_order" here contradicts the global group_by year setting in _config.yml