### PR TITLE
Add j1yoo.github.io to User community

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://mchadolias.github.io/" target="_blank">★</a>
 <a href="https://syanyong.github.io/" target="_blank">★</a>
 <a href="https://jucheval.github.io/" target="_blank">★</a>
+<a href="https://j1yoo.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi! I'd like to add my academic website to the User community section.

**Website:** https://j1yoo.github.io/

This PR adds a single star link to the Academics row in the User community table.

Thank you for creating and maintaining this beautiful theme!