### PR TITLE
CVSectionRename

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     ffi (1.17.1-arm-linux-gnu)
     ffi (1.17.1-arm-linux-musl)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x64-mingw-ucrt)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     ffi (1.17.1-x86_64-linux-musl)
@@ -86,6 +87,9 @@ GEM
       bigdecimal
       rake (>= 13)
     google-protobuf (4.30.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.1-x64-mingw-ucrt)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.30.1-x86_64-darwin)
@@ -202,6 +206,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.5-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.5-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.18.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.5-x86_64-linux-gnu)
@@ -235,6 +241,8 @@ GEM
       google-protobuf (~> 4.30)
     sass-embedded (1.86.0-arm64-darwin)
       google-protobuf (~> 4.30)
+    sass-embedded (1.86.0-x64-mingw-ucrt)
+      google-protobuf (~> 4.30)
     sass-embedded (1.86.0-x86_64-darwin)
       google-protobuf (~> 4.30)
     sass-embedded (1.86.0-x86_64-linux-gnu)
@@ -267,6 +275,7 @@ PLATFORMS
   arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu

--- a/_config.yml
+++ b/_config.yml
@@ -622,24 +622,39 @@ third_party_libraries:
       js: "https://cdn.jsdelivr.net/npm/venobox@{{version}}/dist/venobox.min.js"
     version: "2.1.8"
 
-# -----------------------------------------------------------------------------
-# Get external JSON data
-# -----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------  
+# Load external JSON data 
+# -----------------------------------------------------------------------------  
 
 jekyll_get_json:
   - data: resume
     json: assets/json/resume.json # it can also be an url
 
-jsonresume:
-  - basics
-  - work
-  - education
-  - publications
-  - projects
-  - volunteer
-  - awards
-  - certificates
-  - skills
-  - languages
-  - interests
-  - references
+# Map section keys (must match resume.json) to display labels  
+# 'key' = section name in resume.json (unchanged)
+# 'label' = name shown on the site
+jsonresume:  
+  - key: basics  
+    label: "Profile"   # Renaming section basics to "Profile"
+  - key: work  
+    label: "Work Experience"  
+  - key: education  
+    label: "Education"  
+  - key: publications  
+    label: "Publications"  
+  - key: projects  
+    label: "Projects"  
+  - key: volunteer  
+    label: "Volunteer Experience"  
+  - key: awards  
+    label: "Honors & Awards"  
+  - key: certificates  
+    label: "Certifications"  
+  - key: skills  
+    label: "Skills"  
+  - key: languages  
+    label: "Languages"  
+  - key: interests  
+    label: "Specializations & Interests"  
+  - key: references  
+    label: "References"

--- a/_layouts/cv.liquid
+++ b/_layouts/cv.liquid
@@ -81,14 +81,21 @@ layout: default
       <div class="cv">
         {% for data in site.data.resume %}
           {% if site.jsonresume and site.jsonresume.size > 0 %}
-            {% unless site.jsonresume contains data[0] %}
+            {% assign section_entry = site.jsonresume | where: "key", data[0] | first %}
+            {% if section_entry == null %}
               {% continue %}
-            {% endunless %}
+            {% endif %}
           {% endif %}
-          {% if data[0] == 'meta' or data[1].size == 0 %} {% continue %} {% endif %}
-          <a class="anchor" id="{{ data[0] }}"></a>
+
+          {% if data[0] == 'meta' or data[1].size == 0 %}
+            {% continue %}
+          {% endif %}
+
+          <a class="anchor" id="{{ data[0] | slugify }}"></a>
           <div class="card mt-3 p-3">
-            <h3 class="card-title font-weight-medium">{{ data[0] | capitalize }}</h3>
+            {% assign section_label = section_entry.label | default: data[0] | capitalize %}
+            <h3 class="card-title font-weight-medium">{{ section_label }}</h3>
+
             <div>
               {% case data[0] %}
                 {% when 'basics' %}
@@ -115,8 +122,6 @@ layout: default
                   {% include resume/certificates.liquid %}
                 {% when 'references' %}
                   {% include resume/references.liquid %}
-                {% else %}
-
               {% endcase %}
             </div>
           </div>


### PR DESCRIPTION
**Addressing issue #2274** by making the section name changeable. 
Allows users to rename CV sections (from resume.json) via _config.yml. The key refers to the original section name, and the label specifies the new display name shown on the webpage.
<img width="625" alt="RenameCVSection" src="https://github.com/user-attachments/assets/d872998f-f505-4052-9ae4-b088f810a996" />
