### PR TITLE
Add Fukushima Lab to User community (Labs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://big-culture.github.io/" target="_blank">★</a>
 <a href="https://martinbulla.github.io/bullab/" target="_blank">★</a>
 <a href="https://gpforesteyes.github.io/" target="_blank">★</a>
+<a href="https://kenji-fukushima-lab.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This PR adds Fukushima Lab to the **User community** section in `README.md` under **Labs**. Thank you for maintaining such a great and inspiring website template.

Added link:
- https://kenji-fukushima-lab.github.io/
