### PR TITLE
Bluesky URL prefix should not be appended

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ og_image: # The site-wide (default for all links) Open Graph preview image
 
 acm_id: # your dl.acm.org/profile/id
 blogger_url: # your blogger URL
-bluesky_url: # your bluesky id (like yourname.bsky.social)
+bluesky_id: # your bluesky id (like yourname.bsky.social)
 dblp_url: # your DBLP profile url
 discord_id: # your discord id (18-digit unique numerical identifier)
 facebook_id: # your facebook id

--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ og_image: # The site-wide (default for all links) Open Graph preview image
 
 acm_id: # your dl.acm.org/profile/id
 blogger_url: # your blogger URL
-bluesky_id: # your bluesky id (like yourname.bsky.social)
+bluesky_url: # your bluesky URL
 dblp_url: # your DBLP profile url
 discord_id: # your discord id (18-digit unique numerical identifier)
 facebook_id: # your facebook id

--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ og_image: # The site-wide (default for all links) Open Graph preview image
 
 acm_id: # your dl.acm.org/profile/id
 blogger_url: # your blogger URL
-bluesky_url: # your bluesky URL
+bluesky_url: # your bluesky id (like yourname.bsky.social)
 dblp_url: # your DBLP profile url
 discord_id: # your discord id (18-digit unique numerical identifier)
 facebook_id: # your facebook id

--- a/_includes/social.liquid
+++ b/_includes/social.liquid
@@ -109,8 +109,8 @@
 {% if site.facebook_id %}
   <a href="https://facebook.com/{{ site.facebook_id }}" title="Facebook"><i class="fa-brands fa-facebook"></i></a>
 {% endif %}
-{% if site.bluesky_url %}
-  <a href="https://bsky.app/profile/{{ site.bluesky_url }}" title="Bluesky"><i class="fa-brands fa-bluesky"></i></a>
+{% if site.bluesky_id %}
+  <a href="https://bsky.app/profile/{{ site.bluesky_id }}" title="Bluesky"><i class="fa-brands fa-bluesky"></i></a>
 {% endif %}
 {% if site.youtube_id %}
   <a href="https://youtube.com/@{{ site.youtube_id }}" title="YouTube"><i class="fa-brands fa-youtube"></i></a>

--- a/_includes/social.liquid
+++ b/_includes/social.liquid
@@ -109,8 +109,8 @@
 {% if site.facebook_id %}
   <a href="https://facebook.com/{{ site.facebook_id }}" title="Facebook"><i class="fa-brands fa-facebook"></i></a>
 {% endif %}
-{% if site.bluesky_id %}
-  <a href="https://bsky.app/profile/{{ site.bluesky_id }}" title="Bluesky"><i class="fa-brands fa-bluesky"></i></a>
+{% if site.bluesky_url %}
+  <a href="{{ site.bluesky_url }}" title="Bluesky"><i class="fa-brands fa-bluesky"></i></a>
 {% endif %}
 {% if site.youtube_id %}
   <a href="https://youtube.com/@{{ site.youtube_id }}" title="YouTube"><i class="fa-brands fa-youtube"></i></a>


### PR DESCRIPTION
This PR modifies

- `_config.yml` to rename `bluesky_url` into `bluesky_id`
- `_includes/social.liquid` to handle the renaming in the display of social media icons