### PR TITLE
Load Javascripts in header, instead of body.

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -13,6 +13,9 @@
       <meta http-equiv="refresh" content="3; url={{ redirect }}">
     {% endif %}
     {% include head.liquid %}
+
+    <!-- JavaScripts -->
+    {% include scripts.liquid %}
   </head>
 
   <!-- Body -->
@@ -49,8 +52,5 @@
 
     <!-- Footer -->
     {% include footer.liquid %}
-
-    <!-- JavaScripts -->
-    {% include scripts.liquid %}
   </body>
 </html>


### PR DESCRIPTION
To avoid a flash of unstyled content issue, `shorcut-key.js` must be loaded in the header. We achieve this by loading all Javascript in `scripts.liquid` in the header.

This resolves issue #3129, which only appears on MacOS.

*Note:* This issue could also be resolved by loading only `<script src="{{ '/assets/js/shortcut-key.js' | relative_url | bust_file_cache }}"></script> ` in the header, instead of all of the javascript in `scripts.liquid`.