### PR TITLE
Fix for the CV page's date sorting of work history, education, and volunteering

### DIFF
--- a/_includes/resume/education.liquid
+++ b/_includes/resume/education.liquid
@@ -1,14 +1,57 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign education = data[1] | sort: 'startDate' | reverse %}
-  {% for content in education %}
+  {%- comment -%}
+  Normalize startDate/endDate:
+  - If only year is given ("YYYY"), append "-01-01"
+  - If year+month is given ("YYYY-MM"), append "-01"
+  - Otherwise assume full ISO
+  Then build sortable keys based on endDate (default far-future), then startDate.
+  {%- endcomment -%}
+  {% assign pairs = "" | split: "" %}
+  {% for edu in data[1] %}
+    {%- assign raw_start = edu.startDate | default: "1900" -%}
+    {%- assign raw_end   = edu.endDate   | default: "" -%}
+
+    {%- assign start_iso = raw_start -%}
+    {%- if raw_start.size == 4 -%}
+      {%- assign start_iso = raw_start | append: "-01-01" -%}
+    {%- elsif raw_start.size == 7 -%}
+      {%- assign start_iso = raw_start | append: "-01" -%}
+    {%- endif -%}
+
+    {%- if raw_end == "" -%}
+      {%- assign end_iso = "2100-12-31" -%}
+    {%- else -%}
+      {%- assign end_iso = raw_end -%}
+      {%- if raw_end.size == 4 -%}
+        {%- assign end_iso = raw_end | append: "-12-31" -%}
+      {%- elsif raw_end.size == 7 -%}
+        {%- assign end_iso = raw_end | append: "-28" -%}
+      {%- endif -%}
+    {%- endif -%}
+
+    {% assign end_key   = end_iso   | date: "%Y%m%d" %}
+    {% assign start_key = start_iso | date: "%Y%m%d" %}
+    {% capture pair %}{{ end_key }}-{{ start_key }}::{{ forloop.index0 }}{% endcapture %}
+    {% assign pairs = pairs | push: pair %}
+  {% endfor %}
+
+  {% assign pairs = pairs | sort | reverse %}
+
+  {% for pair in pairs %}
+    {% assign idx = pair | split: '::' | last | plus: 0 %}
+    {% assign content = data[1][idx] %}
+
     <li class="list-group-item">
       <div class="row">
         <div class="col-xs-2 cl-sm-2 col-md-2 text-center date-column">
           {% if content.startDate and content.startDate != '' %}
-            {% assign startDate = content.startDate | split: '-' | slice: 0, 2 | join: '.' %}
-            {% assign endDate = content.endDate | split: '-' | slice: 0, 2 | join: '.' | default: 'Present' %}
-            {% assign date = startDate | append: ' - ' %}
-            {% assign date = date | append: endDate %}
+            {% assign start_label = content.startDate %}
+            {% if content.endDate and content.endDate != '' %}
+              {% assign end_label = content.endDate %}
+            {% else %}
+              {% assign end_label = "Present" %}
+            {% endif %}
+            {% assign date = start_label | append: " - " | append: end_label %}
           {% else %}
             {% assign date = null %}
           {% endif %}
@@ -17,7 +60,7 @@
               <tr>
                 <td>
                   {% if date %}
-                    <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px"> {{ date }} </span>
+                    <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px">{{ date }}</span>
                   {% endif %}
                 </td>
               </tr>
@@ -34,6 +77,7 @@
             </tbody>
           </table>
         </div>
+
         <div class="col-xs-10 cl-sm-10 col-md-10 mt-2 mt-md-0">
           <h6 class="title font-weight-bold ml-1 ml-md-4">
             <a href="{{ content.url }}">{{ content.studyType }}</a>
@@ -42,9 +86,7 @@
           <h6 class="ml-1 ml-md-4" style="font-size: 0.95rem; font-style: italic">{{ content.area }}</h6>
           <ul class="items">
             {% for item in content.courses %}
-              <li>
-                <span class="item">{{ item }}</span>
-              </li>
+              <li><span class="item">{{ item }}</span></li>
             {% endfor %}
           </ul>
         </div>

--- a/_includes/resume/volunteer.liquid
+++ b/_includes/resume/volunteer.liquid
@@ -1,22 +1,83 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign volunteer = data[1] | sort: 'startDate' | reverse %}
-  {% for content in volunteer %}
+  {%- comment -%}
+  Normalize start/end (handle YYYY, YYYY-MM, YYYY-MM-DD) using string ops only.
+  Build sortable keys as YYYYMMDD (strings). Primary sort = end, secondary = start.
+  {%- endcomment -%}
+  {% assign pairs = "" | split: "" %}
+  {% for vol in data[1] %}
+    {%- assign raw_start = vol.startDate | default: "" | append: "" -%}
+    {%- assign raw_end   = vol.endDate   | default: "" | append: "" -%}
+
+    {%- if raw_start == "" -%}
+      {%- assign start_iso = "1900-01-01" -%}
+    {%- elsif raw_start.size == 4 -%}
+      {%- assign start_iso = raw_start | append: "-01-01" -%}
+    {%- elsif raw_start.size == 7 -%}
+      {%- assign start_iso = raw_start | append: "-01" -%}
+    {%- else -%}
+      {%- assign start_iso = raw_start -%}
+    {%- endif -%}
+
+    {%- if raw_end == "" -%}
+      {%- assign end_iso = "2100-12-31" -%}
+    {%- elsif raw_end.size == 4 -%}
+      {%- assign end_iso = raw_end | append: "-12-31" -%}
+    {%- elsif raw_end.size == 7 -%}
+      {%- assign end_iso = raw_end | append: "-28" -%}
+    {%- else -%}
+      {%- assign end_iso = raw_end -%}
+    {%- endif -%}
+
+    {%- assign start_key = start_iso | remove: "-" | slice: 0, 8 -%}
+    {%- assign end_key   = end_iso   | remove: "-" | slice: 0, 8 -%}
+
+    {% capture pair %}{{ end_key }}-{{ start_key }}::{{ forloop.index0 }}{% endcapture %}
+    {% assign pairs = pairs | push: pair %}
+  {% endfor %}
+
+  {% assign pairs = pairs | sort | reverse %}
+
+  {% for pair in pairs %}
+    {% assign idx = pair | split: '::' | last | plus: 0 %}
+    {% assign content = data[1][idx] %}
+
     <li class="list-group-item">
       <div class="row">
         <div class="col-xs-2 cl-sm-2 col-md-2 text-center date-column">
-          {% if content.startDate %}
-            {% assign startDate = content.startDate | split: '-' | slice: 0, 2 | join: '.' %}
-            {% assign endDate = content.endDate | split: '-' | slice: 0, 2 | join: '.' | default: 'Present' %}
-            {% assign date = startDate | append: ' - ' %}
-            {% assign date = date | append: endDate %}
-          {% else %}
-            {% assign date = '' %}
-          {% endif %}
+          {%- assign s_raw = content.startDate | default: "" | append: "" -%}
+          {%- assign e_raw = content.endDate   | default: "" | append: "" -%}
+
+          {%- if s_raw != "" -%}
+            {%- if s_raw.size == 4 -%}
+              {%- assign start_label = s_raw -%}
+            {%- elsif s_raw.size == 7 -%}
+              {%- assign start_label = s_raw | replace: "-", "." -%}
+            {%- else -%}
+              {%- assign start_label = s_raw | slice: 0, 7 | replace: "-", "." -%}
+            {%- endif -%}
+
+            {%- if e_raw == "" -%}
+              {%- assign end_label = "Present" -%}
+            {%- elsif e_raw.size == 4 -%}
+              {%- assign end_label = e_raw -%}
+            {%- elsif e_raw.size == 7 -%}
+              {%- assign end_label = e_raw | replace: "-", "." -%}
+            {%- else -%}
+              {%- assign end_label = e_raw | slice: 0, 7 | replace: "-", "." -%}
+            {%- endif -%}
+
+            {%- assign date = start_label | append: " - " | append: end_label -%}
+          {%- else -%}
+            {%- assign date = "" -%}
+          {%- endif -%}
+
           <table class="table-cv">
             <tbody>
               <tr>
                 <td>
-                  <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px"> {{ date }} </span>
+                  {% if date != "" %}
+                    <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px">{{ date }}</span>
+                  {% endif %}
                 </td>
               </tr>
               {% if content.location %}
@@ -32,6 +93,7 @@
             </tbody>
           </table>
         </div>
+
         <div class="col-xs-10 cl-sm-10 col-md-10 mt-2 mt-md-0">
           <h6 class="title font-weight-bold ml-1 ml-md-4">
             <a href="{{ content.url }}">{{ content.position }}</a>
@@ -40,9 +102,7 @@
           <h6 class="ml-1 ml-md-4" style="font-size: 0.95rem; font-style: italic">{{ content.summary }}</h6>
           <ul class="items">
             {% for item in content.highlights %}
-              <li>
-                <span class="item">{{ item }}</span>
-              </li>
+              <li><span class="item">{{ item }}</span></li>
             {% endfor %}
           </ul>
         </div>

--- a/_includes/resume/work.liquid
+++ b/_includes/resume/work.liquid
@@ -1,22 +1,86 @@
 <ul class="card-text font-weight-light list-group list-group-flush">
-  {% assign work = data[1] | sort: 'startDate' | reverse %}
-  {% for content in work %}
+  {%- comment -%}
+  Normalize dates via string ops only:
+  - start: "" -> 1900-01-01, YYYY -> YYYY-01-01, YYYY-MM -> YYYY-MM-01
+  - end:   "" -> 2100-12-31, YYYY -> YYYY-12-31, YYYY-MM -> YYYY-MM-28
+  Build sortable keys as YYYYMMDD. Sort by end then start (desc).
+  {%- endcomment -%}
+  {% assign pairs = "" | split: "" %}
+  {% for job in data[1] %}
+    {%- assign raw_start = job.startDate | default: "" | append: "" -%}
+    {%- assign raw_end   = job.endDate   | default: "" | append: "" -%}
+
+    {%- if raw_start == "" -%}
+      {%- assign start_iso = "1900-01-01" -%}
+    {%- elsif raw_start.size == 4 -%}
+      {%- assign start_iso = raw_start | append: "-01-01" -%}
+    {%- elsif raw_start.size == 7 -%}
+      {%- assign start_iso = raw_start | append: "-01" -%}
+    {%- else -%}
+      {%- assign start_iso = raw_start -%}
+    {%- endif -%}
+
+    {%- if raw_end == "" -%}
+      {%- assign end_iso = "2100-12-31" -%}
+    {%- elsif raw_end.size == 4 -%}
+      {%- assign end_iso = raw_end | append: "-12-31" -%}
+    {%- elsif raw_end.size == 7 -%}
+      {%- assign end_iso = raw_end | append: "-28" -%}
+    {%- else -%}
+      {%- assign end_iso = raw_end -%}
+    {%- endif -%}
+
+    {%- assign start_key = start_iso | remove: "-" | slice: 0, 8 -%}
+    {%- assign end_key   = end_iso   | remove: "-" | slice: 0, 8 -%}
+
+    {% capture pair %}{{ end_key }}-{{ start_key }}::{{ forloop.index0 }}{% endcapture %}
+    {% assign pairs = pairs | push: pair %}
+  {% endfor %}
+
+  {% assign pairs = pairs | sort | reverse %}
+
+  {%- for pair in pairs -%}
+    {% assign idx = pair | split: '::' | last | plus: 0 %}
+    {% assign content = data[1][idx] %}
+
     <li class="list-group-item">
       <div class="row">
         <div class="col-xs-2 cl-sm-2 col-md-2 text-center date-column">
-          {% if content.startDate %}
-            {% assign startDate = content.startDate | split: '-' | slice: 0, 2 | join: '.' %}
-            {% assign endDate = content.endDate | split: '-' | slice: 0, 2 | join: '.' | default: 'Present' %}
-            {% assign date = startDate | append: ' - ' %}
-            {% assign date = date | append: endDate %}
+          {%- comment -%} Human-friendly date labels without |date {%- endcomment -%}
+          {% assign s_raw = content.startDate | default: "" | append: "" %}
+          {% assign e_raw = content.endDate   | default: "" | append: "" %}
+
+          {% if s_raw != "" %}
+            {% if s_raw.size == 4 %}
+              {% assign start_label = s_raw %}
+            {% elsif s_raw.size == 7 %}
+              {% assign start_label = s_raw | replace: "-", "." %}
+            {% else %}
+              {% assign start_label = s_raw | slice: 0, 7 | replace: "-", "." %}
+            {% endif %}
+
+            {% if e_raw == "" %}
+              {% assign end_label = "Present" %}
+            {% elsif e_raw.size == 4 %}
+              {% assign end_label = e_raw %}
+            {% elsif e_raw.size == 7 %}
+              {% assign end_label = e_raw | replace: "-", "." %}
+            {% else %}
+              {% assign end_label = e_raw | slice: 0, 7 | replace: "-", "." %}
+            {% endif %}
+
+            {% assign date = start_label | append: " - " | append: end_label %}
           {% else %}
-            {% assign date = '' %}
+            {% assign date = "" %}
           {% endif %}
+
           <table class="table-cv">
             <tbody>
               <tr>
                 <td>
-                  <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px"> {{ date }} </span>
+                  {% if date != "" %}
+                    <span class="badge font-weight-bold danger-color-dark text-uppercase align-middle" style="min-width: 75px">{{ date }}</span>
+                  {% endif %}
                 </td>
               </tr>
               {% if content.location %}
@@ -32,6 +96,7 @@
             </tbody>
           </table>
         </div>
+
         <div class="col-xs-10 cl-sm-10 col-md-10 mt-2 mt-md-0">
           <h6 class="title font-weight-bold ml-1 ml-md-4">
             <a href="{{ content.url }}">{{ content.position }}</a>
@@ -40,13 +105,11 @@
           <h6 class="ml-1 ml-md-4" style="font-size: 0.95rem; font-style: italic">{{ content.summary }}</h6>
           <ul class="items">
             {% for item in content.highlights %}
-              <li>
-                <span class="item">{{ item }}</span>
-              </li>
+              <li><span class="item">{{ item }}</span></li>
             {% endfor %}
           </ul>
         </div>
       </div>
     </li>
-  {% endfor %}
+  {%- endfor -%}
 </ul>


### PR DESCRIPTION
This PR normalizes partial dates (YYYY, YYYY-MM) to full ISO strings for sorting. It replaces the Liquid date filter with string ops so year-only and year-month values display and sort correctly.

Fixes #3271