### PR TITLE
Typo in jekyll-scholar plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -218,7 +218,7 @@ plugins:
   - jekyll-minifier
   - jekyll-paginate-v2
   - jekyll-regex-replace
-  - jekyll/scholar
+  - jekyll-scholar
   - jekyll-sitemap
   - jekyll-tabs
   - jekyll-terser


### PR DESCRIPTION
I suspect this is a typo and the plugin should be jekyll-scholar and not jekyll/scholar?