### PR TITLE
Add auto-orient flag to Imagemagick config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -362,7 +362,7 @@ imagemagick:
     - ".tiff"
     - ".gif"
   output_formats:
-    webp: "-quality 85"
+    webp: "-auto-orient -quality 85"
 
 # Lazy loading images
 #   If you enable lazy loading, all images will add the loading="lazy" attribute.


### PR DESCRIPTION
Currently, images generated by Imagemagick do not respect the orientation of the source image. By adding the auto-orient flag, the images are the correct orientation.

Before
<img width="920" height="562" alt="image" src="https://github.com/user-attachments/assets/73f59d7f-b6c5-468a-9023-0f0457a53a3c" />

After
<img width="947" height="621" alt="image" src="https://github.com/user-attachments/assets/2f24de99-2e84-4052-8d0f-945acdad81e4" />


