### PR TITLE
Socials icons: Check if rss_icon: false

### DIFF
--- a/_includes/social.liquid
+++ b/_includes/social.liquid
@@ -59,7 +59,9 @@
     {% when 'research_gate_profile' %}
       <a href="https://www.researchgate.net/profile/{{ social[1] }}/" title="ResearchGate"><i class="ai ai-researchgate"></i></a>
     {% when 'rss_icon' %}
-      <a href="{{ site.baseurl }}/feed.xml" title="RSS Feed"><i class="fa-solid fa-square-rss"></i></a>
+      {% if social[1] == true %}
+        <a href="{{ site.baseurl }}/feed.xml" title="RSS Feed"><i class="fa-solid fa-square-rss"></i></a>
+      {% endif %}
     {% when 'scholar_userid' %}
       <a href="https://scholar.google.com/citations?user={{ social[1] }}" title="Google Scholar"><i class="ai ai-google-scholar"></i></a>
     {% when 'scopus_id' %}


### PR DESCRIPTION
Partially addresses issue #3280.

Currently, the RSS feed icon in the socials section will show whenever `rss_icon` in `data/_socials.yml` has a value --- **even if that value is `false`**.

Unlike the other social settings, which are empty by default, for `rss_icon` the default setting is `true`.

So it makes sense that a user might expect `rss_icon: false` to disable said icon.

This PR just adds a check if the value is `false` and hides the icon if so.