### PR TITLE
explicitly install imagemagick to support ubuntu-latest (>=24.04) in Github actions

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -43,6 +43,7 @@ jobs:
             }
       - name: Install and Build 🔧
         run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick
           pip3 install --upgrade jupyter
           export JEKYLL_ENV=production
           bundle exec jekyll build

--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -31,6 +31,7 @@ jobs:
             }
       - name: Install and Build 🔧
         run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick
           pip3 install --upgrade jupyter
           export JEKYLL_ENV=production
           bundle exec jekyll build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
           value: ${{ github.repository }}
       - name: Install and Build 🔧
         run: |
+          sudo apt-get update && sudo apt-get install -y imagemagick
           pip3 install --upgrade nbconvert
           export JEKYLL_ENV=production
           bundle exec jekyll build


### PR DESCRIPTION
Install `imagemagick` within `Install and Build 🔧` step of Github actions

Relevant issue: 
[#2902](https://github.com/alshedivat/al-folio/issues/2902) `convert` Command Not Found on Ubuntu 24.04

Reason: 
`ubuntu-latest` in Github actions is pointed to `ubuntu-24.04` now, in which `imagemagick` is no longer pre-installed. See [this](https://github.com/actions/runner-images/issues/10772).

Modified files (actions) recommended by @george-gca 
```
- .github/workflows/deploy.yml
- .github/workflows/broken-links-site.yml
- .github/workflows/axe.yml
```