### PR TITLE
Re-Enable exclusions of jekyll minifier

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -232,7 +232,7 @@ sass:
 
 jekyll-minifier:
   compress_javascript: false # set to false since we are using terser as the js minifier
-  # exclude: ["robots.txt", "assets/js/search/*.js"]
+  exclude: ["robots.txt", "assets/js/search/*.js"]
 
 # -----------------------------------------------------------------------------
 # Terser


### PR DESCRIPTION
Resolve #3037

This PR just re-enable the old exclusions of jekyll-minifier to ensure that the files aren't altered.