### PR TITLE
Fix "comma and and" before last author in publication list

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -79,8 +79,8 @@
         {%- endif -%}
 
         {%- if forloop.length > 1 -%}
-          {% if forloop.first == false %},&nbsp;{% endif %}
-          {%- if forloop.last and author_array_limit == author_array_size %}and&nbsp;{% endif -%}
+          {% if forloop.first == false and forloop.last == false%},&nbsp;{% endif %}
+          {%- if forloop.last and author_array_limit == author_array_size %}&nbsp;and&nbsp;{% endif -%}
         {% endif %}
         {%- if author_is_self -%}
           <em>

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -74,15 +74,15 @@
             {% if coauthor.firstname contains author.first %}
               {%- assign coauthor_url = coauthor.url -%}
               {% break %}
-            {% endif %}
+            {%- endif -%}
           {% endfor %}
         {%- endif -%}
 
         {%- if forloop.length > 1 -%}
           {% if forloop.first == false -%}
-            {%- if forloop.length > 2 %},&nbsp;{% elsif forloop.length == 2 -%}&nbsp;{% endif %}
+            {%- if forloop.length > 2 %}, {% elsif forloop.length == 2 %} {% endif %}
           {%- endif %}
-          {%- if forloop.last and author_array_limit == author_array_size %}and&nbsp;{% endif -%}
+          {%- if forloop.last and author_array_limit == author_array_size %}and {% endif -%}
         {% endif %}
         {%- if author_is_self -%}
           <em>

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -79,8 +79,10 @@
         {%- endif -%}
 
         {%- if forloop.length > 1 -%}
-          {% if forloop.first == false and forloop.last == false%},&nbsp;{% endif %}
-          {%- if forloop.last and author_array_limit == author_array_size %}&nbsp;and&nbsp;{% endif -%}
+          {% if forloop.first == false -%}
+            {%- if forloop.length > 2 %},&nbsp;{% elsif forloop.length == 2 -%}&nbsp;{% endif %}
+          {%- endif %}
+          {%- if forloop.last and author_array_limit == author_array_size %}and&nbsp;{% endif -%}
         {% endif %}
         {%- if author_is_self -%}
           <em>


### PR DESCRIPTION
When formatting the list of authors of a paper, there is a comma and the word 'and' before the last author. With 3 or more authors this can be interpreted as Oxford comma, but with two authors it is just wrong.

I applied this patch locally to get rid of the last comma.

Before:
<img width="938" alt="before" src="https://github.com/user-attachments/assets/c1a93e07-3274-4a04-865c-0a65bf3a00f7" />

After:
<img width="952" alt="after" src="https://github.com/user-attachments/assets/ce546ea4-9512-4fc4-8da1-bf11c453f23a" />
