### PR TITLE
Fix #2598, shift to last_modified_at instead of last_updated.

### DIFF
--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -19,7 +19,8 @@ layout: default
     <p class="post-meta">
       Created on {{ page.date | date: '%B %d, %Y' }}
       {% if page.author %}by {{ page.author }}{% endif %}
-      {% if page.last_updated %}, last updated on {{ page.last_updated | date: '%B %d, %Y' }}{% endif %}
+      {% assign last_date = page.last_modified_at | default: page.last_updated %}
+      {% if last_date %}, last updated on {{ last_date | date: '%B %d, %Y' }}{% endif %}
       {% if page.meta %}• {{ page.meta }}{% endif %}
     </p>
     <p class="post-tags">

--- a/_posts/2024-01-27-vega-lite.md
+++ b/_posts/2024-01-27-vega-lite.md
@@ -2,7 +2,7 @@
 layout: post
 title: a post with vega lite
 date: 2024-01-27 00:20:00
-last_updated: 2024-04-14 04:30:00
+last_modified_at: 2024-04-14 04:30:00
 description: this is what included vega lite code could look like
 tags: formatting charts
 categories: sample-posts


### PR DESCRIPTION
Use `last_modified_at` rather than `last_updated`. So that the jekyll-sitemap plugin automatically looks for the standard `last_modified_at` front matter field to generate the `<lastmod>` tag in your `sitemap.xml`.

It fixes [#2598](https://github.com/alshedivat/al-folio/issues/2598) 

Also, it preserves backward compatibility, as the updated metadata logic prioritizes the `page.last_modified_at`, and defaults to `page.last_updated`. 
