### PR TITLE
docs: correct email configuration location in QUICKSTART.md

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -35,7 +35,8 @@
 
 ## Step 3: Personalize (2 min)
 
-1. Open `_config.yml` in your repository and update these fields:
+1. Open `_config.yml` in your repository
+2. Update these fields:
    ```yaml
    title: My Website
    first_name: Your
@@ -43,11 +44,7 @@
    url: https://your-username.github.io # or your custom domain
    baseurl: # Leave this empty (do NOT delete it)
    ```
-2. Open `_data/socials.yml` and update the email field:
-   ```yaml
-   email: your.email@example.com
-   ```
-3. Commit your changes
+3. Click **Commit changes** (at the bottom of the page)
 
 ## Step 4: View Your Site (1 min)
 


### PR DESCRIPTION
Fixes #3488

Updates `QUICKSTART.md` to correctly point to `_data/socials.yml` for email configuration, as the `email` field is not present in `_config.yml`.