### PR TITLE
Re-add ability to exclude posts from search

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ navbar_fixed: true
 footer_fixed: true
 search_enabled: true
 socials_in_search: true
+posts_in_search: true
 bib_search: true
 
 # Dimensions

--- a/_scripts/search.liquid.js
+++ b/_scripts/search.liquid.js
@@ -52,30 +52,32 @@ ninja.data = [
       {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
-  {%- for post in site.posts -%}
-    {
-      {%- assign title = post.title | escape | strip -%}
-      id: "post-{{ title | slugify }}",
-      {% if post.redirect == blank %}
-        title: "{{ title | truncatewords: 13 }}",
-      {% elsif post.redirect contains '://' %}
-        title: '{{ title | truncatewords: 13 }} <svg width="1.2rem" height="1.2rem" top=".5rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>',
-      {% else %}
-        title: "{{ title | truncatewords: 13 }}",
-      {% endif %}
-      description: "{{ post.description | strip_html | strip_newlines | escape | strip }}",
-      section: "Posts",
-      handler: () => {
+  {%- if site.posts_in_search -%}
+    {%- for post in site.posts -%}
+      {
+        {%- assign title = post.title | escape | strip -%}
+        id: "post-{{ title | slugify }}",
         {% if post.redirect == blank %}
-          window.location.href = "{{ post.url | relative_url }}";
+          title: "{{ title | truncatewords: 13 }}",
         {% elsif post.redirect contains '://' %}
-          window.open("{{ post.redirect }}", "_blank");
+          title: '{{ title | truncatewords: 13 }} <svg width="1.2rem" height="1.2rem" top=".5rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path></svg>',
         {% else %}
-          window.location.href = "{{ post.redirect | relative_url }}";
+          title: "{{ title | truncatewords: 13 }}",
         {% endif %}
+        description: "{{ post.description | strip_html | strip_newlines | escape | strip }}",
+        section: "Posts",
+        handler: () => {
+          {% if post.redirect == blank %}
+            window.location.href = "{{ post.url | relative_url }}";
+          {% elsif post.redirect contains '://' %}
+            window.open("{{ post.redirect }}", "_blank");
+          {% else %}
+            window.location.href = "{{ post.redirect | relative_url }}";
+          {% endif %}
+        },
       },
-    },
-  {%- endfor -%}
+    {%- endfor -%}
+  {%- endif -%}
   {%- for collection in site.collections -%}
     {%- if collection.label != 'posts' -%}
       {%- for item in collection.docs -%}


### PR DESCRIPTION
Earlier there was a tag in the `_config.yml` file to exclude the posts from the search results. I could no longer find that option and hence modified the `search.liquid.js` file.
It basically checks if the `posts_in_search` tag is true or not.