### PR TITLE
Revert padding from #2617 for CV tables

### DIFF
--- a/_sass/_cv.scss
+++ b/_sass/_cv.scss
@@ -8,6 +8,11 @@ div.container-link-button {
 
 table.table-cv {
   background-color: transparent !important;
+
+  td,
+  th {
+    padding: 1px;
+  }
 }
 
 a.btncv {


### PR DESCRIPTION
PR #2617 added a noticeable amount of right padding to all table cells. This might be fine for tables in content (e.g. posts), but creates odd spaces in the CV page, which is largely made up of tables.