### PR TITLE
[MINOR] Update bib_search.liquid to use input type `search`

### DIFF
--- a/_includes/bib_search.liquid
+++ b/_includes/bib_search.liquid
@@ -1,4 +1,4 @@
 {% if site.bib_search %}
   <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
-  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+  <input type="search" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
 {% endif %}


### PR DESCRIPTION
Switches the input type from text to search to add an X to clear the search box from text.

Fixes #3328

Sorry if I'm missing something obvious with this. I don't have much webdev experience.