### PR TITLE
Fix last row line number overflow issue in diff2html block

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -644,6 +644,12 @@ footer.sticky-bottom {
   }
 }
 
+// diff2html - Fix for diff2html line number overflow
+
+.d2h-diff-table {
+  position: relative;
+}
+
 // Distill
 
 .distill {


### PR DESCRIPTION
Fix #3198 

Current:

![image](https://github.com/user-attachments/assets/dee68f6d-ee12-424b-947c-e5b6d153d157)

After fix:

![Image](https://github.com/user-attachments/assets/310606f4-4359-499d-8865-228d9d638465)