### PR TITLE
Add .lycheeignore file with linkedin to stop error on workflow Linkcheck

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Link Checker 🔗
-        uses: lycheeverse/lychee-action@v1.9.0
+        uses: lycheeverse/lychee-action@v2.1.0
         with:
           fail: true
           # removed md files that include liquid tags

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+linkedin.com

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
 linkedin.com
+reddit.com


### PR DESCRIPTION
Add a .lycheeignore file with LinkedIn to stop the error in the workflow Link Checker due to response 999, and update to the new version lycheeverse/lychee-action@v2.1.0.