### PR TITLE
Fix resume custom reference link bug

### DIFF
--- a/_layouts/cv.liquid
+++ b/_layouts/cv.liquid
@@ -8,11 +8,16 @@ layout: default
         {{ page.title }}
         {% if page.cv_pdf %}
           <a
-            href="{{ page.cv_pdf | prepend: 'assets/pdf/' | relative_url}}"
+            {% if page.cv_pdf contains '://' %}
+              href="{{ page.cv_pdf }}"
+            {% else %}
+              href="{{ page.cv_pdf | prepend: 'assets/pdf/' | relative_url }}"
+            {% endif %}
             target="_blank"
             rel="noopener noreferrer"
             class="float-right"
-            ><i class="fa-solid fa-file-pdf"></i
+          >
+            <i class="fa-solid fa-file-pdf"></i
           ></a>
         {% endif %}
       </h1>

--- a/_layouts/cv.liquid
+++ b/_layouts/cv.liquid
@@ -17,8 +17,8 @@ layout: default
             rel="noopener noreferrer"
             class="float-right"
           >
-            <i class="fa-solid fa-file-pdf"></i
-          ></a>
+            <i class="fa-solid fa-file-pdf"></i>
+          </a>
         {% endif %}
       </h1>
       {% if page.description %}


### PR DESCRIPTION
Hi,

I noticed an issue where the CV page fails to link to the correct custom PDF when the `{% unless site.data.resume %}` block is executed in `cv.liquid`. To resolve this, I updated the code to align its logic with the else block to make it consistent.