### PR TITLE
Fix apostrophe in news title for search

### DIFF
--- a/_includes/scripts/search.liquid
+++ b/_includes/scripts/search.liquid
@@ -106,7 +106,7 @@
                 {%- assign title = item.title | newline_to_br | replace: "<br />", " " | replace: "<br/>", " " | strip_html | strip_newlines | escape | strip -%}
               {%- endif -%}
               id: "{{ collection.label }}-{{ title | slugify }}",
-              title: '{{ title | emojify | truncatewords: 13 }}',
+              title: '{{ title | escape | emojify | truncatewords: 13 }}',
               description: "{{ item.description | strip_html | strip_newlines | escape | strip }}",
               section: "{{ collection.label | capitalize }}",
               {%- unless item.inline -%}


### PR DESCRIPTION
Fix #2876 