### PR TITLE
Add 'Relevant Coursework:' label to course items

### DIFF
--- a/_includes/cv/education.liquid
+++ b/_includes/cv/education.liquid
@@ -76,7 +76,7 @@
             <ul class="items">
               {% for item in entry.courses %}
                 <li>
-                  <span class="item">{{ item }}</span>
+                  <span class="item"><b>Relevant Coursework:</b> {{ item }}</span>
                 </li>
               {% endfor %}
               {% for item in entry.highlights %}


### PR DESCRIPTION
I could not realize that what is the difference between "courses" and "highlight" so I added this `<b>Relevant Coursework:</b>` label to clearify courses from highlights