### PR TITLE
keep dark mode inside the (site.enable_darkmode) conditional

### DIFF
--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -69,9 +69,9 @@
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url | bust_css_cache }}">
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
 
+{% if site.enable_darkmode %}
 <!-- Dark Mode -->
 <script src="{{ '/assets/js/theme.js' | relative_url | bust_file_cache }}"></script>
-{% if site.enable_darkmode %}
   <link
     defer
     rel="stylesheet"


### PR DESCRIPTION
Hi,
I noticed some weird behavior when I turned dark mode off (some of the text seemed to disappear, it became white :) )

I traced it to: {% if site.enable_darkmode %} in head.liquid
where some darkmode features are place before the if statement.

When putting it inside the if statement then the weird behavior was solved; see the pull request here :)

Cheers,
Jan