### PR TITLE
update dropdown-menu css

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -250,7 +250,8 @@ ul.task-list input[type="checkbox"] {
   opacity: 0.95;
 }
 
-.navbar .dropdown-menu {
+.navbar .dropdown-menu,
+.btn-group.dropdown .dropdown-menu {
   background-color: var(--global-bg-color);
   border: 1px solid var(--global-divider-color);
 
@@ -273,6 +274,16 @@ ul.task-list input[type="checkbox"] {
   &:hover {
     color: var(--global-hover-color);
     background-color: var(--global-bg-color);
+  }
+}
+
+.dropdown-item.active,
+.dropdown-item:active {
+  background-color: var(--global-hover-color);
+  color: var(--global-hover-text-color) !important;
+
+  &:hover {
+    color: var(--global-hover-text-color);
   }
 }
 
@@ -1039,29 +1050,6 @@ progress::-moz-progress-bar {
     &:hover {
       background-color: var(--global-hover-color) !important;
       color: var(--global-hover-text-color) !important;
-    }
-  }
-
-  .dropdown-menu {
-    background-color: var(--global-bg-color);
-  }
-
-  .dropdown-item {
-    background-color: var(--global-bg-color);
-    color: var(--global-text-color);
-
-    &:hover {
-      color: var(--global-hover-color);
-    }
-  }
-
-  .dropdown-item.active,
-  .dropdown-item:active {
-    background-color: var(--global-hover-color);
-    color: var(--global-hover-text-color) !important;
-
-    &:hover {
-      color: var(--global-hover-text-color);
     }
   }
 }


### PR DESCRIPTION
This pull request fixes a issue that makes the active navbar dropdown menu item unable to follow the global background color settings. 

It achieves this by merging the definition of `.navbar .dropdown-menu` and `.btn-group.dropdown .dropdown-menu` in the `_base.scss`. This should not affect the looking of dropdown menus in a button.

**Before:**
<img width="274" height="194" alt="before" src="https://github.com/user-attachments/assets/4fa59325-8dc9-4156-a8f6-293ce467d00d" />

**After:**
<img width="274" height="194" alt="after" src="https://github.com/user-attachments/assets/5bcf16bc-0b3e-4b27-b5f2-95ae50f3e40f" />

**Button dropdown menu:**
<img width="316" height="241" alt="button" src="https://github.com/user-attachments/assets/5609e568-1635-491d-8451-354e48eed9c5" />
