### PR TITLE
Make external service URLs configurable for repository page

### DIFF
--- a/CUSTOMIZE.md
+++ b/CUSTOMIZE.md
@@ -91,6 +91,30 @@ What this means is, if there is no resume data defined in [\_config.yml](_config
 
 The user and repository information is defined in [\_data/repositories.yml](_data/repositories.yml). You can add as many users and repositories as you want. Both informations are used in the `repositories` section.
 
+### Configuring external service URLs
+
+The repository page uses external services to display GitHub statistics and trophies. By default, these are:
+
+- `github-readme-stats.vercel.app` for user stats and repository cards
+- `github-profile-trophy.vercel.app` for GitHub profile trophies
+
+**Important:** These default services are hosted by third parties and may not be available 100% of the time. For better reliability, privacy, and customization, you can self-host these services and configure your website to use your own instances.
+
+To use your own instances of these services, configure the URLs in [\_config.yml](_config.yml):
+
+```yaml
+external_services:
+  github_readme_stats_url: https://github-readme-stats.vercel.app
+  github_profile_trophy_url: https://github-profile-trophy.vercel.app
+```
+
+To self-host these services, follow the deployment instructions in their respective repositories:
+
+- [github-readme-stats](https://github.com/anuraghazra/github-readme-stats)
+- [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy)
+
+Once deployed, update the URLs above to point to your custom deployment.
+
 ## Creating new pages
 
 You can create new pages by adding new Markdown files in the [\_pages](_pages/) directory. The easiest way to do this is to copy an existing page and modify it. You can choose the layout of the page by changing the [layout](https://jekyllrb.com/docs/layouts/) attribute in the [frontmatter](https://jekyllrb.com/docs/front-matter/) of the Markdown file, and also the path to access it by changing the [permalink](https://jekyllrb.com/docs/permalinks/) attribute. You can also add new layouts in the [\_layouts](_layouts/) directory if you feel the need for it.

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,13 @@ repo_trophies:
   theme_light: flat # https://github.com/ryo-ma/github-profile-trophy
   theme_dark: gitdimmed # https://github.com/ryo-ma/github-profile-trophy
 
+# External service URLs for repository page
+# To use a different instance or service for displaying GitHub stats and trophies,
+# update these URLs. These are used in the repository templates.
+external_services:
+  github_readme_stats_url: https://github-readme-stats.vercel.app
+  github_profile_trophy_url: https://github-profile-trophy.vercel.app
+
 # -----------------------------------------------------------------------------
 # RSS Feed
 # -----------------------------------------------------------------------------

--- a/_includes/repository/repo.liquid
+++ b/_includes/repository/repo.liquid
@@ -36,12 +36,12 @@
     <img
       class="only-light w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
     <img
       class="only-dark w-100"
       alt="{{ include.repository }}"
-      src="https://github-readme-stats.vercel.app/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
+      src="{{ site.external_services.github_readme_stats_url }}/api/pin/?username={{ repo_url[0] }}&repo={{ repo_url[1] }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_owner={{ show_owner }}&description_lines_count={{ max_lines }}"
     >
   </a>
 </div>

--- a/_includes/repository/repo_trophies.liquid
+++ b/_includes/repository/repo_trophies.liquid
@@ -4,12 +4,12 @@
       <img
         class="only-light"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
       >
       <img
         class="only-dark"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=6"
       >
     </span>
 
@@ -17,12 +17,12 @@
       <img
         class="only-light"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=4"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=4"
       >
       <img
         class="only-dark"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=4"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=4"
       >
     </span>
 
@@ -30,12 +30,12 @@
       <img
         class="only-light"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=3"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_light }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=3"
       >
       <img
         class="only-dark"
         alt="{{ include.username }}"
-        src="https://github-profile-trophy.vercel.app/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=3"
+        src="{{ site.external_services.github_profile_trophy_url }}/?username={{ include.username }}&theme={{ site.repo_trophies.theme_dark }}&locale={{ site.lang }}&margin-w=15&margin-h=15&no-bg=true&rank=-C&column=3"
       >
     </span>
   </a>

--- a/_includes/repository/repo_user.liquid
+++ b/_includes/repository/repo_user.liquid
@@ -23,12 +23,12 @@
     <img
       class="only-light w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_icons=true"
+      src="{{ site.external_services.github_readme_stats_url }}/api/?username={{ include.username }}&theme={{ site.repo_theme_light }}&locale={{ lang }}&show_icons=true"
     >
     <img
       class="only-dark w-100"
       alt="{{ include.username }}"
-      src="https://github-readme-stats.vercel.app/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_icons=true"
+      src="{{ site.external_services.github_readme_stats_url }}/api/?username={{ include.username }}&theme={{ site.repo_theme_dark }}&locale={{ lang }}&show_icons=true"
     >
   </a>
 </div>


### PR DESCRIPTION
## Description

This PR makes the URLs for external services used on the repository page configurable in `_config.yml`. This allows users to self-host these services for better reliability, privacy, and customization.

## Changes

- Added `external_services` configuration section in `_config.yml` with:
  - `github_readme_stats_url` (default: `https://github-readme-stats.vercel.app`)
  - `github_profile_trophy_url` (default: `https://github-profile-trophy.vercel.app`)
- Updated repository template files to use configurable URLs:
  - `_includes/repository/repo_user.liquid`
  - `_includes/repository/repo.liquid`
  - `_includes/repository/repo_trophies.liquid`
- Added documentation in `CUSTOMIZE.md` explaining:
  - Why self-hosting is recommended (default services may have availability issues)
  - How to configure custom service URLs
  - Links to the service repositories for deployment instructions

## Resolves

Resolves #3388 - This makes it possible to configure self-hosted versions of these services, giving users full control over the external services used for displaying GitHub statistics and trophies.

## Testing

- Verified that default configuration still works with original service URLs
- Confirmed that URLs are properly interpolated in all template files
- Documentation clearly explains the configuration options