### PR TITLE
Improve explanation of create from this template

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,16 @@ The recommended approach for using **al-folio** is to first create your own site
 
 **For the quickest setup**, follow the [Quick Start Guide](QUICKSTART.md), which will have you up and running in 5 minutes.
 
+### Template vs. Fork: Which Should I Use?
+
+**Use the "Use this template" button** (recommended) when creating your own al-folio site. This creates a clean, independent copy that is not linked to the main al-folio repository.
+
+**If you already forked the repository**, your fork will work fine, but you should be aware of a common pitfall:
+
+- Forks maintain a connection to the original repository, which can make it easy to accidentally submit pull requests to al-folio with your personal site changes
+- **Solution:** When making changes to your fork, always create a new branch (e.g., `git checkout -b my-site-updates`) and verify that you're pushing to **your own fork** before submitting pull requests
+- Only submit pull requests to `alshedivat/al-folio` if you're intentionally contributing improvements that benefit the entire al-folio community
+
 ### Important Notes for GitHub Pages Sites
 
 If you plan to upload your site to `<your-github-username>.github.io`, the repository name :warning: **MUST BE** :warning: `<your-github-username>.github.io` or `<your-github-orgname>.github.io`, as stated in the [GitHub pages docs](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,11 +21,16 @@
 
 ## Step 1: Create Your Repository (1 min)
 
-1. Click **[Use this template](https://github.com/new?template_name=al-folio&template_owner=alshedivat)** on the al-folio repository page
-2. Name your repository:
-   - **Personal/Organization site:** `username.github.io` (replace `username` with your GitHub username)
-   - **Project site:** Any name (e.g., `my-research-website`)
-3. Click **Create repository from template**
+**⚠️ Important:** Use the **"Use this template"** button, NOT the fork button. This ensures your site is independent and you won't accidentally submit your personal changes back to the al-folio project.
+
+1. Go to the [al-folio repository](https://github.com/alshedivat/al-folio)
+2. Click the green **"Use this template"** button (top right), then select **"Create a new repository"**
+3. Name your repository:
+   - **Personal/Organization site (if you want your site to be at `username.github.io`):** `username.github.io` (replace `username` with your GitHub username)
+   - **Project site (if you want your site to be at `username.github.io/project-name`):** Any name (e.g., `my-research-website`)
+4. Click **"Create repository from template"**
+
+**Already forked by mistake?** No problem. Your fork will work fine—just be careful when making changes. Create a new branch for your updates (e.g., `git checkout -b my-site-updates`) and make sure you push to **your own repository**, not the main al-folio project.
 
 ## Step 2: Configure Deployment (1 min)
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,21 @@ Run the test yourself: [Google Lighthouse PageSpeed Insights](https://pagespeed.
 
 ## Getting started
 
+**⚠️ Important: Use "Use this template" (not fork)**
+
+When creating your own website with al-folio, you have two options:
+
+- ✅ **Recommended:** Click "[Use this template](https://github.com/new?template_name=al-folio&template_owner=alshedivat)" – This creates a clean copy that is independent from the main al-folio repository. Changes you make to your site won't be accidentally submitted to al-folio as pull requests.
+- ❌ **Not recommended:** Forking the repository – This keeps a link to the main al-folio repo, making it easy to accidentally submit your personal site changes as contributions to our project.
+
+**If you already forked:** Don't worry! You can still work with your fork normally. Just make sure to:
+
+1. Make changes on a dedicated branch (e.g., `my-site-updates`)
+2. When pushing changes, always verify you're pushing to **your own repository**, not the main al-folio repository
+3. Never create pull requests to `alshedivat/al-folio` unless you're intentionally contributing improvements that benefit all users
+
+For quick setup, see [QUICKSTART.md](QUICKSTART.md).
+
 Want to learn more about Jekyll? Check out [this tutorial](https://www.taniarascia.com/make-a-static-website-with-jekyll/). Why Jekyll? Read [Andrej Karpathy's blog post](https://karpathy.github.io/2014/07/01/switching-to-jekyll/)! Why write a blog? Read [Rachel Thomas blog post](https://medium.com/@racheltho/why-you-yes-you-should-blog-7d2544ac1045).
 
 ## Installing and Deploying


### PR DESCRIPTION
This pull request improves the documentation to clarify the recommended way to create a new site using the al-folio template, emphasizing the use of the "Use this template" button instead of forking. It explains the differences between the two approaches, highlights common pitfalls with forking, and provides guidance for users who have already forked the repository.

Documentation improvements regarding repository creation:

* Added a prominent section in `README.md` explaining why "Use this template" is preferred over forking, including step-by-step instructions and advice for users who have already forked.
* Updated `QUICKSTART.md` to strongly recommend using the "Use this template" button, clarified the steps for creating a new repository, and included tips for users who have already forked by mistake.
* Added a new section in `INSTALL.md` detailing the differences between using the template and forking, common pitfalls, and best practices for contributing.