### PR TITLE
Add personal webpage link to user community section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://siddharthsule.com/" target="_blank">★</a>
 <a href="https://waynexucn.github.io/" target="_blank">★</a>
 <a href="https://zlatanajanovic.com/" target="_blank">★</a>
+<a href="https://mchadolias.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Adds my personal academic website to the list of community pages in the README. This helps other collaborators connect and see related work. The link has been verified and follows the established format. Thank you for the template it was very useful!