### PR TITLE
Revert duplicate Google Analytics

### DIFF
--- a/_includes/scripts.liquid
+++ b/_includes/scripts.liquid
@@ -227,15 +227,6 @@
   <!-- Analytics -->
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
-
-    gtag('config', '{{ site.google_analytics }}');
-  </script>
   <script defer src="{{ '/assets/js/google-analytics-setup.js' | relative_url }}"></script>
 {% endif %}
 


### PR DESCRIPTION
This reverts PR #2962. The inline script here is exactly the same as the `/assets/js/google-analytics-setup.js` sourced on the following line, so Google Analytics is being triggered twice.

It seems that #2962 originally added this because liquid templating of the setup script didn't work (#3095). However, this was then properly fixed in #3117.