### PR TITLE
Fix: Improve footnote and citation colors in Distill posts

### DIFF
--- a/_sass/_distill.scss
+++ b/_sass/_distill.scss
@@ -132,6 +132,39 @@ d-article {
 
   d-footnote {
     scroll-margin-top: 66px;
+    color: var(--global-theme-color) !important; /* Footnote text color */
+    &:hover {
+      color: var(--global-hover-color) !important; /* Footnote hover color */
+    }
+  }
+
+  /* Styling for footnote pop-ups (d-hover-box element) */
+  /* Distill's JS creates these dynamically. */
+  d-hover-box { /* This is a custom element for Distill pop-ups */
+    background-color: var(--global-card-bg-color) !important;
+    border: 1px solid var(--global-divider-color) !important; /* Border for the pop-up box */
+    color: var(--global-text-color) !important; /* Default text color inside pop-up */
+    
+    /* Ensure paragraphs, list items, and other common elements inside also get the correct text color */
+    p, li, span, div { 
+      color: var(--global-text-color) !important;
+    }
+
+    a { /* Links inside pop-up */
+      color: var(--global-theme-color) !important;
+      &:hover {
+        color: var(--global-hover-color) !important;
+      }
+    }
+  }
+
+  /* Citations */
+  d-cite a,
+  a.citation { /* Target citations within d-cite and also general .citation links */
+    color: var(--global-theme-color) !important;
+    &:hover {
+      color: var(--global-hover-color) !important;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #3168. (Implemented by [jules.google](https://jules.google).)

This commit addresses an issue where footnotes, citations, and their pop-ups had poor contrast in dark mode on Distill-style blog posts.

The following changes were made to `_sass/_distill.scss`:

- Footnotes (`d-footnote`) and citations (`d-cite a`, `a.citation`) now use the CSS variable `var(--global-theme-color)` for their text color. This variable is theme-aware and ensures appropriate visibility in both light and dark modes.
- Hover states for footnotes and citations now use `var(--global-hover-color)`.
- Footnote pop-ups (using the `d-hover-box` custom element) have been styled:
    - Background color is set to `var(--global-card-bg-color)`.
    - Border is set to `1px solid var(--global-divider-color)`.
    - Text color within the pop-up is `var(--global-text-color)`.
    - Links within the pop-up also use `var(--global-theme-color)`.

These changes ensure that footnotes, citations, and their associated pop-ups are readable and have good contrast in both light and dark themes, consistent with the overall site styling.