### PR TITLE
Implement sorting options for resume sections

### DIFF
--- a/_includes/resume/awards.liquid
+++ b/_includes/resume/awards.liquid
@@ -1,5 +1,13 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% for content in data[1] %}
+  {% case page.sort_entries.awards %}
+    {% when 'reverse' %}
+      {% assign awards = data[1] | sort: 'date' | reverse %}
+    {% when 'forward' %}
+      {% assign awards = data[1] | sort: 'date' %}
+    {% else %}
+      {% assign awards = data[1] %}
+  {% endcase %}
+  {% for content in awards %}
     <li class="list-group-item">
       <div class="row">
         <div class="col-xs-2 cl-sm-2 col-md-2 text-center date-column">

--- a/_includes/resume/certificates.liquid
+++ b/_includes/resume/certificates.liquid
@@ -1,5 +1,12 @@
 <div class="list-groups">
-  {% assign certificates = data[1] | sort: 'date' | reverse %}
+  {% case page.sort_entries.certificates %}
+    {% when 'reverse' %}
+      {% assign certificates = data[1] | sort: 'date' | reverse %}
+    {% when 'forward' %}
+      {% assign certificates = data[1] | sort: 'date' %}
+    {% else %}
+      {% assign certificates = data[1] %}
+  {% endcase %}
   {% for content in certificates %}
     <div class="list-group col-md-6">
       <table class="table-cv list-group-table">

--- a/_includes/resume/education.liquid
+++ b/_includes/resume/education.liquid
@@ -1,5 +1,12 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign education = data[1] | sort: 'startDate' | reverse %}
+  {% case page.sort_entries.education %}
+    {% when 'reverse' %}
+      {% assign education = data[1] | sort: 'startDate' | reverse %}
+    {% when 'forward' %}
+      {% assign education = data[1] | sort: 'startDate' %}
+    {% else %}
+      {% assign education = data[1] %}
+  {% endcase %}
   {% for content in education %}
     <li class="list-group-item">
       <div class="row">

--- a/_includes/resume/projects.liquid
+++ b/_includes/resume/projects.liquid
@@ -1,5 +1,13 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% for content in data[1] %}
+  {% case page.sort_entries.projects %}
+    {% when 'reverse' %}
+      {% assign projects = data[1] | sort: 'startDate' | reverse %}
+    {% when 'forward' %}
+      {% assign projects = data[1] | sort: 'startDate' %}
+    {% else %}
+      {% assign projects = data[1] %}
+  {% endcase %}
+  {% for content in projects %}
     <li class="list-group-item">
       <div class="row">
         <div class="col-xs-2 cl-sm-2 col-md-2 text-center date-column">

--- a/_includes/resume/publications.liquid
+++ b/_includes/resume/publications.liquid
@@ -1,5 +1,12 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign publications = data[1] | sort: 'releaseDate' | reverse %}
+  {% case page.sort_entries.publications %}
+    {% when 'reverse' %}
+      {% assign publications = data[1] | sort: 'releaseDate' | reverse %}
+    {% when 'forward' %}
+      {% assign publications = data[1] | sort: 'releaseDate' %}
+    {% else %}
+      {% assign publications = data[1] %}
+  {% endcase %}
   {% for content in publications %}
     <li class="list-group-item">
       <div class="row">

--- a/_includes/resume/volunteer.liquid
+++ b/_includes/resume/volunteer.liquid
@@ -1,5 +1,12 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign volunteer = data[1] | sort: 'startDate' | reverse %}
+  {% case page.sort_entries.volunteer %}
+    {% when 'reverse' %}
+      {% assign volunteer = data[1] | sort: 'startDate' | reverse %}
+    {% when 'forward' %}
+      {% assign volunteer = data[1] | sort: 'startDate' %}
+    {% else %}
+      {% assign volunteer = data[1] %}
+  {% endcase %}
   {% for content in volunteer %}
     <li class="list-group-item">
       <div class="row">

--- a/_includes/resume/work.liquid
+++ b/_includes/resume/work.liquid
@@ -1,5 +1,12 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign work = data[1] | sort: 'startDate' | reverse %}
+  {% case page.sort_entries.work %}
+    {% when 'reverse' %}
+      {% assign work = data[1] | sort: 'startDate' | reverse %}
+    {% when 'forward' %}
+      {% assign work = data[1] | sort: 'startDate' %}
+    {% else %}
+      {% assign work = data[1] %}
+  {% endcase %}
   {% for content in work %}
     <li class="list-group-item">
       <div class="row">

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -8,7 +8,7 @@ cv_pdf: example_pdf.pdf # you can also use external links here
 
 # [reverse|forward|none]: chronological sorting, none displays entries in the same order as in `resume.json`
 sort_entries:
-  awards: reverse 
+  awards: reverse
   certificates: reverse
   education: reverse
   projects: reverse

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -5,6 +5,17 @@ title: cv
 nav: true
 nav_order: 5
 cv_pdf: example_pdf.pdf # you can also use external links here
+
+# [reverse|forward|none]: chronological sorting, none displays entries in the same order as in `resume.json`
+sort_entries:
+  awards: reverse 
+  certificates: reverse
+  education: reverse
+  projects: reverse
+  publications: reverse
+  volunteer: reverse
+  work: reverse
+
 description: This is a description of the page. You can modify it in '_pages/cv.md'. You can also change or remove the top pdf download button.
 toc:
   sidebar: left

--- a/assets/json/resume.json
+++ b/assets/json/resume.json
@@ -70,42 +70,42 @@
   "certificates": [
     {
       "name": "Machine Learning",
-      "date": "2018-01-01",
+      "date": "2020-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-location-dot"
     },
     {
       "name": "Quantum Computing",
-      "date": "2018-01-01",
+      "date": "2011-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-tag"
     },
     {
       "name": "Quantum Information",
-      "date": "2018-01-01",
+      "date": "2015-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-envelope"
     },
     {
       "name": "Quantum Cryptography",
-      "date": "2018-01-01",
+      "date": "2015-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-hashtag"
     },
     {
       "name": "Quantum Communication",
-      "date": "2018-01-01",
+      "date": "2017-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-calendar"
     },
     {
       "name": "Quantum Teleportation",
-      "date": "2018-01-01",
+      "date": "2014-01-01",
       "issuer": "Stanford University",
       "url": "https://example.com",
       "icon": "fa-solid fa-clipboard-check"


### PR DESCRIPTION
Maintains the default sort order in relevant CV sections as reverse chronological but allows to modify it section-by-section (reverse, forward, or none). `resume.json` was edited in order to showcase the difference in options as an example for the Certificates section (they all had the same date previously).