### PR TITLE
Fix Line Ending Issues for Shell Scripts in Docker for Windows 10

### DIFF
--- a/.gitattibutes
+++ b/.gitattibutes
@@ -1,0 +1,2 @@
+# Force LF line endings, needed for Docker to work on Windows
+*.sh text eol=lf


### PR DESCRIPTION
Shell scripts like entry_point.sh caused errors in Docker due to CRLF line endings on Windows (`exec /tmp/entry_point.sh: no such file or directory`).

Added `.gitattributes` to enforce LF line endings for *.sh files.

This resolves the issue and ensures consistent behavior across platforms.