### PR TITLE
Fix CSS display properties and margin typo

### DIFF
--- a/_layouts/book-review.liquid
+++ b/_layouts/book-review.liquid
@@ -167,6 +167,9 @@ layout: default
 </div>
 
 <style>
+      .post article {
+        display: flow-root;
+      }
       figure {
         float: none;
         width: auto;
@@ -217,7 +220,7 @@ layout: default
           figure {
 
                 float: right;
-                display: in-line block; /* in-line block; */
+                display: inline-block; /* inline-block; */
                 margin: 0px 0px 0px 0px;  /* adjust as needed */
                 padding: 0px 0px 0px 20px;
                /* top right bottom left */
@@ -242,7 +245,7 @@ layout: default
   blockquote {
 
       position: relative;
-      marign: 0px;
+      margin: 0px;
       display: table;
 
   }


### PR DESCRIPTION
The image would overflow into the footer, these css changes fix the problem. The did only appear, when the text was smaller than the height of the image, so on the al folio example, this issue could not be seen. Its a solution for my raised Issue #3583

Atteched images of the problem on my own site (I did not screenshot the wole page):

before:
<img width="577" height="599" alt="overflow" src="https://github.com/user-attachments/assets/c4f3f3d3-08a5-464f-9c0c-c827ef193c73" />

after:
<img width="290" height="642" alt="fixed overflow" src="https://github.com/user-attachments/assets/de44294f-5585-45f3-a9a2-b5611aaf6df9" />
