### PR TITLE
fix language-not-found issues on repo page with simplified and traditional Chinese

### DIFF
--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -18,11 +18,11 @@
         {% assign lang = 'cn' %}
       {% when 'tw', 'hk', 'mo', 'hant' %}
         {% assign lang = 'zh-tw' %}
-
     {% endcase %}
-{% endcase %}
 
 {% comment %} Add a new language using when... if needed {% endcomment %}
+{% endcase %}
+
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 {% if site.data.repositories.repo_description_lines_max %}

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -5,6 +5,20 @@
   {% assign show_owner = true %}
 {% endif %}
 
+{% assign lang = site.active_lang | split: '-' | first %}
+{% if lang == 'pt' %}
+  {% assign lang = site.active_lang %}
+{% endif %}
+{% if lang == 'zh' %}
+  {% assign lang_last = site.active_lang | split: '-' | last %}
+  {% if lang_last == 'cn' or lang_last == 'sg' or lang_last == 'my' or lang_last == 'hans' %}
+    {% assign lang = 'cn' %}
+  {% elsif lang_last == 'tw' or lang_last == 'hk' or lang_last == 'mo' or lang_last == 'hant' %}
+    {% assign lang = 'zh-tw' %}
+  {% endif %}
+{% endif %}
+{% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
+
 {% if site.data.repositories.repo_description_lines_max %}
   {% assign max_lines = site.data.repositories.repo_description_lines_max %}
 {% else %}

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -5,24 +5,24 @@
   {% assign show_owner = true %}
 {% endif %}
 
-{% assign lang = site.active_lang | split: '-' | first %}
+{% assign lang = site.lang | split: '-' | first %}
 
 {% case lang %}
   {% when 'pt' %}
     {% assign lang = site.active_lang %}
 
   {% when 'zh' %}
-    {% assign lang_last = site.active_lang | split: '-' | last %}
+    {% assign lang_last = site.lang | split: '-' | last %}
     {% case lang_last %}
       {% when 'cn', 'sg', 'my', 'hans' %}
         {% assign lang = 'cn' %}
       {% when 'tw', 'hk', 'mo', 'hant' %}
         {% assign lang = 'zh-tw' %}
-
-        {% comment %} when... add a new language here if needed {% endcomment %}
+        
     {% endcase %}
 {% endcase %}
 
+{% comment %} Add a new language using when... if needed {% endcomment %}
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 {% if site.data.repositories.repo_description_lines_max %}
@@ -36,12 +36,12 @@
     <img
       class="only-light w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
     <img
       class="only-dark w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
   </a>
 </div>

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -9,7 +9,7 @@
 
 {% case lang %}
   {% when 'pt' %}
-    {% assign lang = site.active_lang %}
+    {% assign lang = site.lang %}
 
   {% when 'zh' %}
     {% assign lang_last = site.lang | split: '-' | last %}
@@ -18,7 +18,7 @@
         {% assign lang = 'cn' %}
       {% when 'tw', 'hk', 'mo', 'hant' %}
         {% assign lang = 'zh-tw' %}
-        
+
     {% endcase %}
 {% endcase %}
 

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -6,17 +6,23 @@
 {% endif %}
 
 {% assign lang = site.active_lang | split: '-' | first %}
-{% if lang == 'pt' %}
-  {% assign lang = site.active_lang %}
-{% endif %}
-{% if lang == 'zh' %}
-  {% assign lang_last = site.active_lang | split: '-' | last %}
-  {% if lang_last == 'cn' or lang_last == 'sg' or lang_last == 'my' or lang_last == 'hans' %}
-    {% assign lang = 'cn' %}
-  {% elsif lang_last == 'tw' or lang_last == 'hk' or lang_last == 'mo' or lang_last == 'hant' %}
-    {% assign lang = 'zh-tw' %}
-  {% endif %}
-{% endif %}
+
+{% case lang %}
+  {% when 'pt' %}
+    {% assign lang = site.active_lang %}
+
+  {% when 'zh' %}
+    {% assign lang_last = site.active_lang | split: '-' | last %}
+    {% case lang_last %}
+      {% when 'cn', 'sg', 'my', 'hans' %}
+        {% assign lang = 'cn' %}
+      {% when 'tw', 'hk', 'mo', 'hant' %}
+        {% assign lang = 'zh-tw' %}
+
+        {% comment %} when... add a new language here if needed {% endcomment %}
+    {% endcase %}
+{% endcase %}
+
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 {% if site.data.repositories.repo_description_lines_max %}

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -20,7 +20,7 @@
         {% assign lang = 'zh-tw' %}
     {% endcase %}
 
-{% comment %} Add a new language using when... if needed {% endcomment %}
+    {% comment %} Add a new language using when... if needed {% endcomment %}
 {% endcase %}
 
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -1,15 +1,21 @@
 {% assign lang = site.active_lang | split: '-' | first %}
-{% if lang == 'pt' %}
-  {% assign lang = site.active_lang %}
-{% endif %}
-{% if lang == 'zh' %}
-  {% assign lang_last = site.active_lang | split: '-' | last %}
-  {% if lang_last == 'cn' or lang_last == 'sg' or lang_last == 'my' or lang_last == 'hans' %}
-    {% assign lang = 'cn' %}
-  {% elsif lang_last == 'tw' or lang_last == 'hk' or lang_last == 'mo' or lang_last == 'hant' %}
-    {% assign lang = 'zh-tw' %}
-  {% endif %}
-{% endif %}
+
+{% case lang %}
+  {% when 'pt' %}
+    {% assign lang = site.active_lang %}
+
+  {% when 'zh' %}
+    {% assign lang_last = site.active_lang | split: '-' | last %}
+    {% case lang_last %}
+      {% when 'cn', 'sg', 'my', 'hans' %}
+        {% assign lang = 'cn' %}
+      {% when 'tw', 'hk', 'mo', 'hant' %}
+        {% assign lang = 'zh-tw' %}
+
+        {% comment %} when... add a new language here if needed {% endcomment %}
+    {% endcase %}
+{% endcase %}
+
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 <div class="repo p-2 text-center">

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -11,11 +11,11 @@
         {% assign lang = 'cn' %}
       {% when 'tw', 'hk', 'mo', 'hant' %}
         {% assign lang = 'zh-tw' %}
-
     {% endcase %}
-{% endcase %}
 
 {% comment %} Add a new language using when... if needed {% endcomment %}
+{% endcase %}
+
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 <div class="repo p-2 text-center">

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -13,7 +13,7 @@
         {% assign lang = 'zh-tw' %}
     {% endcase %}
 
-{% comment %} Add a new language using when... if needed {% endcomment %}
+    {% comment %} Add a new language using when... if needed {% endcomment %}
 {% endcase %}
 
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -1,21 +1,21 @@
-{% assign lang = site.active_lang | split: '-' | first %}
+{% assign lang = site.lang | split: '-' | first %}
 
 {% case lang %}
   {% when 'pt' %}
-    {% assign lang = site.active_lang %}
+    {% assign lang = site.lang %}
 
   {% when 'zh' %}
-    {% assign lang_last = site.active_lang | split: '-' | last %}
+    {% assign lang_last = site.lang | split: '-' | last %}
     {% case lang_last %}
       {% when 'cn', 'sg', 'my', 'hans' %}
         {% assign lang = 'cn' %}
       {% when 'tw', 'hk', 'mo', 'hant' %}
         {% assign lang = 'zh-tw' %}
 
-        {% comment %} when... add a new language here if needed {% endcomment %}
     {% endcase %}
 {% endcase %}
 
+{% comment %} Add a new language using when... if needed {% endcomment %}
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
 
 <div class="repo p-2 text-center">
@@ -23,12 +23,12 @@
     <img
       class="only-light w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&show_icons=true"
+      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_icons=true"
     >
     <img
       class="only-dark w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&show_icons=true"
+      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_icons=true"
     >
   </a>
 </div>

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -11,7 +11,7 @@
   {% endif %}
 {% endif %}
 {% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
- 
+
 <div class="repo p-2 text-center">
   <a href="https://github.com/{{ include.username }}">
     <img

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -1,3 +1,17 @@
+{% assign lang = site.active_lang | split: '-' | first %}
+{% if lang == 'pt' %}
+  {% assign lang = site.active_lang %}
+{% endif %}
+{% if lang == 'zh' %}
+  {% assign lang_last = site.active_lang | split: '-' | last %}
+  {% if lang_last == 'cn' or lang_last == 'sg' or lang_last == 'my' or lang_last == 'hans' %}
+    {% assign lang = 'cn' %}
+  {% elsif lang_last == 'tw' or lang_last == 'hk' or lang_last == 'mo' or lang_last == 'hant' %}
+    {% assign lang = 'zh-tw' %}
+  {% endif %}
+{% endif %}
+{% comment %} If you still encounter language-display issues, check the available locale codes in github-readme-stats (different from ISO-639 standard used in your website): https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales {% endcomment %}
+ 
 <div class="repo p-2 text-center">
   <a href="https://github.com/{{ include.username }}">
     <img


### PR DESCRIPTION
The author of github-readme-stats uses the non-standard code "cn" for simplified Chinese, see [here](https://github.com/anuraghazra/github-readme-stats?tab=readme-ov-file#available-locales). While for traditional Chinese the author only provides "zh-tw". The github-readme-stats functions on repo page will break if the user sets the site language to ALL variants of Chinese except for zh-tw. This hack is to make all sub-variants of simplified Chinese fall back to "cn" and all sub-variants of traditional Chinese fall back to "zh-tw".

This patch fixes the problem and has been tested locally & with GitHub pages.