### PR TITLE
Add Academia.edu support to social media integrations

### DIFF
--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -2,6 +2,9 @@
 # the commented lines are the default social media links supported by the template
 # the socials will be displayed in the order they are defined here
 
+# academia_edu:  your organization and your username Ex. https://organization.academia.edu/UserName
+#  organization: princeton # your organization as appears in the subdomain
+#  username:  AlbertEinstein # your username
 # acm_id: # your dl.acm.org/profile/id
 # blogger_url: # your blogger URL
 # bluesky_url: # your bluesky URL

--- a/_includes/social.liquid
+++ b/_includes/social.liquid
@@ -1,5 +1,7 @@
 {% for social in site.data.socials %}
   {% case social[0] %}
+    {% when 'academia_edu' %}
+      <a href="https://{{ social[1].organization }}.academia.edu/{{ social[1].username }}" title="Academia.edu"><i class="ai ai-academia"></i></a>
     {% when 'acm_id' %}
       <a href="https://dl.acm.org/profile/{{ social[1] }}/" title="ACM DL"><i class="ai ai-acm"></i></a>
     {% when 'blogger_url' %}


### PR DESCRIPTION
## Description

This pull request adds support for Academia.edu profiles to the al-folio social media integrations. Academia.edu is widely used by academics to share and discover research,.

The changes are minimal and well-contained:
1. Added configuration options in socials.yml for Academia.edu with organization and username fields
2. Updated social.liquid to handle the new social integration using the Academicons font which already includes support for Academia.edu

## Changes

The implementation uses Academicons, which already includes the Academia.edu icon (`ai-academia`), making this addition a natural fit for the theme.

Unlike some other social media links that only require a single ID or URL, Academia.edu profiles include both an organization (subdomain) and a username in the format: `https://[organization].academia.edu/[username]`. The implemented solution supports this pattern by adding two parameters in the socials.yml file.

## Why this is important

Academia.edu is a popular platform used by millions of researchers worldwide to share their work. Adding support for it in the al-folio theme aligns with the theme's academic focus and enhances its utility for scholarly users. Many academics maintain both personal websites and Academia.edu profiles, and being able to link between them provides better visibility for their research.

The Academicons font already includes support for Academia.edu, so adding this feature is a natural extension that makes use of existing resources in the theme.

## Testing

The changes have been tested locally with a sample Academia.edu profile, and the icon displays correctly alongside other social media icons. The changes are minimal and don't affect any existing functionality.

## Screenshot

<img width="991" alt="image" src="https://github.com/user-attachments/assets/15468b67-3002-44ce-aa25-22bc10766664" />
