### PR TITLE
Fix toc highlight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     ffi (1.17.1-arm-linux-gnu)
     ffi (1.17.1-arm-linux-musl)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x64-mingw-ucrt)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
@@ -86,6 +87,9 @@ GEM
       bigdecimal
       rake (>= 13)
     google-protobuf (4.30.0-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.0-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.30.0-x86_64-darwin)
@@ -202,6 +206,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.3-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.3-x86_64-linux-gnu)
@@ -235,6 +241,8 @@ GEM
       google-protobuf (~> 4.29)
     sass-embedded (1.85.1-arm64-darwin)
       google-protobuf (~> 4.29)
+    sass-embedded (1.85.1-x64-mingw-ucrt)
+      google-protobuf (~> 4.29)
     sass-embedded (1.85.1-x86_64-darwin)
       google-protobuf (~> 4.29)
     sass-embedded (1.85.1-x86_64-linux-gnu)
@@ -267,6 +275,7 @@ PLATFORMS
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu

--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -52,5 +52,6 @@
 
     <!-- JavaScripts -->
     {% include scripts.liquid %}
+    <script src="{{ '/assets/js/toc-fix.js' | relative_url }}"></script> 
   </body>
 </html>

--- a/assets/js/toc-fix.js
+++ b/assets/js/toc-fix.js
@@ -1,0 +1,52 @@
+$(document).ready(function () {
+  // Initialize ScrollSpy
+  $('body').scrollspy({
+      target: 'nav[data-toggle="toc"]',
+      offset: 90 
+  });
+
+  // Smooth Scroll and Force ScrollSpy Update on Click
+  $('nav[data-toggle="toc"]').on("click", ".nav-link", function (e) {
+      e.preventDefault();
+      var targetId = $(this).attr("href");
+      var target = $(targetId);
+
+      if (target.length) {
+          $("html, body").stop().animate(
+              {
+                  scrollTop: target.offset().top - 80
+              },
+              400,
+              function () {
+                  $('body').scrollspy('refresh');
+              }
+          );
+      }
+  });
+
+  // Fix ScrollSpy Not Updating on Scroll
+  $(window).on('scroll', function () {
+      let scrollPos = $(document).scrollTop();
+
+      // Iterate over each section and update active TOC item
+      $('nav[data-toggle="toc"] .nav-link').each(function () {
+          let currLink = $(this);
+          let refElement = $(currLink.attr("href"));
+
+          if (refElement.length) {
+              let refTop = refElement.offset().top - 100; 
+              let refBottom = refTop + refElement.outerHeight();
+
+              if (scrollPos >= refTop && scrollPos < refBottom) {
+                  $('nav[data-toggle="toc"] .nav-link').removeClass("active");
+                  currLink.addClass("active");
+              }
+          }
+      });
+  });
+
+  // Debugging: Log active section to console
+  $(window).on('activate.bs.scrollspy', function () {
+      console.log('Active Section:', $('.nav-link.active').text());
+  });
+});


### PR DESCRIPTION
### Fix TOC highlighting issue (al-folio#ISSUE_NUMBER)
This PR fixes the Table of Contents (TOC) issue where:
- Clicking a TOC link highlighted the wrong section (off by one).
- Scrolling manually did not correctly update the TOC highlight.

### Changes:
- Added `toc-fix.js` to ensure proper ScrollSpy behavior.
- Included `toc-fix.js` in `_layouts/default.liquid`.
- Adjusted smooth scrolling behavior.

### Testing:
-  Clicking TOC items now correctly highlights the active section.
-  Scrolling manually updates the TOC highlight correctly.
-  Works correctly across all screen sizes.