### PR TITLE
feat: add Goodreads social link support

### DIFF
--- a/_includes/metadata.liquid
+++ b/_includes/metadata.liquid
@@ -117,6 +117,9 @@
       {% when 'gitlab_username' %}
         {% capture link %}https://gitlab.com/{{ social[1] }}{% endcapture %}
         {% assign sameaslinks = sameaslinks | push: link %}
+      {% when 'goodreads_id' %}
+        {% capture link %}https://www.goodreads.com/user/show/{{ social[1] }}{% endcapture %}
+        {% assign sameaslinks = sameaslinks | push: link %}
       {% when 'hal_id' %}
         {% capture link %}https://cv.hal.science/{{ social[1] }}/{% endcapture %}
         {% assign sameaslinks = sameaslinks | push: link %}


### PR DESCRIPTION
## Summary

- Add `goodreads_id` to the schema.org `sameAs` generator in `metadata.liquid`

Depends on [george-gca/jekyll-socials#6](https://github.com/george-gca/jekyll-socials/pull/6) which adds `goodreads_id` as a built-in social platform using the Font Awesome `fa-brands fa-goodreads` icon to the jekyll-socials plugin.

Closes #3529

## How it works

Once the jekyll-socials plugin is updated, users simply add to `_data/socials.yml`:
```yml
goodreads_id: 123456789-username
```

The plugin renders the icon using Font Awesome's existing `fa-brands fa-goodreads` class, so no additional CSS or SVG changes are needed — it works out of the box with the existing font icon styling.

## Screenshots

### Light mode
<img width="645" height="142" alt="Screenshot 2026-02-14 at 11 13 00 PM" src="https://github.com/user-attachments/assets/701a0d57-a98c-4433-ba5d-4b29d0027899" />

### Light mode (hover)
<img width="634" height="140" alt="Screenshot 2026-02-14 at 11 13 08 PM" src="https://github.com/user-attachments/assets/7cf33fd4-06bc-4359-9573-5799c4fd0d4a" />


### Dark mode
<img width="647" height="142" alt="Screenshot 2026-02-14 at 11 11 09 PM" src="https://github.com/user-attachments/assets/1406a377-f14e-4dd2-b3e9-547c8fe4b53c" />


### Dark mode (hover)
<img width="606" height="134" alt="Screenshot 2026-02-14 at 11 12 50 PM" src="https://github.com/user-attachments/assets/e4832a80-386a-4965-a3b0-c40f6748445f" />

## Test plan

- [ ] Add `goodreads_id: 123456789-username` to `_data/socials.yml` and verify the icon renders with correct link
- [ ] Verify icon color matches other social icons in both light and dark mode
- [ ] Verify hover transitions to theme color
- [ ] Verify schema.org `sameAs` metadata includes the Goodreads URL
- [ ] Verify existing social icons are unaffected