### PR TITLE
[Fix] cache bust plugin not loading new scss on deployments

### DIFF
--- a/_plugins/cache-bust.rb
+++ b/_plugins/cache-bust.rb
@@ -43,7 +43,7 @@ module Jekyll
     end
 
     def bust_css_cache(file_name)
-      CacheDigester.new(file_name: file_name, directory: 'assets/_sass').digest!
+      CacheDigester.new(file_name: file_name, directory: '_sass').digest!
     end
   end
 end


### PR DESCRIPTION
## The Bug
I created page with custom scss, and noticed my local docker page looked different than my deployed page (no bounding rectangles around tables and UI elements). 

### Development
<img width="1171" height="776" alt="image" src="https://github.com/user-attachments/assets/88725305-c4ad-4f43-95d9-3d9cebe481d0" />

### Deployed GH Page
<img width="1166" height="776" alt="image" src="https://github.com/user-attachments/assets/fb368847-1089-403b-80fc-7661fd51226f" />


## The Fix
Updating the cache bust plugin to the current dir of scss fixed my issue. Perhaps this plugin was not updated when scss dir was moved? 

### Deployed GH Page
<img width="1578" height="1192" alt="image" src="https://github.com/user-attachments/assets/2756eba5-44b9-484a-af8c-4b6c68aeb7ad" />
