### PR TITLE
Fix: correctly process external posts to display tags and categories

### DIFF
--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-05-01'
+  last_updated: '2026-05-13'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2540
+    citations: 2545
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -30,7 +30,7 @@ papers:
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8250
+    citations: 8325
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -42,7 +42,7 @@ papers:
     title: Brownian motion
     year: '1936'
   qc6CJjYAAAAJ:-qpA3cGbmHsC:
-    citations: 538
+    citations: 541
     title: On the Relation between the Expansion and the Mean Density of the Universe
     year: '1932'
   qc6CJjYAAAAJ:-vzq6BoH5oUC:
@@ -70,7 +70,7 @@ papers:
     title: Elementary Considerations on the Interpretation of the Foundations of Quantum Mechanics
     year: '2011'
   qc6CJjYAAAAJ:0EnyYjriUFMC:
-    citations: 1193
+    citations: 1201
     title: 'The Born Einstein Letters: correspondence between Albert Einstein and Max and Hedwig Born from 1916 to 1955 with commentaries by Max Born. Translated by Irene Born'
     year: '1971'
   qc6CJjYAAAAJ:0KZCP5UExFUC:
@@ -110,7 +110,7 @@ papers:
     title: Correspondencia con Michele Besso:(1903-1955)
     year: '1994'
   qc6CJjYAAAAJ:0t1ZDozeHsAC:
-    citations: 6
+    citations: 5
     title: Essays in science
     year: '1954'
   qc6CJjYAAAAJ:0wD49__q8KEC:
@@ -134,7 +134,7 @@ papers:
     title: "L'\xE9ther et la th\xE9orie de la relativit\xE9"
     year: '1921'
   qc6CJjYAAAAJ:1DhOeZtQFr0C:
-    citations: 494
+    citations: 495
     title: Principle Points of the General Theory of Relativity
     year: '1918'
   qc6CJjYAAAAJ:1EM7I_rJWO4C:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1528
+    citations: 1530
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -242,7 +242,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm von Siemens: Letter, 4 Jan 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:3fE2CSJIrl8C:
-    citations: 329
+    citations: 330
     title: A generalization of the relativistic theory of gravitation, II
     year: '1946'
   qc6CJjYAAAAJ:3pYxbvHKFu8C:
@@ -258,7 +258,7 @@ papers:
     title: Relativity in Newtonian Mechanics and the Michelson-Morley Experiment
     year: Unknown Year
   qc6CJjYAAAAJ:3vbIHxFL9FgC:
-    citations: 346
+    citations: 347
     title: "Experimenteller Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1915'
   qc6CJjYAAAAJ:3z7foVzkq2cC:
@@ -270,11 +270,11 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7111
+    citations: 7132
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
-    citations: 539
+    citations: 541
     title: The Origins of the General Theory of Relativity
     year: '1933'
   qc6CJjYAAAAJ:4E1Y8I9HL1wC:
@@ -290,7 +290,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 2952
+    citations: 2972
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
@@ -302,7 +302,7 @@ papers:
     title: Naturwissenschaft und Religion
     year: '1960'
   qc6CJjYAAAAJ:4TOpqqG69KYC:
-    citations: 35
+    citations: 34
     title: 'Die Evolution der Physik: Von Newton bis zur Quantentheorie'
     year: '1956'
   qc6CJjYAAAAJ:4UtermoNRQAC:
@@ -346,7 +346,7 @@ papers:
     title: 'Einstein, the Man and His Achievement: A Series of Broadcast Talks'
     year: '1967'
   qc6CJjYAAAAJ:5-tCjTwfAdEC:
-    citations: 457
+    citations: 460
     title: "Die Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:5Hlrm_bZEgcC:
@@ -358,7 +358,7 @@ papers:
     title: 'Albert Einstein] to Hendrik A. Lorentz: Letter, 1 Jan 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:5LPo_wSKItgC:
-    citations: 110
+    citations: 111
     title: "Bemerkung zu der Arbeit von A. Friedmann \u201E\xDCber die Kr\xFCmmung des Raumes \u201C"
     year: '1922'
   qc6CJjYAAAAJ:5McdzzY_mmwC:
@@ -390,11 +390,11 @@ papers:
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10399
+    citations: 10479
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
-    citations: 215
+    citations: 216
     title: Unified field theory of gravitation and electricity
     year: '1925'
   qc6CJjYAAAAJ:5rMqqAh47xYC:
@@ -418,7 +418,7 @@ papers:
     title: Refrigeration
     year: '1927'
   qc6CJjYAAAAJ:6DS7WFnF4J4C:
-    citations: 138
+    citations: 140
     title: Koniglich Preussische Akademie der Wissenschaften
     year: '1983'
   qc6CJjYAAAAJ:6Dd5luMImnEC:
@@ -438,7 +438,7 @@ papers:
     title: "Conceptos, ambientes de aprendizaje:\xBF c\xF3mo aprendemos los humanos en diferentes contextos? Waleska Aldana Segura"
     year: Unknown Year
   qc6CJjYAAAAJ:6ftYtcnYaCAC:
-    citations: 339
+    citations: 342
     title: Ather and Relativitatstheorie. J
     year: '1920'
   qc6CJjYAAAAJ:6gD0efnhv6MC:
@@ -458,7 +458,7 @@ papers:
     title: "Bietet die feldtheorie M\xF6glichkeiten f\xFCr die L\xF6sung des Quantenproblems?"
     year: '1923'
   qc6CJjYAAAAJ:7DJsn6tmoAwC:
-    citations: 326
+    citations: 329
     title: "\xC4ther und Relativit\xE4ts-theorie"
     year: '1920'
   qc6CJjYAAAAJ:7DTIKO_nxaIC:
@@ -506,7 +506,7 @@ papers:
     title: 'Albert Einstein] to Johannes Stark: Letter, 17 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:8AbLer7MMksC:
-    citations: 58
+    citations: 59
     title: 'The Collected Papers of Albert Einstein, Vol. 5: The Swiss Years: Correspondence, 1902-1914'
     year: '1995'
   qc6CJjYAAAAJ:8NHCvSvNRCIC:
@@ -546,7 +546,7 @@ papers:
     title: "Bemerkung zu der Arbeit von D. Mirimanoff \u201E\xDCber die Grundgleichungen\u2026\u201D \uFE01"
     year: '1909'
   qc6CJjYAAAAJ:8k81kl-MbHgC:
-    citations: 377
+    citations: 378
     title: Essays in science
     year: '2011'
   qc6CJjYAAAAJ:8moDcb_GFzgC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4555
+    citations: 4556
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -578,7 +578,7 @@ papers:
     title: "Riemann\u2010Geometrie mit Aufrechterhaltung des Begriffes des Fernparallelismus"
     year: '1928'
   qc6CJjYAAAAJ:9N3KX2BFTccC:
-    citations: 100
+    citations: 101
     title: Elementare Uberlegungen zur Interpretation der Grundlagen der Quanten-Mechanik
     year: '1953'
   qc6CJjYAAAAJ:9PbDelcLwNgC:
@@ -654,7 +654,7 @@ papers:
     title: La relativit# a speciale
     year: '1920'
   qc6CJjYAAAAJ:AVQCy-ZCKIsC:
-    citations: 112
+    citations: 113
     title: "Planck\u2019s theory of radiation and the theory of specific heat"
     year: '1907'
   qc6CJjYAAAAJ:AYaE08C4-t8C:
@@ -710,7 +710,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 restreinte et g\xE9n\xE9rale"
     year: '1990'
   qc6CJjYAAAAJ:BW2nPTmhBn4C:
-    citations: 293
+    citations: 294
     title: "\xDCber die im elektromagnetischen Felde auf ruhende K\xF6rper ausge\xFCbten ponderomotorischen Kr\xE4fte"
     year: '1908'
   qc6CJjYAAAAJ:BbFSz4cl-9EC:
@@ -718,7 +718,7 @@ papers:
     title: VI. GRAVITATIONAL WAVES
     year: '1979'
   qc6CJjYAAAAJ:BjLbhSWBl98C:
-    citations: 219
+    citations: 224
     title: "Experimental proof of the existence of Amp\xE8re's molecular currents"
     year: '1915'
   qc6CJjYAAAAJ:BnRbUGEozz8C:
@@ -766,7 +766,7 @@ papers:
     title: 'Albert Einstein] to Paul Seippel: Letter, 19 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:CLQ-NLsb8zAC:
-    citations: 3151
+    citations: 3158
     title: Ideas and Opinions
     year: '1954'
   qc6CJjYAAAAJ:COU-sansr_wC:
@@ -774,7 +774,7 @@ papers:
     title: "Elie Cartan-Albert Einstein: lettres sur le parall\xE9lisme absolu 1929-1932"
     year: '1979'
   qc6CJjYAAAAJ:CQX_Vi8q7s0C:
-    citations: 1958
+    citations: 1961
     title: Introduction Einstein's Relativity
     year: '1992'
   qc6CJjYAAAAJ:CRQ797xmLJIC:
@@ -814,7 +814,7 @@ papers:
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5282
+    citations: 5293
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3001
+    citations: 3044
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -898,7 +898,7 @@ papers:
     title: Kreative Methoden 239 Kindern in Deutsehland lebensweltliche Erfahrungen von politischen Er
     year: Unknown Year
   qc6CJjYAAAAJ:E2bRg1zSkIsC:
-    citations: 286
+    citations: 288
     title: A teoria da relatividade especial e geral
     year: '2003'
   qc6CJjYAAAAJ:E2dP09oujfMC:
@@ -938,7 +938,7 @@ papers:
     title: 'Albert Einstein] to Romain Rolland: Letter, 22 Mar 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:EYYDruWGBe4C:
-    citations: 226
+    citations: 227
     title: "The Collected Papers of Albert Einstein, Vol. 2, The Swiss Years: Writings, 1900\u20131909 (English Translation Supplement)"
     year: '1989'
   qc6CJjYAAAAJ:Ecsxi449JjsC:
@@ -946,7 +946,7 @@ papers:
     title: "Sur le probl\xE8me de la formation de la personnalit\xE9 cr\xE9atrice d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:Ei5r6KrKXVQC:
-    citations: 1510
+    citations: 1513
     title: "Theorie der Opaleszenz von homogenen Fl\xFCssigkeiten und Fl\xFCssigkeitsgemischen in der N\xE4he des kritischen Zustandes"
     year: '2006'
   qc6CJjYAAAAJ:EpJ50YjRFhcC:
@@ -986,7 +986,7 @@ papers:
     title: 'Einstein: Science and Religion'
     year: Unknown Year
   qc6CJjYAAAAJ:FKYJxdYMdFIC:
-    citations: 996
+    citations: 999
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:FKzTm0Bp8ZYC:
@@ -1010,11 +1010,11 @@ papers:
     title: Impact of Science on the Development of Pacifism, before 9 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:FTNwVkz-CAMC:
-    citations: 80
+    citations: 81
     title: Outline of a generalized theory of relativity and of a theory of gravitation
     year: '1913'
   qc6CJjYAAAAJ:FV77Gu53xKkC:
-    citations: 122
+    citations: 123
     title: the Theory of Gravitation
     year: '1974'
   qc6CJjYAAAAJ:FcH-RsB9iB0C:
@@ -1062,7 +1062,7 @@ papers:
     title: Systematische Untersuchung fiber kompatible Feldgleichungen, welche von einem Riemannschen Raum mit Fernparallelismus gesetzt werden k6nnen
     year: '1931'
   qc6CJjYAAAAJ:G36d5HCDkJYC:
-    citations: 215
+    citations: 216
     title: Remarks on Bertrand Russell's theory of knowledge
     year: '1946'
   qc6CJjYAAAAJ:GCDlZl827dEC:
@@ -1078,7 +1078,7 @@ papers:
     title: 'HA Lorentz: His Creative Genius and His Personality'
     year: '1953'
   qc6CJjYAAAAJ:GJVTs2krol4C:
-    citations: 136
+    citations: 137
     title: "Theoretische bemerkungen \xFCber die brownsche bewegung"
     year: '2010'
   qc6CJjYAAAAJ:GO2DTSf4MZMC:
@@ -1118,11 +1118,11 @@ papers:
     title: 'Zitate Aus Mein Weltbild: Sieben Radierungen Von Terry Haass'
     year: '1975'
   qc6CJjYAAAAJ:Gpwnp1kGG20C:
-    citations: 257
+    citations: 258
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3063
+    citations: 3082
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1154,7 +1154,7 @@ papers:
     title: Science Fiction and Fantasy
     year: '1980'
   qc6CJjYAAAAJ:H4IpxOyCX80C:
-    citations: 178
+    citations: 179
     title: "L'\xE9volution des id\xE9es en physique"
     year: '1963'
   qc6CJjYAAAAJ:HKviVsUxM5wC:
@@ -1166,7 +1166,7 @@ papers:
     title: Vincenzo Bellini
     year: '1935'
   qc6CJjYAAAAJ:HPvNdXBGwkEC:
-    citations: 12
+    citations: 13
     title: Electrodynamic Movement of Fluid Metals Particularly for Refrigerating Machines
     year: '1928'
   qc6CJjYAAAAJ:HaiYZdWvYCYC:
@@ -1178,11 +1178,11 @@ papers:
     title: Riemann-Metrik mit Aufrechterhaltung des Begriffes der Fern-parallelismus, Preuss
     year: '1928'
   qc6CJjYAAAAJ:HklM7qHXWrUC:
-    citations: 457
+    citations: 460
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
-    citations: 21475
+    citations: 21587
     title: Uber einen die Erzeugung und Verwandlung des Lichtes betreffenden heurischen Gesichtpunkt
     year: '1905'
   qc6CJjYAAAAJ:HtEfBTGE9r8C:
@@ -1206,11 +1206,11 @@ papers:
     title: Zur Abwehr
     year: '1921'
   qc6CJjYAAAAJ:I9gX6wnfuA8C:
-    citations: 329
+    citations: 332
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3925
+    citations: 3926
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
@@ -1226,7 +1226,7 @@ papers:
     title: Sehallausbreitung in teilweise disseziierten Gasen.
     year: '1920'
   qc6CJjYAAAAJ:IWHjjKOFINEC:
-    citations: 797
+    citations: 800
     title: Cosmological considerations on the general theory of relativity
     year: '1986'
   qc6CJjYAAAAJ:IZKZNMMMWs0C:
@@ -1246,7 +1246,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 4, The Swiss years: writings, 1912-1914 [English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:IjCSPb-OGe4C:
-    citations: 1397
+    citations: 1401
     title: The gravitational equations and the problem of motion
     year: '1938'
   qc6CJjYAAAAJ:IkxDsZK-5NQC:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6474
+    citations: 6485
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1266,7 +1266,7 @@ papers:
     title: "Berichtigung zur Abhandlung:\u201E\xDCber die elektromagnetischen Grundgleichungen f\xFCr bewegte K\xF6rper\u201D \uFE01"
     year: '1908'
   qc6CJjYAAAAJ:J-pR_7NvFogC:
-    citations: 845
+    citations: 847
     title: 'The Swiss Years: Writings, 1914-1917'
     year: '1996'
   qc6CJjYAAAAJ:J4wmHkHhN-kC:
@@ -1286,11 +1286,11 @@ papers:
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2442
+    citations: 2453
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
-    citations: 137
+    citations: 138
     title: Warum Krieg?
     year: '1972'
   qc6CJjYAAAAJ:JjPkQosUWiAC:
@@ -1310,11 +1310,11 @@ papers:
     title: "Briefe zur Wellenmechanik: Schr\xF6dinger, Planck, Einstein, Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:K3LRdlH-MEoC:
-    citations: 81
+    citations: 82
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 740
+    citations: 752
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1342,7 +1342,7 @@ papers:
     title: Why socialism?
     year: '1951'
   qc6CJjYAAAAJ:KOc9rAu6-V4C:
-    citations: 399
+    citations: 404
     title: letter to Max Born
     year: '1926'
   qc6CJjYAAAAJ:KQ7zX_ltr48C:
@@ -1370,7 +1370,7 @@ papers:
     title: "Die spezielle Relativit\xE4sthorie"
     year: '1912'
   qc6CJjYAAAAJ:KlAtU1dfN6UC:
-    citations: 450
+    citations: 453
     title: On the Influence of Gravitation on the Propagation of Light
     year: '1911'
   qc6CJjYAAAAJ:KqnX2w3egDsC:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6759
+    citations: 6796
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1406,7 +1406,7 @@ papers:
     title: Briefwechsel 1916-1955
     year: '1972'
   qc6CJjYAAAAJ:LGA7_l5-FVwC:
-    citations: 129
+    citations: 130
     title: Preussiche Akademie der Wissenchaften Berlin
     year: '1927'
   qc6CJjYAAAAJ:LIyjJRbbAUMC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3122
+    citations: 3151
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5374
+    citations: 5397
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1506,7 +1506,7 @@ papers:
     title: Two-body problem in general relativity theory
     year: '1936'
   qc6CJjYAAAAJ:M3ejUd6NZC8C:
-    citations: 489
+    citations: 490
     title: "Prinzipielles zur allgemeinen Relativit\xE4tstheorie"
     year: '1918'
   qc6CJjYAAAAJ:M8meJADSprsC:
@@ -1514,7 +1514,7 @@ papers:
     title: El significado de la relatividad
     year: '1971'
   qc6CJjYAAAAJ:MDX3w3dAD3YC:
-    citations: 914
+    citations: 917
     title: Zum quantensatz von Sommerfeld und Epstein
     year: '1917'
   qc6CJjYAAAAJ:MGPUR4WVBMEC:
@@ -1522,11 +1522,11 @@ papers:
     title: "Notiz zu der Arbeit von A. Friedmann \u201E\xDCber die Kr\xFCmmung des Raumes \u201C"
     year: '1923'
   qc6CJjYAAAAJ:ML0RJ9NH7IQC:
-    citations: 327
+    citations: 329
     title: New possibility for a unified field theory of gravitation and electricity
     year: '1928'
   qc6CJjYAAAAJ:MNNNGtAgD4EC:
-    citations: 342
+    citations: 343
     title: "Bemerkung zu dem Gesetz von E\xF6tv\xF6s"
     year: '1911'
   qc6CJjYAAAAJ:MTuJV9umhWMC:
@@ -1538,7 +1538,7 @@ papers:
     title: "La corr\xE9lation de l'empirique et du rationnel dans l'oeuvre scientifique d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:MXK_kJrjxJIC:
-    citations: 639
+    citations: 641
     title: On a stationary system with spherical symmetry consisting of many gravitating masses
     year: '1939'
   qc6CJjYAAAAJ:MqTxh1vmwXEC:
@@ -1558,7 +1558,7 @@ papers:
     title: Physikalische Grundlagen einer Gravitationstheorie
     year: '1914'
   qc6CJjYAAAAJ:NAGhd4NKCV8C:
-    citations: 144
+    citations: 146
     title: "K\xF6niglich Preu\xDFische Akademie der Wissenschaften Berlin"
     year: '1916'
   qc6CJjYAAAAJ:NGoJ35N4lvkC:
@@ -1566,11 +1566,11 @@ papers:
     title: "Bemerkungen zu P. Harzers Abhandlung \xAB\xDCber die Mitf\xFChrung des Lichtes in Glas und die Aberration\xBB(AN 4748)"
     year: '1914'
   qc6CJjYAAAAJ:NJ774b8OgUMC:
-    citations: 24
+    citations: 25
     title: The advent of the quantum theory
     year: '1951'
   qc6CJjYAAAAJ:NM66qo_NnlUC:
-    citations: 1029
+    citations: 1032
     title: 'The Collected Papers of Albert Einstein: English Translation'
     year: '1989'
   qc6CJjYAAAAJ:NMxIlDl6LWMC:
@@ -1606,7 +1606,7 @@ papers:
     title: Zum Ehrenfestschen Paradoxon
     year: '1910'
   qc6CJjYAAAAJ:NnTm98qLMbgC:
-    citations: 586
+    citations: 588
     title: Mein weltbild
     year: '1934'
   qc6CJjYAAAAJ:Nnq8S6OXqDYC:
@@ -1622,7 +1622,7 @@ papers:
     title: Sidelights on Relativity,... I. Ether and Relativity. II. Geometry and Experience
     year: '1922'
   qc6CJjYAAAAJ:Nufq_to8ts0C:
-    citations: 199
+    citations: 201
     title: "Das Prinzip von der Erhaltung der Schwerpunktsbewegung und die Tr\xE4gheit der Energie"
     year: '1906'
   qc6CJjYAAAAJ:Nw5Pwe77XXAC:
@@ -1630,7 +1630,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm Wien: Letter, 17 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:Nw_I7GeUguwC:
-    citations: 167
+    citations: 168
     title: "Zur allgemeinen molekularen Theorie der W\xE4rme"
     year: '1904'
   qc6CJjYAAAAJ:NzUpm4bhSXQC:
@@ -1638,11 +1638,11 @@ papers:
     title: "Die Quantentheorie der spezifischen W\xE4rme"
     year: '1967'
   qc6CJjYAAAAJ:O0MA3yP7Y3UC:
-    citations: 306
+    citations: 307
     title: 'The Collected Papers of Albert Einstein, Volume 8: The Berlin Years: Correspondence, 1914-1918.'
     year: '1998'
   qc6CJjYAAAAJ:O3NaXMp0MMsC:
-    citations: 137
+    citations: 138
     title: How I created the theory of relativity
     year: '1982'
   qc6CJjYAAAAJ:OBae9N4Z9bMC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8138
+    citations: 8216
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1670,7 +1670,7 @@ papers:
     title: On the relativity problem
     year: '2007'
   qc6CJjYAAAAJ:OVe_t5h5bhEC:
-    citations: 272
+    citations: 274
     title: "Mi visi\xF3n del mundo"
     year: '1985'
   qc6CJjYAAAAJ:Oi-j_DTgP3cC:
@@ -1694,7 +1694,7 @@ papers:
     title: On German Literature for Viola Da Gamba in the 16th and 17th Centuries
     year: '1977'
   qc6CJjYAAAAJ:P1qO8dLd1z8C:
-    citations: 271
+    citations: 272
     title: The Photoelectric Effect
     year: '1905'
   qc6CJjYAAAAJ:P9oYG7HA76QC:
@@ -1734,7 +1734,7 @@ papers:
     title: 'Wissenschaftlicher Briefwechsel Mit Bohr, Einstein, Heisenberg, Ua: Scientific Correspondence with Bohr, Einstein, Heisenberg, Ao Volume 1: 1919-1929. 1919-1929'
     year: '1979'
   qc6CJjYAAAAJ:Q7hiZQKJ-pAC:
-    citations: 222
+    citations: 223
     title: 'Cosmic religion: with other opinions and aphorisms'
     year: '1931'
   qc6CJjYAAAAJ:Q9ss7R9eeXsC:
@@ -1758,7 +1758,7 @@ papers:
     title: "Cien a\xF1os de relatividad: Los art\xEDculos de Albert Einstein de 1905 y 1906"
     year: '2004'
   qc6CJjYAAAAJ:QIV2ME_5wuYC:
-    citations: 750
+    citations: 754
     title: Does the inertia of a body depend upon its energy-content?
     year: '1905'
   qc6CJjYAAAAJ:QKtdBID3u5MC:
@@ -1830,7 +1830,7 @@ papers:
     title: "Physikalische Gesellschaft zu Berlin und Deutsche Gesellschaft f\xFCr technische Physik. Berlin, 17. Juli 1931"
     year: '2006'
   qc6CJjYAAAAJ:R3hNpaxXUhUC:
-    citations: 290
+    citations: 291
     title: "Lettres \xE0 Maurice Solovine"
     year: '1956'
   qc6CJjYAAAAJ:R6aXIXmdpM0C:
@@ -1854,7 +1854,7 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4509
+    citations: 4523
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
@@ -1878,7 +1878,7 @@ papers:
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7644
+    citations: 7705
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2018
+    citations: 2023
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1962,7 +1962,7 @@ papers:
     title: The new field theory
     year: '1929'
   qc6CJjYAAAAJ:TIZ-Mc8IlK0C:
-    citations: 1104
+    citations: 1105
     title: On the method of theoretical physics
     year: '1934'
   qc6CJjYAAAAJ:TKTY8N1AUUAC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9278
+    citations: 9323
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2006,7 +2006,7 @@ papers:
     title: Bemerkung zu E. Gehrckes Notiz
     year: '1918'
   qc6CJjYAAAAJ:UC7Jl7-kV0oC:
-    citations: 161
+    citations: 162
     title: Scientific papers presented to Max Born
     year: '1953'
   qc6CJjYAAAAJ:UEa65astgjsC:
@@ -2018,7 +2018,7 @@ papers:
     title: 'Albert Einstein] to Otto Naumann: Letter, 7 Dec 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:ULOm3_A8WrAC:
-    citations: 319
+    citations: 320
     title: On the motion of particles in general relativity theory
     year: '1949'
   qc6CJjYAAAAJ:UO8fSLLLPykC:
@@ -2038,7 +2038,7 @@ papers:
     title: "Bemerkung zu Herrn Schr\xF6dingers Notiz\" \xDCber ein L\xF6sungssystem der allgemein kovarianten Gravitationsgleichungen\", 3 M\xE4r 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:UY3hNwcQ290C:
-    citations: 25
+    citations: 26
     title: "La teor\xEDa de la relatividad: Sus or\xEDgenes e impacto sobre el pensamiento moderno"
     year: '1983'
   qc6CJjYAAAAJ:UbXTy9l1WKIC:
@@ -2050,7 +2050,7 @@ papers:
     title: "Sobre la electrodin\xE1mica de los cuerpos en movimiento"
     year: '2005'
   qc6CJjYAAAAJ:UebtZRa9Y70C:
-    citations: 1017
+    citations: 1024
     title: "\xDCber die spezielle und die allgemeine Relativit\xE4tstheorie"
     year: '2008'
   qc6CJjYAAAAJ:UlRcoTO8nVoC:
@@ -2162,7 +2162,7 @@ papers:
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1606
+    citations: 1617
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2174,7 +2174,7 @@ papers:
     title: La discussion Einstein-Bohr.
     year: Unknown Year
   qc6CJjYAAAAJ:WF5omc3nYNoC:
-    citations: 1052
+    citations: 1059
     title: On gravitational waves
     year: '1937'
   qc6CJjYAAAAJ:WIVIxizkzXoC:
@@ -2186,7 +2186,7 @@ papers:
     title: "Relativit\xE4t und gravitation. Erwiderung auf eine bemerkung von M. Abraham"
     year: '1912'
   qc6CJjYAAAAJ:WM2K3OHRCGMC:
-    citations: 218
+    citations: 219
     title: "Notas autobiogr\xE1ficas"
     year: '2003'
   qc6CJjYAAAAJ:WMtz-WDmgKQC:
@@ -2218,7 +2218,7 @@ papers:
     title: Emission and absorption of radiation according to the quantum theory
     year: '1916'
   qc6CJjYAAAAJ:WtgKeONp1i0C:
-    citations: 184
+    citations: 185
     title: "Lettres a Maurice Solovine: reprod. en facsimil\xE9 et trad. en fran\xE7aise: avec une introduction et trois photographies"
     year: '1956'
   qc6CJjYAAAAJ:WxjA8IQWSGYC:
@@ -2242,7 +2242,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919 april 1920 (hardback)
     year: '2004'
   qc6CJjYAAAAJ:X5QHDg3V9EEC:
-    citations: 5
+    citations: 4
     title: Science and synthesis
     year: '1971'
   qc6CJjYAAAAJ:X5YyAB84Iw4C:
@@ -2274,7 +2274,7 @@ papers:
     title: 'Albert Einstein] to Paul Gruner: Letter, 11 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:XZvG1uL-wj0C:
-    citations: 1152
+    citations: 1153
     title: 'On the method of theoretical physics: The Herbert Spencer lecture, delivered at Oxford 10 June 1933'
     year: '1933'
   qc6CJjYAAAAJ:Xc-mKOjpdrwC:
@@ -2282,11 +2282,11 @@ papers:
     title: Relativistische Physik
     year: Unknown Year
   qc6CJjYAAAAJ:XdYaqolBBq8C:
-    citations: 28
+    citations: 29
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1504
+    citations: 1519
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2302,7 +2302,7 @@ papers:
     title: 'Reise nach Japan Palestine Spanien 6 Oktober 1922-12.3. 23: Various places'
     year: '1923'
   qc6CJjYAAAAJ:XiSMed-E-HIC:
-    citations: 64
+    citations: 65
     title: What I believe
     year: '1956'
   qc6CJjYAAAAJ:Xnn2mF3JXD4C:
@@ -2322,7 +2322,7 @@ papers:
     title: "Research@ FrankfurtSchool in Zeiten der Finanzmarktkrise \u201EA Collection of Working Papers \u201C"
     year: Unknown Year
   qc6CJjYAAAAJ:Y0agIcFmOsQC:
-    citations: 1203
+    citations: 1204
     title: A correction on my work-A new determination of molecular dimensions
     year: '1969'
   qc6CJjYAAAAJ:Y1W0x10ZrwMC:
@@ -2346,7 +2346,7 @@ papers:
     title: Essays in physics
     year: '1950'
   qc6CJjYAAAAJ:YK4ucWkmU_UC:
-    citations: 76
+    citations: 75
     title: 'Albert Einstein, the Human Side: New Glimpses from His Archives'
     year: '1981'
   qc6CJjYAAAAJ:YP-lgzILWVMC:
@@ -2382,7 +2382,7 @@ papers:
     title: Physics, philosophy and scientific progress.
     year: '1950'
   qc6CJjYAAAAJ:YoqGh_aPxy4C:
-    citations: 77
+    citations: 79
     title: The common language of science
     year: '1941'
   qc6CJjYAAAAJ:YpRCXavlr0AC:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2348
+    citations: 2359
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2402,7 +2402,7 @@ papers:
     title: Mi credo humanista
     year: '1991'
   qc6CJjYAAAAJ:ZDu_srLEjN8C:
-    citations: 142
+    citations: 143
     title: Preussische akademie der wissenschaften, Phys-math
     year: '1925'
   qc6CJjYAAAAJ:ZEcFV8kAgqMC:
@@ -2430,7 +2430,7 @@ papers:
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4061
+    citations: 4073
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2442,7 +2442,7 @@ papers:
     title: "Physik und realit\xE4t"
     year: '1936'
   qc6CJjYAAAAJ:ZfRJV9d4-WMC:
-    citations: 96
+    citations: 97
     title: Pourquoi la guerre?
     year: '1933'
   qc6CJjYAAAAJ:ZgPQhQxLujAC:
@@ -2458,7 +2458,7 @@ papers:
     title: 'Relativiteit: speciale en algemene theorie'
     year: '1986'
   qc6CJjYAAAAJ:Zph67rFs4hoC:
-    citations: 395
+    citations: 398
     title: "Grundz\xFCge der Relativit\xE4tstheorie"
     year: '2002'
   qc6CJjYAAAAJ:ZppSRAJs3i8C:
@@ -2494,7 +2494,7 @@ papers:
     title: Gravitational and electromagnetic fields
     year: '1931'
   qc6CJjYAAAAJ:_Re3VWB3Y0AC:
-    citations: 130
+    citations: 131
     title: 'Einstein and the Poet: In Search of the Cosmic Man'
     year: '1983'
   qc6CJjYAAAAJ:_Ybze24A_UAC:
@@ -2518,7 +2518,7 @@ papers:
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
-    citations: 457
+    citations: 460
     title: "Die Relativit\xE4ts-Theorie"
     year: '1911'
   qc6CJjYAAAAJ:a2necdfpwlEC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3773
+    citations: 3785
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,7 +2534,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4318
+    citations: 4325
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
@@ -2562,11 +2562,11 @@ papers:
     title: "Religi\xF3n y ciencia"
     year: '2000'
   qc6CJjYAAAAJ:abG-DnoFyZgC:
-    citations: 285
+    citations: 286
     title: The fundamentals of theoretical physics
     year: '1950'
   qc6CJjYAAAAJ:ace9KxS0p5UC:
-    citations: 286
+    citations: 284
     title: Zur theorie der lichterzeugung und lichtabsorption
     year: '1906'
   qc6CJjYAAAAJ:adHtZc2wMuEC:
@@ -2602,7 +2602,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 26 Nov 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:bCjgOgSFrM0C:
-    citations: 1269
+    citations: 1272
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
@@ -2626,7 +2626,7 @@ papers:
     title: 'Albert Einstein] to Paul Hertz: Letter, 22 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:bUu3lypoyhcC:
-    citations: 821
+    citations: 824
     title: On the quantum theory of radiation
     year: '1972'
   qc6CJjYAAAAJ:bcT4vkklUMwC:
@@ -2634,7 +2634,7 @@ papers:
     title: "Briefe zur Wellenmechanik: Schr\xF6dinger, Planck, Einstein, Lorentz; mit 4 Portr"
     year: '1963'
   qc6CJjYAAAAJ:bczYY1dZPtQC:
-    citations: 91
+    citations: 92
     title: "M\xE9thode pour la d\xE9termination de valeurs statistiques d'observations concernant des grandeurs soumises a des fluctuations irr\xE9guli\xE8res"
     year: '1914'
   qc6CJjYAAAAJ:bf7w-NijnqMC:
@@ -2662,7 +2662,7 @@ papers:
     title: 'The collected papers of Albert Einstein. vol. 9, The Berlin years: correspondence, January 1919-April 1920:[English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:brChLMnLtjYC:
-    citations: 182
+    citations: 183
     title: Relativity Principle and its Consequences in Modern Physics. Collection of Scientific Works, V. 1
     year: '1965'
   qc6CJjYAAAAJ:bsl25C5uMOsC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1545
+    citations: 1549
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7631
+    citations: 7689
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2710,7 +2710,7 @@ papers:
     title: "Die spezielle relativit\xE4tstheorie Einsteins und die logik"
     year: '1924'
   qc6CJjYAAAAJ:cRMvf6lLvU8C:
-    citations: 291
+    citations: 292
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
@@ -2758,7 +2758,7 @@ papers:
     title: "Signification de la relativit\xE9: appendice \xE0 la cinqui\xE8me \xE9dition de\" The meaning of relativity\"(d\xE9cembre 1954). Compl\xE9ments"
     year: '1960'
   qc6CJjYAAAAJ:d4tt_xEv1X8C:
-    citations: 219
+    citations: 220
     title: Lichtgeschwindigkeit und statik des Gravitationsfeldes
     year: '1912'
   qc6CJjYAAAAJ:d6JCS5z0ckYC:
@@ -2782,7 +2782,7 @@ papers:
     title: "Correspondence 1903\u20131955, ed"
     year: '1972'
   qc6CJjYAAAAJ:dTyEYWd-f8wC:
-    citations: 178
+    citations: 179
     title: "L'\xE9volution des id\xE9es en physique: des premiers concepts aux th\xE9ories de la relativit\xE9 et des quanta"
     year: '1948'
   qc6CJjYAAAAJ:dX-nQPao9noC:
@@ -2826,11 +2826,11 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5783
+    citations: 5798
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
-    citations: 29
+    citations: 30
     title: Nichteuklidische Geometrie und Physik
     year: '1925'
   qc6CJjYAAAAJ:eCFM_hdDfssC:
@@ -2842,7 +2842,7 @@ papers:
     title: Besprechungen
     year: '1918'
   qc6CJjYAAAAJ:eJXPG6dFmWUC:
-    citations: 491
+    citations: 493
     title: The theory of relativity
     year: '1996'
   qc6CJjYAAAAJ:eKGuBlYFiu8C:
@@ -2918,7 +2918,7 @@ papers:
     title: 'Albert Einstein] to Kathia Adler: Letter, 20 Feb 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:fLJJVVwU7EQC:
-    citations: 353
+    citations: 354
     title: "Ein einfaches Experiment zum Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1916'
   qc6CJjYAAAAJ:fPk4N6BV_jEC:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3754
+    citations: 3807
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -3002,7 +3002,7 @@ papers:
     title: Electrons et photons
     year: '1928'
   qc6CJjYAAAAJ:h7-KW5G1enMC:
-    citations: 118
+    citations: 119
     title: Induktion und Deduktion in der Physik
     year: '1919'
   qc6CJjYAAAAJ:hB2aVRuWZNwC:
@@ -3010,7 +3010,7 @@ papers:
     title: "Ejn\u0161tejnovskaja teorija otnosite\u013Enosti"
     year: '1972'
   qc6CJjYAAAAJ:hEXC_dOfxuUC:
-    citations: 394
+    citations: 395
     title: Reply to critics
     year: '1949'
   qc6CJjYAAAAJ:hEp1lTclR2YC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5184
+    citations: 5208
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3038,15 +3038,15 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3785
+    citations: 3797
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
-    citations: 346
+    citations: 347
     title: Notiz zu unserer Arbeit
     year: '1915'
   qc6CJjYAAAAJ:hcF2OqvMasEC:
-    citations: 137
+    citations: 138
     title: Warum Krieg?
     year: '1933'
   qc6CJjYAAAAJ:he8YCnfqqkoC:
@@ -3082,7 +3082,7 @@ papers:
     title: 'As it was: the UNESCO Courier December 1951'
     year: '1996'
   qc6CJjYAAAAJ:iH-uZ7U-co4C:
-    citations: 114
+    citations: 115
     title: Knowledge of past and future in quantum mechanics
     year: '1931'
   qc6CJjYAAAAJ:iKmOvsfbmGkC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8693
+    citations: 8747
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4121
+    citations: 4172
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5711
+    citations: 5736
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3190,7 +3190,7 @@ papers:
     title: Hedwig und Max Born
     year: '1916'
   qc6CJjYAAAAJ:kFzFP8IdBVAC:
-    citations: 377
+    citations: 378
     title: Einstein's essays in science
     year: '2009'
   qc6CJjYAAAAJ:kGbpvR7Ecy8C:
@@ -3214,7 +3214,7 @@ papers:
     title: "L\u2019agopuntura in campo oncologico. Riflessioni ed esperienze dell\u2019ultimo decennio."
     year: Unknown Year
   qc6CJjYAAAAJ:k_IJM867U9cC:
-    citations: 119
+    citations: 120
     title: "Relativit\xE4tstheorie in mathematischer Behandlung"
     year: '1925'
   qc6CJjYAAAAJ:kbDB7uaqCfAC:
@@ -3222,7 +3222,7 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 6865
+    citations: 6918
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
@@ -3234,11 +3234,11 @@ papers:
     title: Court Expert Opinion in the Matter of Signal Co. vs. Atlas Works, ca. 3 Dec 1921
     year: Unknown Year
   qc6CJjYAAAAJ:l6Q3WhenKVUC:
-    citations: 590
+    citations: 592
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:l7t_Zn2s7bgC:
-    citations: 651
+    citations: 656
     title: Ether and the Theory of Relativity
     year: '2007'
   qc6CJjYAAAAJ:lAj_JhtUatoC:
@@ -3266,7 +3266,7 @@ papers:
     title: "Grundgedanken und Probleme der Relativit\xE4tstheorie"
     year: '1923'
   qc6CJjYAAAAJ:lLPirIASiZEC:
-    citations: 853
+    citations: 855
     title: "The Collected Papers of Albert Einstein, Volume 15 (Translation Supplement): The Berlin Years: Writings & Correspondence, June 1925\u2013May 1927"
     year: '2018'
   qc6CJjYAAAAJ:lOG7zRu2uA8C:
@@ -3306,7 +3306,7 @@ papers:
     title: A new form of the general relativistic field equations
     year: '1955'
   qc6CJjYAAAAJ:mN77zE6YZBUC:
-    citations: 725
+    citations: 729
     title: Ueber spezielle und allgemeine Relativitaetstheorie, 127
     year: '1969'
   qc6CJjYAAAAJ:mNm_27jwclsC:
@@ -3342,7 +3342,7 @@ papers:
     title: Albert Einstein] to Michele Besso:[A second] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:mnAcAzq93VMC:
-    citations: 121
+    citations: 120
     title: Riemannian Geometry with Maintaining the Notion of distant parallelism
     year: '1928'
   qc6CJjYAAAAJ:mpaOjDK6XBIC:
@@ -3390,7 +3390,7 @@ papers:
     title: Einstein on Peace, ed. Otto Nathan and Heinz Norden
     year: '1960'
   qc6CJjYAAAAJ:njp6nI0QjqAC:
-    citations: 455
+    citations: 456
     title: "\xDCber die Entwickelung unserer Anschauungen \xFCber das Wesen und die Konstitution der Strahlung"
     year: '1909'
   qc6CJjYAAAAJ:nlKf13ul9_IC:
@@ -3410,7 +3410,7 @@ papers:
     title: Os fundamentos da teoria da relatividade geral
     year: '1916'
   qc6CJjYAAAAJ:ntg98fmFLVcC:
-    citations: 401
+    citations: 404
     title: The elementary theory of the Brownian motion
     year: '1908'
   qc6CJjYAAAAJ:nvAonm6-wpUC:
@@ -3418,11 +3418,11 @@ papers:
     title: "Neue Zugangswege zur Entw\xF6hnungs-behandlung in Sachsen, Sachsen-Anhalt und Th\xFCringen"
     year: Unknown Year
   qc6CJjYAAAAJ:nwfoItMF7hMC:
-    citations: 438
+    citations: 441
     title: "Teor\u0131a cu\xE1ntica de gases ideales monoat\xF3micos, Sitz"
     year: '1924'
   qc6CJjYAAAAJ:o4Qvs5Y5TLQC:
-    citations: 990
+    citations: 993
     title: The Early Years 1879-1902
     year: '1987'
   qc6CJjYAAAAJ:o9ULDYDKYbIC:
@@ -3434,7 +3434,7 @@ papers:
     title: Eine neue formale Deutung der Maxwellschen Feldgleichungen der Elektrodynamik
     year: '1916'
   qc6CJjYAAAAJ:oFKsPyNwwpYC:
-    citations: 84
+    citations: 85
     title: "\xDCber die M\xF6glichkeit einer neuen Pr\xFCfung des Relativit\xE4tsprinzips"
     year: '2006'
   qc6CJjYAAAAJ:oFWWKr2Zb18C:
@@ -3454,7 +3454,7 @@ papers:
     title: 'Le pouvoir nu: propos sur la guerre et la paix, 1914-1955'
     year: '1991'
   qc6CJjYAAAAJ:oYLFIHfuHKwC:
-    citations: 245
+    citations: 247
     title: "Zum kosmologischen Problem der allgemeinen Relativit\xE4tstheorie"
     year: '1931'
   qc6CJjYAAAAJ:oea97a5D_h0C:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20427
+    citations: 20494
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3478,7 +3478,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 6 Jul 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:oursBaop5wYC:
-    citations: 1503
+    citations: 1507
     title: Zur theorie der brownschen bewegung
     year: '1906'
   qc6CJjYAAAAJ:oy0z8GdgWhYC:
@@ -3574,7 +3574,7 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2180
+    citations: 2195
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
@@ -3590,11 +3590,11 @@ papers:
     title: "En busca del eslab\xF3n perdido entre educaci\xF3n y desarrollo: desaf\xEDos y retos para la universidad en Am\xE9rica Latina y el Caribe"
     year: Unknown Year
   qc6CJjYAAAAJ:qjMakFHDy7sC:
-    citations: 3299
+    citations: 3313
     title: On the electrodynamics of moving bodies
     year: '1905'
   qc6CJjYAAAAJ:qsWQJNntlusC:
-    citations: 3205
+    citations: 3212
     title: Ideas and opinions
     year: '1995'
   qc6CJjYAAAAJ:quBVm8e4N6QC:
@@ -3602,11 +3602,11 @@ papers:
     title: "Zu Kaluzas Theorie des Zusammenhanges von Gravitation und Elektrizit\xE4t. Zweite Mitteilung"
     year: '2006'
   qc6CJjYAAAAJ:qxL8FJ1GzNcC:
-    citations: 613
+    citations: 615
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27651
+    citations: 27734
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3642,7 +3642,7 @@ papers:
     title: "A evolu\xE7\xE3o da f\xEDsica: o desenvolvimento das ideias desde os primitivos conceitos at\xE9 \xE0 Relatividade e aos Quanta"
     year: '1939'
   qc6CJjYAAAAJ:rFyVMFCKTwsC:
-    citations: 328
+    citations: 331
     title: Elementare Theorie der Brownschen) Bewegung
     year: '1908'
   qc6CJjYAAAAJ:rKOGDx9nJ1EC:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3001
+    citations: 3044
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4838
+    citations: 4856
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3730,11 +3730,11 @@ papers:
     title: "\xDCber die gegenw\xE4rtige Krise der theoretischen Physik"
     year: '1922'
   qc6CJjYAAAAJ:sJK75vZXtG0C:
-    citations: 205
+    citations: 207
     title: Mis ideas y opiniones
     year: '2011'
   qc6CJjYAAAAJ:sNmaIFBj_lkC:
-    citations: 8
+    citations: 6
     title: Compton Effect
     year: '1966'
   qc6CJjYAAAAJ:sYWh8IhQ1GMC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4294
+    citations: 4342
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3782,7 +3782,7 @@ papers:
     title: Uproar in the Lecture Hall, 13 Feb 1920
     year: Unknown Year
   qc6CJjYAAAAJ:t6usbXjVLHcC:
-    citations: 144
+    citations: 143
     title: The human side
     year: '1979'
   qc6CJjYAAAAJ:t7izwRedFcYC:
@@ -3838,7 +3838,7 @@ papers:
     title: "equations of motion\uFB01 one therefore could not doubt that the laws of nature are"
     year: '1907'
   qc6CJjYAAAAJ:uCYQzKCmtZwC:
-    citations: 1226
+    citations: 1228
     title: Out of my later years
     year: '1950'
   qc6CJjYAAAAJ:uH1VZYVfkoQC:
@@ -3866,7 +3866,7 @@ papers:
     title: "Bemerkung zu meiner Arbeit \u201CZur allgemeinen Relativit\xE4tstheorie\u201D"
     year: '2006'
   qc6CJjYAAAAJ:ufrVoPGSRksC:
-    citations: 643
+    citations: 644
     title: The influence of the expansion of space on the gravitation fields surrounding the individual stars
     year: '1945'
   qc6CJjYAAAAJ:uh8FjILnQOkC:
@@ -3930,7 +3930,7 @@ papers:
     title: On the five-dimensional representation of gravitation and electricity
     year: '1941'
   qc6CJjYAAAAJ:viPVbuMW504C:
-    citations: 399
+    citations: 401
     title: Collected Scientific Works
     year: '1965'
   qc6CJjYAAAAJ:viTTOddtVMkC:
@@ -3970,7 +3970,7 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3243
+    citations: 3272
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
@@ -3990,11 +3990,11 @@ papers:
     title: On a generalization of Kaluza's theory of electricity
     year: '1938'
   qc6CJjYAAAAJ:w7CBUyPWg-0C:
-    citations: 10
+    citations: 9
     title: Eine ableitung des theorems von Jacobi
     year: '1917'
   qc6CJjYAAAAJ:wEOyVsangm4C:
-    citations: 746
+    citations: 747
     title: Philosopher-Scientist, ed
     year: '1970'
   qc6CJjYAAAAJ:wGzT3bKASkAC:
@@ -4058,7 +4058,7 @@ papers:
     title: "Briefe zur Wellenmechanik [von][Erwin] Schr\xF6dinger,[Max] Planck,[ALbert] Einstein und [Hendrik Antoon] Lorentz"
     year: '1963'
   qc6CJjYAAAAJ:xvKSgulxyWUC:
-    citations: 793
+    citations: 795
     title: 'The collected papers of Albert Einstein: writings, 1912-1914. The Swiss years'
     year: '1966'
   qc6CJjYAAAAJ:xwIxJehhd2UC:
@@ -4078,7 +4078,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1334
+    citations: 1340
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:
@@ -4094,7 +4094,7 @@ papers:
     title: A generalized theory of gravitation
     year: '1948'
   qc6CJjYAAAAJ:yNohvu9kXXYC:
-    citations: 440
+    citations: 443
     title: Quantentheorie des idealen einatomigen Gases, Sitzber
     year: '1924'
   qc6CJjYAAAAJ:yS0fcbgecPsC:
@@ -4102,7 +4102,7 @@ papers:
     title: Education for independent thought
     year: '1952'
   qc6CJjYAAAAJ:yXZqsUWzai8C:
-    citations: 142
+    citations: 144
     title: "Koniglich Preu\u03B2ische Akademie der Wissenschaften"
     year: '1916'
   qc6CJjYAAAAJ:yZoBfgUKqwcC:
@@ -4122,7 +4122,7 @@ papers:
     title: "Z Einsteinovy Pra\u017Esk\xE9 korespondence"
     year: '1962'
   qc6CJjYAAAAJ:z2g7kDSNNyoC:
-    citations: 22
+    citations: 23
     title: "Eine neue elektrostatische Methode zur Messung kleiner Elektrizit\xE4tsmengen"
     year: '1908'
   qc6CJjYAAAAJ:zCpYd49hD24C:
@@ -4174,6 +4174,6 @@ papers:
     title: "Albert Einstein] to Rudolf F\xF6rster: Letter, 17 Jan 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:zxzvZ9-XIW8C:
-    citations: 76
+    citations: 75
     title: Albert Einstein, the human side
     year: '2013'

--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-05-13'
+  last_updated: '2026-05-15'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2545
+    citations: 2548
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -30,7 +30,7 @@ papers:
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8325
+    citations: 8347
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -70,7 +70,7 @@ papers:
     title: Elementary Considerations on the Interpretation of the Foundations of Quantum Mechanics
     year: '2011'
   qc6CJjYAAAAJ:0EnyYjriUFMC:
-    citations: 1201
+    citations: 1205
     title: 'The Born Einstein Letters: correspondence between Albert Einstein and Max and Hedwig Born from 1916 to 1955 with commentaries by Max Born. Translated by Irene Born'
     year: '1971'
   qc6CJjYAAAAJ:0KZCP5UExFUC:
@@ -82,7 +82,7 @@ papers:
     title: "Zeitungen gleichen Sparb\xFCchern: dass sie voll geschrieben sind, bedeutet noch nichts."
     year: Unknown Year
   qc6CJjYAAAAJ:0SnApaDgcCoC:
-    citations: 66
+    citations: 69
     title: podolsky B and Rosen N 1935 Phys
     year: Unknown Year
   qc6CJjYAAAAJ:0UEtxawf5sEC:
@@ -110,7 +110,7 @@ papers:
     title: Correspondencia con Michele Besso:(1903-1955)
     year: '1994'
   qc6CJjYAAAAJ:0t1ZDozeHsAC:
-    citations: 5
+    citations: 6
     title: Essays in science
     year: '1954'
   qc6CJjYAAAAJ:0wD49__q8KEC:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1530
+    citations: 1532
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -210,7 +210,7 @@ papers:
     title: 'Albert Einstein] to Conrad Habicht: Letter, 15 Apr 1904'
     year: Unknown Year
   qc6CJjYAAAAJ:2ZctHUgIzyAC:
-    citations: 468
+    citations: 469
     title: "La g\xE9om\xE9trie et l'exp\xE9rience"
     year: '1921'
   qc6CJjYAAAAJ:2hfDYGh-f1UC:
@@ -258,7 +258,7 @@ papers:
     title: Relativity in Newtonian Mechanics and the Michelson-Morley Experiment
     year: Unknown Year
   qc6CJjYAAAAJ:3vbIHxFL9FgC:
-    citations: 347
+    citations: 348
     title: "Experimenteller Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1915'
   qc6CJjYAAAAJ:3z7foVzkq2cC:
@@ -270,7 +270,7 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7132
+    citations: 7137
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
@@ -290,7 +290,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 2972
+    citations: 2975
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
@@ -390,7 +390,7 @@ papers:
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10479
+    citations: 10502
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
@@ -418,7 +418,7 @@ papers:
     title: Refrigeration
     year: '1927'
   qc6CJjYAAAAJ:6DS7WFnF4J4C:
-    citations: 140
+    citations: 141
     title: Koniglich Preussische Akademie der Wissenschaften
     year: '1983'
   qc6CJjYAAAAJ:6Dd5luMImnEC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4556
+    citations: 4562
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -610,7 +610,7 @@ papers:
     title: "Cum v\u0103d eu lumea: o antologie"
     year: '1992'
   qc6CJjYAAAAJ:9tJtKg94vZsC:
-    citations: 209
+    citations: 210
     title: Do gravitational fields play an essential role in the structure of elementary particles?
     year: '1919'
   qc6CJjYAAAAJ:9tletLqOvukC:
@@ -654,7 +654,7 @@ papers:
     title: La relativit# a speciale
     year: '1920'
   qc6CJjYAAAAJ:AVQCy-ZCKIsC:
-    citations: 113
+    citations: 112
     title: "Planck\u2019s theory of radiation and the theory of specific heat"
     year: '1907'
   qc6CJjYAAAAJ:AYaE08C4-t8C:
@@ -726,7 +726,7 @@ papers:
     title: 'Albert Einstein] to Willem de Sitter: Letter, before 12 Mar 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:BqipwSGYUEgC:
-    citations: 189
+    citations: 190
     title: Elementary derivation of the equivalence of mass and energy
     year: '1935'
   qc6CJjYAAAAJ:BtfE7wd9KvMC:
@@ -774,7 +774,7 @@ papers:
     title: "Elie Cartan-Albert Einstein: lettres sur le parall\xE9lisme absolu 1929-1932"
     year: '1979'
   qc6CJjYAAAAJ:CQX_Vi8q7s0C:
-    citations: 1961
+    citations: 1962
     title: Introduction Einstein's Relativity
     year: '1992'
   qc6CJjYAAAAJ:CRQ797xmLJIC:
@@ -790,7 +790,7 @@ papers:
     title: "Untersuchungen \xFCber die Theorie der Brownschen Bewegung/Abhandlungen \xFCber die Brownsche Bewegung und verwandte Erscheinungen"
     year: '1999'
   qc6CJjYAAAAJ:CY3uIpTmi-gC:
-    citations: 150
+    citations: 148
     title: Einstein on Cosmic Religion and Other Opinions and Aphorisms
     year: '2009'
   qc6CJjYAAAAJ:CmbFvBriOyMC:
@@ -814,7 +814,7 @@ papers:
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5293
+    citations: 5297
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3044
+    citations: 3057
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -946,7 +946,7 @@ papers:
     title: "Sur le probl\xE8me de la formation de la personnalit\xE9 cr\xE9atrice d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:Ei5r6KrKXVQC:
-    citations: 1513
+    citations: 1514
     title: "Theorie der Opaleszenz von homogenen Fl\xFCssigkeiten und Fl\xFCssigkeitsgemischen in der N\xE4he des kritischen Zustandes"
     year: '2006'
   qc6CJjYAAAAJ:EpJ50YjRFhcC:
@@ -1062,7 +1062,7 @@ papers:
     title: Systematische Untersuchung fiber kompatible Feldgleichungen, welche von einem Riemannschen Raum mit Fernparallelismus gesetzt werden k6nnen
     year: '1931'
   qc6CJjYAAAAJ:G36d5HCDkJYC:
-    citations: 216
+    citations: 215
     title: Remarks on Bertrand Russell's theory of knowledge
     year: '1946'
   qc6CJjYAAAAJ:GCDlZl827dEC:
@@ -1122,7 +1122,7 @@ papers:
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3082
+    citations: 3085
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1142,7 +1142,7 @@ papers:
     title: "Theorien verborgener Parameter, EPR-Korrelationen, Bell\u2019sche Ungleichung, GHZ-Zust ande"
     year: '1999'
   qc6CJjYAAAAJ:GzlcqhCAosUC:
-    citations: 490
+    citations: 491
     title: "QUANTEN\u2010MECHANIK UND WIRKLICHKEIT"
     year: '1948'
   qc6CJjYAAAAJ:H-nlc5mcmJQC:
@@ -1182,7 +1182,7 @@ papers:
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
-    citations: 21587
+    citations: 21604
     title: Uber einen die Erzeugung und Verwandlung des Lichtes betreffenden heurischen Gesichtpunkt
     year: '1905'
   qc6CJjYAAAAJ:HtEfBTGE9r8C:
@@ -1210,7 +1210,7 @@ papers:
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3926
+    citations: 3931
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
@@ -1226,7 +1226,7 @@ papers:
     title: Sehallausbreitung in teilweise disseziierten Gasen.
     year: '1920'
   qc6CJjYAAAAJ:IWHjjKOFINEC:
-    citations: 800
+    citations: 801
     title: Cosmological considerations on the general theory of relativity
     year: '1986'
   qc6CJjYAAAAJ:IZKZNMMMWs0C:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6485
+    citations: 6489
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1278,7 +1278,7 @@ papers:
     title: Tables of Einstein Functions
     year: '1962'
   qc6CJjYAAAAJ:JQPmwQThujIC:
-    citations: 468
+    citations: 469
     title: "La g\xE9om\xE9trie et l'exp\xE9rience, par Albert Einstein; traduit par Maurice Solovine"
     year: '1921'
   qc6CJjYAAAAJ:JXi_AgyUMBAC:
@@ -1286,7 +1286,7 @@ papers:
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2453
+    citations: 2456
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
@@ -1314,7 +1314,7 @@ papers:
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 752
+    citations: 755
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1370,7 +1370,7 @@ papers:
     title: "Die spezielle Relativit\xE4sthorie"
     year: '1912'
   qc6CJjYAAAAJ:KlAtU1dfN6UC:
-    citations: 453
+    citations: 454
     title: On the Influence of Gravitation on the Propagation of Light
     year: '1911'
   qc6CJjYAAAAJ:KqnX2w3egDsC:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6796
+    citations: 6810
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1406,7 +1406,7 @@ papers:
     title: Briefwechsel 1916-1955
     year: '1972'
   qc6CJjYAAAAJ:LGA7_l5-FVwC:
-    citations: 130
+    citations: 131
     title: Preussiche Akademie der Wissenchaften Berlin
     year: '1927'
   qc6CJjYAAAAJ:LIyjJRbbAUMC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3151
+    citations: 3156
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5397
+    citations: 5401
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1514,7 +1514,7 @@ papers:
     title: El significado de la relatividad
     year: '1971'
   qc6CJjYAAAAJ:MDX3w3dAD3YC:
-    citations: 917
+    citations: 918
     title: Zum quantensatz von Sommerfeld und Epstein
     year: '1917'
   qc6CJjYAAAAJ:MGPUR4WVBMEC:
@@ -1522,7 +1522,7 @@ papers:
     title: "Notiz zu der Arbeit von A. Friedmann \u201E\xDCber die Kr\xFCmmung des Raumes \u201C"
     year: '1923'
   qc6CJjYAAAAJ:ML0RJ9NH7IQC:
-    citations: 329
+    citations: 330
     title: New possibility for a unified field theory of gravitation and electricity
     year: '1928'
   qc6CJjYAAAAJ:MNNNGtAgD4EC:
@@ -1558,7 +1558,7 @@ papers:
     title: Physikalische Grundlagen einer Gravitationstheorie
     year: '1914'
   qc6CJjYAAAAJ:NAGhd4NKCV8C:
-    citations: 146
+    citations: 147
     title: "K\xF6niglich Preu\xDFische Akademie der Wissenschaften Berlin"
     year: '1916'
   qc6CJjYAAAAJ:NGoJ35N4lvkC:
@@ -1622,7 +1622,7 @@ papers:
     title: Sidelights on Relativity,... I. Ether and Relativity. II. Geometry and Experience
     year: '1922'
   qc6CJjYAAAAJ:Nufq_to8ts0C:
-    citations: 201
+    citations: 202
     title: "Das Prinzip von der Erhaltung der Schwerpunktsbewegung und die Tr\xE4gheit der Energie"
     year: '1906'
   qc6CJjYAAAAJ:Nw5Pwe77XXAC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8216
+    citations: 8237
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1694,7 +1694,7 @@ papers:
     title: On German Literature for Viola Da Gamba in the 16th and 17th Centuries
     year: '1977'
   qc6CJjYAAAAJ:P1qO8dLd1z8C:
-    citations: 272
+    citations: 271
     title: The Photoelectric Effect
     year: '1905'
   qc6CJjYAAAAJ:P9oYG7HA76QC:
@@ -1734,7 +1734,7 @@ papers:
     title: 'Wissenschaftlicher Briefwechsel Mit Bohr, Einstein, Heisenberg, Ua: Scientific Correspondence with Bohr, Einstein, Heisenberg, Ao Volume 1: 1919-1929. 1919-1929'
     year: '1979'
   qc6CJjYAAAAJ:Q7hiZQKJ-pAC:
-    citations: 223
+    citations: 226
     title: 'Cosmic religion: with other opinions and aphorisms'
     year: '1931'
   qc6CJjYAAAAJ:Q9ss7R9eeXsC:
@@ -1758,7 +1758,7 @@ papers:
     title: "Cien a\xF1os de relatividad: Los art\xEDculos de Albert Einstein de 1905 y 1906"
     year: '2004'
   qc6CJjYAAAAJ:QIV2ME_5wuYC:
-    citations: 754
+    citations: 757
     title: Does the inertia of a body depend upon its energy-content?
     year: '1905'
   qc6CJjYAAAAJ:QKtdBID3u5MC:
@@ -1846,7 +1846,7 @@ papers:
     title: 'The essential Einstein: his greatest works'
     year: '2008'
   qc6CJjYAAAAJ:RPps9qLA3-kC:
-    citations: 105
+    citations: 106
     title: Letter to Jacques Hadamard
     year: '1952'
   qc6CJjYAAAAJ:Rc-B-9qnGaUC:
@@ -1854,7 +1854,7 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4523
+    citations: 4527
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
@@ -1878,7 +1878,7 @@ papers:
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7705
+    citations: 7713
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2023
+    citations: 2026
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1962,7 +1962,7 @@ papers:
     title: The new field theory
     year: '1929'
   qc6CJjYAAAAJ:TIZ-Mc8IlK0C:
-    citations: 1105
+    citations: 1106
     title: On the method of theoretical physics
     year: '1934'
   qc6CJjYAAAAJ:TKTY8N1AUUAC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9323
+    citations: 9360
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2038,7 +2038,7 @@ papers:
     title: "Bemerkung zu Herrn Schr\xF6dingers Notiz\" \xDCber ein L\xF6sungssystem der allgemein kovarianten Gravitationsgleichungen\", 3 M\xE4r 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:UY3hNwcQ290C:
-    citations: 26
+    citations: 27
     title: "La teor\xEDa de la relatividad: Sus or\xEDgenes e impacto sobre el pensamiento moderno"
     year: '1983'
   qc6CJjYAAAAJ:UbXTy9l1WKIC:
@@ -2050,7 +2050,7 @@ papers:
     title: "Sobre la electrodin\xE1mica de los cuerpos en movimiento"
     year: '2005'
   qc6CJjYAAAAJ:UebtZRa9Y70C:
-    citations: 1024
+    citations: 1022
     title: "\xDCber die spezielle und die allgemeine Relativit\xE4tstheorie"
     year: '2008'
   qc6CJjYAAAAJ:UlRcoTO8nVoC:
@@ -2162,7 +2162,7 @@ papers:
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1617
+    citations: 1618
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2242,7 +2242,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919 april 1920 (hardback)
     year: '2004'
   qc6CJjYAAAAJ:X5QHDg3V9EEC:
-    citations: 4
+    citations: 5
     title: Science and synthesis
     year: '1971'
   qc6CJjYAAAAJ:X5YyAB84Iw4C:
@@ -2274,7 +2274,7 @@ papers:
     title: 'Albert Einstein] to Paul Gruner: Letter, 11 Feb 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:XZvG1uL-wj0C:
-    citations: 1153
+    citations: 1154
     title: 'On the method of theoretical physics: The Herbert Spencer lecture, delivered at Oxford 10 June 1933'
     year: '1933'
   qc6CJjYAAAAJ:Xc-mKOjpdrwC:
@@ -2286,7 +2286,7 @@ papers:
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1519
+    citations: 1518
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2302,7 +2302,7 @@ papers:
     title: 'Reise nach Japan Palestine Spanien 6 Oktober 1922-12.3. 23: Various places'
     year: '1923'
   qc6CJjYAAAAJ:XiSMed-E-HIC:
-    citations: 65
+    citations: 66
     title: What I believe
     year: '1956'
   qc6CJjYAAAAJ:Xnn2mF3JXD4C:
@@ -2346,7 +2346,7 @@ papers:
     title: Essays in physics
     year: '1950'
   qc6CJjYAAAAJ:YK4ucWkmU_UC:
-    citations: 75
+    citations: 76
     title: 'Albert Einstein, the Human Side: New Glimpses from His Archives'
     year: '1981'
   qc6CJjYAAAAJ:YP-lgzILWVMC:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2359
+    citations: 2364
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2402,7 +2402,7 @@ papers:
     title: Mi credo humanista
     year: '1991'
   qc6CJjYAAAAJ:ZDu_srLEjN8C:
-    citations: 143
+    citations: 144
     title: Preussische akademie der wissenschaften, Phys-math
     year: '1925'
   qc6CJjYAAAAJ:ZEcFV8kAgqMC:
@@ -2430,7 +2430,7 @@ papers:
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4073
+    citations: 4077
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2442,7 +2442,7 @@ papers:
     title: "Physik und realit\xE4t"
     year: '1936'
   qc6CJjYAAAAJ:ZfRJV9d4-WMC:
-    citations: 97
+    citations: 98
     title: Pourquoi la guerre?
     year: '1933'
   qc6CJjYAAAAJ:ZgPQhQxLujAC:
@@ -2514,7 +2514,7 @@ papers:
     title: "Depuis le principe d'\xE9quivalence jusqu'aux \xE9quations de la gravitation."
     year: Unknown Year
   qc6CJjYAAAAJ:_kc_bZDykSQC:
-    citations: 408
+    citations: 409
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3785
+    citations: 3791
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,7 +2534,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4325
+    citations: 4328
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
@@ -2566,7 +2566,7 @@ papers:
     title: The fundamentals of theoretical physics
     year: '1950'
   qc6CJjYAAAAJ:ace9KxS0p5UC:
-    citations: 284
+    citations: 287
     title: Zur theorie der lichterzeugung und lichtabsorption
     year: '1906'
   qc6CJjYAAAAJ:adHtZc2wMuEC:
@@ -2602,7 +2602,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 26 Nov 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:bCjgOgSFrM0C:
-    citations: 1272
+    citations: 1273
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
@@ -2662,7 +2662,7 @@ papers:
     title: 'The collected papers of Albert Einstein. vol. 9, The Berlin years: correspondence, January 1919-April 1920:[English translation]'
     year: Unknown Year
   qc6CJjYAAAAJ:brChLMnLtjYC:
-    citations: 183
+    citations: 184
     title: Relativity Principle and its Consequences in Modern Physics. Collection of Scientific Works, V. 1
     year: '1965'
   qc6CJjYAAAAJ:bsl25C5uMOsC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1549
+    citations: 1550
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7689
+    citations: 7700
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2710,7 +2710,7 @@ papers:
     title: "Die spezielle relativit\xE4tstheorie Einsteins und die logik"
     year: '1924'
   qc6CJjYAAAAJ:cRMvf6lLvU8C:
-    citations: 292
+    citations: 293
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
@@ -2826,7 +2826,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5798
+    citations: 5799
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
@@ -2842,7 +2842,7 @@ papers:
     title: Besprechungen
     year: '1918'
   qc6CJjYAAAAJ:eJXPG6dFmWUC:
-    citations: 493
+    citations: 492
     title: The theory of relativity
     year: '1996'
   qc6CJjYAAAAJ:eKGuBlYFiu8C:
@@ -2918,7 +2918,7 @@ papers:
     title: 'Albert Einstein] to Kathia Adler: Letter, 20 Feb 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:fLJJVVwU7EQC:
-    citations: 354
+    citations: 355
     title: "Ein einfaches Experiment zum Nachweis der Amp\xE8reschen Molekularstr\xF6me"
     year: '1916'
   qc6CJjYAAAAJ:fPk4N6BV_jEC:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3807
+    citations: 3818
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5208
+    citations: 5211
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3038,11 +3038,11 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3797
+    citations: 3801
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
-    citations: 347
+    citations: 348
     title: Notiz zu unserer Arbeit
     year: '1915'
   qc6CJjYAAAAJ:hcF2OqvMasEC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8747
+    citations: 8759
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4172
+    citations: 4190
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5736
+    citations: 5738
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3222,7 +3222,7 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 6918
+    citations: 6923
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
@@ -3306,7 +3306,7 @@ papers:
     title: A new form of the general relativistic field equations
     year: '1955'
   qc6CJjYAAAAJ:mN77zE6YZBUC:
-    citations: 729
+    citations: 727
     title: Ueber spezielle und allgemeine Relativitaetstheorie, 127
     year: '1969'
   qc6CJjYAAAAJ:mNm_27jwclsC:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20494
+    citations: 20513
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3478,7 +3478,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 6 Jul 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:oursBaop5wYC:
-    citations: 1507
+    citations: 1516
     title: Zur theorie der brownschen bewegung
     year: '1906'
   qc6CJjYAAAAJ:oy0z8GdgWhYC:
@@ -3574,7 +3574,7 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2195
+    citations: 2197
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
@@ -3590,7 +3590,7 @@ papers:
     title: "En busca del eslab\xF3n perdido entre educaci\xF3n y desarrollo: desaf\xEDos y retos para la universidad en Am\xE9rica Latina y el Caribe"
     year: Unknown Year
   qc6CJjYAAAAJ:qjMakFHDy7sC:
-    citations: 3313
+    citations: 3319
     title: On the electrodynamics of moving bodies
     year: '1905'
   qc6CJjYAAAAJ:qsWQJNntlusC:
@@ -3606,7 +3606,7 @@ papers:
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27734
+    citations: 27746
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3650,7 +3650,7 @@ papers:
     title: "Gelegentliches: Zum f\xFCnfzigsten Geburtstag 14. M\xE4rz 1929 dargebracht von der Soncino-Gesellschaft der Freunde des J\xFCdischen Buches zu Berlin"
     year: '1929'
   qc6CJjYAAAAJ:rPbfW60zdgkC:
-    citations: 1189
+    citations: 1193
     title: Physics and reality
     year: '1936'
   qc6CJjYAAAAJ:rQcm2j6_ZE8C:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3044
+    citations: 3057
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4856
+    citations: 4861
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3734,7 +3734,7 @@ papers:
     title: Mis ideas y opiniones
     year: '2011'
   qc6CJjYAAAAJ:sNmaIFBj_lkC:
-    citations: 6
+    citations: 8
     title: Compton Effect
     year: '1966'
   qc6CJjYAAAAJ:sYWh8IhQ1GMC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4342
+    citations: 4359
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3782,7 +3782,7 @@ papers:
     title: Uproar in the Lecture Hall, 13 Feb 1920
     year: Unknown Year
   qc6CJjYAAAAJ:t6usbXjVLHcC:
-    citations: 143
+    citations: 144
     title: The human side
     year: '1979'
   qc6CJjYAAAAJ:t7izwRedFcYC:
@@ -3838,7 +3838,7 @@ papers:
     title: "equations of motion\uFB01 one therefore could not doubt that the laws of nature are"
     year: '1907'
   qc6CJjYAAAAJ:uCYQzKCmtZwC:
-    citations: 1228
+    citations: 1230
     title: Out of my later years
     year: '1950'
   qc6CJjYAAAAJ:uH1VZYVfkoQC:
@@ -3922,7 +3922,7 @@ papers:
     title: "Fysika jako dobrodru\u017Estv\xED pozn\xE1n\xED"
     year: '1958'
   qc6CJjYAAAAJ:vV6vV6tmYwMC:
-    citations: 159
+    citations: 161
     title: Living philosophies
     year: '1979'
   qc6CJjYAAAAJ:v_xunPV0uK0C:
@@ -3930,7 +3930,7 @@ papers:
     title: On the five-dimensional representation of gravitation and electricity
     year: '1941'
   qc6CJjYAAAAJ:viPVbuMW504C:
-    citations: 401
+    citations: 402
     title: Collected Scientific Works
     year: '1965'
   qc6CJjYAAAAJ:viTTOddtVMkC:
@@ -3970,7 +3970,7 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3272
+    citations: 3277
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
@@ -4078,11 +4078,11 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1340
+    citations: 1344
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:
-    citations: 893
+    citations: 894
     title: Strahlungs-emission und absorption nach der quantentheorie
     year: '1916'
   qc6CJjYAAAAJ:yKZlB_2wKysC:
@@ -4102,7 +4102,7 @@ papers:
     title: Education for independent thought
     year: '1952'
   qc6CJjYAAAAJ:yXZqsUWzai8C:
-    citations: 144
+    citations: 145
     title: "Koniglich Preu\u03B2ische Akademie der Wissenschaften"
     year: '1916'
   qc6CJjYAAAAJ:yZoBfgUKqwcC:
@@ -4174,6 +4174,6 @@ papers:
     title: "Albert Einstein] to Rudolf F\xF6rster: Letter, 17 Jan 1918"
     year: Unknown Year
   qc6CJjYAAAAJ:zxzvZ9-XIW8C:
-    citations: 75
+    citations: 76
     title: Albert Einstein, the human side
     year: '2013'

--- a/_data/citations.yml
+++ b/_data/citations.yml
@@ -1,5 +1,5 @@
 metadata:
-  last_updated: '2026-05-15'
+  last_updated: '2026-05-18'
 papers:
   qc6CJjYAAAAJ:-1WLWRmjvKAC:
     citations: 4
@@ -18,7 +18,7 @@ papers:
     title: 'The Palestine Troubles: Einstein''s Protest, Zionism''s Basis and Achievement; the Mandatory''s Task'
     year: '1929'
   qc6CJjYAAAAJ:-LHtoeeytlUC:
-    citations: 2548
+    citations: 2550
     title: 'Albert Einstein: Philosopher Scientist'
     year: '1969'
   qc6CJjYAAAAJ:-R_Z4shfoosC:
@@ -30,7 +30,7 @@ papers:
     title: The special theory of relativity
     year: '1905'
   qc6CJjYAAAAJ:-_cDHGlXAtsC:
-    citations: 8347
+    citations: 8365
     title: Sitzungsberichte der Preussischen Akad. d
     year: '1917'
   qc6CJjYAAAAJ:-fj4grS0xi0C:
@@ -110,7 +110,7 @@ papers:
     title: Correspondencia con Michele Besso:(1903-1955)
     year: '1994'
   qc6CJjYAAAAJ:0t1ZDozeHsAC:
-    citations: 6
+    citations: 5
     title: Essays in science
     year: '1954'
   qc6CJjYAAAAJ:0wD49__q8KEC:
@@ -194,7 +194,7 @@ papers:
     title: "Die Einstein-Sammlung der ETH-Bibliothek in Z\xFCrich: ein Ueberblick f\xFCr Ben\xFCtzer der Handschriften-Abteilung"
     year: '1970'
   qc6CJjYAAAAJ:2C0LhDdYSbcC:
-    citations: 1532
+    citations: 1530
     title: "Le principe de relativit\xE9 et ses cons\xE9quences dans la physique moderne"
     year: '1910'
   qc6CJjYAAAAJ:2KloaMYe4IUC:
@@ -270,7 +270,7 @@ papers:
     title: Nachtrag zu meiner Arbeit:Thermodynamische Begruendung des photochemischen Aequivalentgesetzes'(from Annalen der Physik 1912)
     year: '1993'
   qc6CJjYAAAAJ:4Bh_hC5jS3YC:
-    citations: 7137
+    citations: 7136
     title: Graviton Mass and Inertia Mass
     year: '1911'
   qc6CJjYAAAAJ:4DMP91E08xMC:
@@ -290,7 +290,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, 17 Apr 1908'
     year: Unknown Year
   qc6CJjYAAAAJ:4JMBOYKVnBMC:
-    citations: 2975
+    citations: 2976
     title: Quantentheorie des einatomigen idealen Gases
     year: '1924'
   qc6CJjYAAAAJ:4QKQTXcH0q8C:
@@ -298,7 +298,7 @@ papers:
     title: "Kritisches zu einer von Hrn. de Sitter gegebenen L\xF6sung der Gravitationsgleichungen"
     year: '1918'
   qc6CJjYAAAAJ:4S6zbAYdD6oC:
-    citations: 15
+    citations: 17
     title: Naturwissenschaft und Religion
     year: '1960'
   qc6CJjYAAAAJ:4TOpqqG69KYC:
@@ -346,7 +346,7 @@ papers:
     title: 'Einstein, the Man and His Achievement: A Series of Broadcast Talks'
     year: '1967'
   qc6CJjYAAAAJ:5-tCjTwfAdEC:
-    citations: 460
+    citations: 461
     title: "Die Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:5Hlrm_bZEgcC:
@@ -390,7 +390,7 @@ papers:
     title: My theory
     year: '1919'
   qc6CJjYAAAAJ:5pGZGXnFQ_sC:
-    citations: 10502
+    citations: 10520
     title: Sitzungsber. K
     year: '1925'
   qc6CJjYAAAAJ:5qfkUJPXOUwC:
@@ -438,7 +438,7 @@ papers:
     title: "Conceptos, ambientes de aprendizaje:\xBF c\xF3mo aprendemos los humanos en diferentes contextos? Waleska Aldana Segura"
     year: Unknown Year
   qc6CJjYAAAAJ:6ftYtcnYaCAC:
-    citations: 342
+    citations: 343
     title: Ather and Relativitatstheorie. J
     year: '1920'
   qc6CJjYAAAAJ:6gD0efnhv6MC:
@@ -458,7 +458,7 @@ papers:
     title: "Bietet die feldtheorie M\xF6glichkeiten f\xFCr die L\xF6sung des Quantenproblems?"
     year: '1923'
   qc6CJjYAAAAJ:7DJsn6tmoAwC:
-    citations: 329
+    citations: 330
     title: "\xC4ther und Relativit\xE4ts-theorie"
     year: '1920'
   qc6CJjYAAAAJ:7DTIKO_nxaIC:
@@ -546,7 +546,7 @@ papers:
     title: "Bemerkung zu der Arbeit von D. Mirimanoff \u201E\xDCber die Grundgleichungen\u2026\u201D \uFE01"
     year: '1909'
   qc6CJjYAAAAJ:8k81kl-MbHgC:
-    citations: 378
+    citations: 379
     title: Essays in science
     year: '2011'
   qc6CJjYAAAAJ:8moDcb_GFzgC:
@@ -566,7 +566,7 @@ papers:
     title: "Die Einstein-Dokumente im Archiv der Humboldt-Universit\xE4t zu Berlin"
     year: '1973'
   qc6CJjYAAAAJ:94rQ0kDLHKYC:
-    citations: 4562
+    citations: 4563
     title: Evolution of Physics
     year: '1954'
   qc6CJjYAAAAJ:9CGX2owmTHMC:
@@ -654,7 +654,7 @@ papers:
     title: La relativit# a speciale
     year: '1920'
   qc6CJjYAAAAJ:AVQCy-ZCKIsC:
-    citations: 112
+    citations: 113
     title: "Planck\u2019s theory of radiation and the theory of specific heat"
     year: '1907'
   qc6CJjYAAAAJ:AYaE08C4-t8C:
@@ -766,7 +766,7 @@ papers:
     title: 'Albert Einstein] to Paul Seippel: Letter, 19 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:CLQ-NLsb8zAC:
-    citations: 3158
+    citations: 3157
     title: Ideas and Opinions
     year: '1954'
   qc6CJjYAAAAJ:COU-sansr_wC:
@@ -790,7 +790,7 @@ papers:
     title: "Untersuchungen \xFCber die Theorie der Brownschen Bewegung/Abhandlungen \xFCber die Brownsche Bewegung und verwandte Erscheinungen"
     year: '1999'
   qc6CJjYAAAAJ:CY3uIpTmi-gC:
-    citations: 148
+    citations: 150
     title: Einstein on Cosmic Religion and Other Opinions and Aphorisms
     year: '2009'
   qc6CJjYAAAAJ:CmbFvBriOyMC:
@@ -814,11 +814,11 @@ papers:
     title: On the moral obligation of the scientist
     year: '1945'
   qc6CJjYAAAAJ:Cv-mv52rCCkC:
-    citations: 5297
+    citations: 5296
     title: On the motion of particles suspended in a liquid at rest, assumed by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:Cx2ibDnldiAC:
-    citations: 38
+    citations: 39
     title: On the quantum mechanics of radiation
     year: '1917'
   qc6CJjYAAAAJ:Cy13deThEpcC:
@@ -858,7 +858,7 @@ papers:
     title: Jarbuch der Radioaktivitat und Elektronik, 4, 411 (1907), reprinted in The Collected Papers of A. Einstein, vol. 2, 252
     year: '1989'
   qc6CJjYAAAAJ:DQNrXyjhriIC:
-    citations: 3057
+    citations: 3068
     title: Die feldgleichungen der gravitation
     year: '1915'
   qc6CJjYAAAAJ:D_sINldO8mEC:
@@ -1122,7 +1122,7 @@ papers:
     title: Ernst Mach
     year: '1916'
   qc6CJjYAAAAJ:Grx829lh2T4C:
-    citations: 3085
+    citations: 3086
     title: Quantum theory of monatomic ideal gases
     year: '1924'
   qc6CJjYAAAAJ:GsgvGxwuA5UC:
@@ -1178,7 +1178,7 @@ papers:
     title: Riemann-Metrik mit Aufrechterhaltung des Begriffes der Fern-parallelismus, Preuss
     year: '1928'
   qc6CJjYAAAAJ:HklM7qHXWrUC:
-    citations: 460
+    citations: 461
     title: "Die Relativit\xE4tstheorie"
     year: '1925'
   qc6CJjYAAAAJ:Hl4CZ0n6gBQC:
@@ -1206,11 +1206,11 @@ papers:
     title: Zur Abwehr
     year: '1921'
   qc6CJjYAAAAJ:I9gX6wnfuA8C:
-    citations: 332
+    citations: 333
     title: "\xC4ther und Relativit\xE4tstheorie: Rede gehalten am 5. Mai 1920 an der Reichs-Universit\xE4t zu Leiden"
     year: '1920'
   qc6CJjYAAAAJ:IEpB_1CIIT4C:
-    citations: 3931
+    citations: 3932
     title: 'THE EVOLUTION OF PHYSICS: THE GROWTH OF IDEAS FROM THE EARLY CON CEPTS TO RELATIVITY AND QUANTA.'
     year: '1938'
   qc6CJjYAAAAJ:IHkkN1K1AlAC:
@@ -1226,7 +1226,7 @@ papers:
     title: Sehallausbreitung in teilweise disseziierten Gasen.
     year: '1920'
   qc6CJjYAAAAJ:IWHjjKOFINEC:
-    citations: 801
+    citations: 803
     title: Cosmological considerations on the general theory of relativity
     year: '1986'
   qc6CJjYAAAAJ:IZKZNMMMWs0C:
@@ -1258,7 +1258,7 @@ papers:
     title: 'Zu Max Plancks sechzegstem Geburtstag: Ansprachen, gehalten am 26. April 1918 in der Deutschen Physikalischen Gesellschaft'
     year: '1918'
   qc6CJjYAAAAJ:IqrShC7OVU0C:
-    citations: 6489
+    citations: 6491
     title: Investigations on the theory of the Brownian movement, edited with notes by R
     year: '1926'
   qc6CJjYAAAAJ:IvSMUa3B7yYC:
@@ -1286,7 +1286,7 @@ papers:
     title: Relativistic theory of the non-symmetric field
     year: '1955'
   qc6CJjYAAAAJ:JZsVLox4iN8C:
-    citations: 2456
+    citations: 2458
     title: 'Autobiographisches in: Albert Einstein: Philosopher-Scientist'
     year: '1949'
   qc6CJjYAAAAJ:J_g5lzvAfSwC:
@@ -1314,7 +1314,7 @@ papers:
     title: Fundamental ideas and problems of the theory of relativity
     year: '2009'
   qc6CJjYAAAAJ:K4-iKlO5MD4C:
-    citations: 755
+    citations: 756
     title: A Heuristic Viewpoint Concerning the Production and Transformation of Light
     year: '1929'
   qc6CJjYAAAAJ:K6kyChav4UkC:
@@ -1370,7 +1370,7 @@ papers:
     title: "Die spezielle Relativit\xE4sthorie"
     year: '1912'
   qc6CJjYAAAAJ:KlAtU1dfN6UC:
-    citations: 454
+    citations: 456
     title: On the Influence of Gravitation on the Propagation of Light
     year: '1911'
   qc6CJjYAAAAJ:KqnX2w3egDsC:
@@ -1390,7 +1390,7 @@ papers:
     title: 'Albert Einstein] to Mileva Einstein-Maric: Letter, after 17 Mar 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:L7JqRCIhofwC:
-    citations: 6810
+    citations: 6818
     title: Sitzungsberichte der Preussischen Akademie der Wissenschaften zu Berlin
     year: '1915'
   qc6CJjYAAAAJ:L7vk9XBBNxgC:
@@ -1454,11 +1454,11 @@ papers:
     title: 'Albert Einstein] to Hedwig Born: Letter, 8 Feb 1918'
     year: Unknown Year
   qc6CJjYAAAAJ:LkGwnXOMwfcC:
-    citations: 3156
+    citations: 3162
     title: The foundation of the general theory of relativity
     year: '1916'
   qc6CJjYAAAAJ:LkrQC8aPkXYC:
-    citations: 5401
+    citations: 5411
     title: 'Relativity: The Special and the General Theory: a Popular Exposition by Albert Einstein; Transl. by Robert W. Lawson'
     year: '1961'
   qc6CJjYAAAAJ:Lmuc1furtc4C:
@@ -1538,7 +1538,7 @@ papers:
     title: "La corr\xE9lation de l'empirique et du rationnel dans l'oeuvre scientifique d'Einstein."
     year: Unknown Year
   qc6CJjYAAAAJ:MXK_kJrjxJIC:
-    citations: 641
+    citations: 643
     title: On a stationary system with spherical symmetry consisting of many gravitating masses
     year: '1939'
   qc6CJjYAAAAJ:MqTxh1vmwXEC:
@@ -1630,7 +1630,7 @@ papers:
     title: 'Albert Einstein] to Wilhelm Wien: Letter, 17 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:Nw_I7GeUguwC:
-    citations: 168
+    citations: 167
     title: "Zur allgemeinen molekularen Theorie der W\xE4rme"
     year: '1904'
   qc6CJjYAAAAJ:NzUpm4bhSXQC:
@@ -1638,7 +1638,7 @@ papers:
     title: "Die Quantentheorie der spezifischen W\xE4rme"
     year: '1967'
   qc6CJjYAAAAJ:O0MA3yP7Y3UC:
-    citations: 307
+    citations: 308
     title: 'The Collected Papers of Albert Einstein, Volume 8: The Berlin Years: Correspondence, 1914-1918.'
     year: '1998'
   qc6CJjYAAAAJ:O3NaXMp0MMsC:
@@ -1662,7 +1662,7 @@ papers:
     title: 'Friedrich Wilhelm Foerster und Albert Einstein: Briefwechsel von 1935 bis 1954'
     year: '2001'
   qc6CJjYAAAAJ:OPs5gEIPXMUC:
-    citations: 8237
+    citations: 8253
     title: On gravitational waves Sitzungsber. preuss
     year: '1918'
   qc6CJjYAAAAJ:OTTXONDVkokC:
@@ -1670,7 +1670,7 @@ papers:
     title: On the relativity problem
     year: '2007'
   qc6CJjYAAAAJ:OVe_t5h5bhEC:
-    citations: 274
+    citations: 275
     title: "Mi visi\xF3n del mundo"
     year: '1985'
   qc6CJjYAAAAJ:Oi-j_DTgP3cC:
@@ -1734,7 +1734,7 @@ papers:
     title: 'Wissenschaftlicher Briefwechsel Mit Bohr, Einstein, Heisenberg, Ua: Scientific Correspondence with Bohr, Einstein, Heisenberg, Ao Volume 1: 1919-1929. 1919-1929'
     year: '1979'
   qc6CJjYAAAAJ:Q7hiZQKJ-pAC:
-    citations: 226
+    citations: 225
     title: 'Cosmic religion: with other opinions and aphorisms'
     year: '1931'
   qc6CJjYAAAAJ:Q9ss7R9eeXsC:
@@ -1830,7 +1830,7 @@ papers:
     title: "Physikalische Gesellschaft zu Berlin und Deutsche Gesellschaft f\xFCr technische Physik. Berlin, 17. Juli 1931"
     year: '2006'
   qc6CJjYAAAAJ:R3hNpaxXUhUC:
-    citations: 291
+    citations: 292
     title: "Lettres \xE0 Maurice Solovine"
     year: '1956'
   qc6CJjYAAAAJ:R6aXIXmdpM0C:
@@ -1854,7 +1854,7 @@ papers:
     title: Bemerkungen iiber den Wandel der Problemstcllungen in der theoretischen Physik
     year: Unknown Year
   qc6CJjYAAAAJ:RfUwGJFMQ-0C:
-    citations: 4527
+    citations: 4529
     title: Zur quantentheorie der strahlung
     year: '1917'
   qc6CJjYAAAAJ:RgMnzfD6kpIC:
@@ -1878,7 +1878,7 @@ papers:
     title: "Kinetische Theorie des W\xE4rmegleichgewichtes und des zweiten Hauptsatzes der Thermodynamik"
     year: '1902'
   qc6CJjYAAAAJ:S9V7H-Nz35UC:
-    citations: 7713
+    citations: 7719
     title: On a Heuristic Point of View Toward the Emission and Transformation of Light
     year: '1905'
   qc6CJjYAAAAJ:SFOYbPikdlgC:
@@ -1926,7 +1926,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 3 Oct 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:SrKkpNFED5gC:
-    citations: 594
+    citations: 593
     title: "Zum gegenw\xE4rtigen Stand des Strahlungsproblems"
     year: '1909'
   qc6CJjYAAAAJ:SrsqWtBqNIQC:
@@ -1938,7 +1938,7 @@ papers:
     title: 'Albert Einstein] to Wladyslaw Natanson: Letter, 24 Aug 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:SzsLJvG5eXAC:
-    citations: 2026
+    citations: 2028
     title: Autobiographical Notes, ed
     year: '1979'
   qc6CJjYAAAAJ:T64LSalLz9oC:
@@ -1990,7 +1990,7 @@ papers:
     title: "Hamilton\u2019s principle and the general theory of relativity"
     year: '1916'
   qc6CJjYAAAAJ:TiIbgCYny7sC:
-    citations: 9360
+    citations: 9371
     title: "Zur Elektrodynamik bewegter K\xF6rper"
     year: Unknown Year
   qc6CJjYAAAAJ:TmnWbB_axlEC:
@@ -2050,7 +2050,7 @@ papers:
     title: "Sobre la electrodin\xE1mica de los cuerpos en movimiento"
     year: '2005'
   qc6CJjYAAAAJ:UebtZRa9Y70C:
-    citations: 1022
+    citations: 1023
     title: "\xDCber die spezielle und die allgemeine Relativit\xE4tstheorie"
     year: '2008'
   qc6CJjYAAAAJ:UlRcoTO8nVoC:
@@ -2126,7 +2126,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 3 Mar 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:VglVhKISWcQC:
-    citations: 8
+    citations: 9
     title: ON A HEURISTIC VIEWPOINT OF THE CREATION AND MODIFICATION OF LIGHT
     year: '1905'
   qc6CJjYAAAAJ:VjBpw8Hezy4C:
@@ -2146,7 +2146,7 @@ papers:
     title: 'The collected papers of Albert Einstein. Vol 6, The Berlin years: writings, 1914-1917:[English translation]'
     year: '2002'
   qc6CJjYAAAAJ:VyOdxF-JhwgC:
-    citations: 256
+    citations: 257
     title: SB preuss
     year: '1916'
   qc6CJjYAAAAJ:VyewGSb6xwwC:
@@ -2162,7 +2162,7 @@ papers:
     title: "L'\xE9tat actuel du probl\xE8me des chaleurs sp\xE9cifiques"
     year: '1912'
   qc6CJjYAAAAJ:W7OEmFMy1HYC:
-    citations: 1618
+    citations: 1620
     title: Lens-like action of a star by the deviation of light in the gravitational field
     year: '1936'
   qc6CJjYAAAAJ:WC4w5-ZrDNIC:
@@ -2174,7 +2174,7 @@ papers:
     title: La discussion Einstein-Bohr.
     year: Unknown Year
   qc6CJjYAAAAJ:WF5omc3nYNoC:
-    citations: 1059
+    citations: 1060
     title: On gravitational waves
     year: '1937'
   qc6CJjYAAAAJ:WIVIxizkzXoC:
@@ -2242,7 +2242,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919 april 1920 (hardback)
     year: '2004'
   qc6CJjYAAAAJ:X5QHDg3V9EEC:
-    citations: 5
+    citations: 4
     title: Science and synthesis
     year: '1971'
   qc6CJjYAAAAJ:X5YyAB84Iw4C:
@@ -2286,7 +2286,7 @@ papers:
     title: 'The Collected Papers of Albert Einstein, Volume 9: The Berlin Years: Correspondence, January 1919-April 1920'
     year: '2004'
   qc6CJjYAAAAJ:XdwVV_xN3QMC:
-    citations: 1518
+    citations: 1520
     title: Draft of a Generalized Theory of Relativity and a Theory of Gravitation
     year: '1913'
   qc6CJjYAAAAJ:XeErXHja3Z8C:
@@ -2302,7 +2302,7 @@ papers:
     title: 'Reise nach Japan Palestine Spanien 6 Oktober 1922-12.3. 23: Various places'
     year: '1923'
   qc6CJjYAAAAJ:XiSMed-E-HIC:
-    citations: 66
+    citations: 65
     title: What I believe
     year: '1956'
   qc6CJjYAAAAJ:Xnn2mF3JXD4C:
@@ -2390,7 +2390,7 @@ papers:
     title: 'Albert Einstein] to Michele and Anna Besso-Winteler: Letter, 1 Aug 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:YsMSGLbcyi4C:
-    citations: 2364
+    citations: 2367
     title: The particle problem in the general theory of relativity
     year: '1935'
   qc6CJjYAAAAJ:YvgfBAebZEkC:
@@ -2430,7 +2430,7 @@ papers:
     title: 'Briefwechsel: Sechzig Briefe aus dem goldenen Zeitalter der modernen Physik'
     year: '1968'
   qc6CJjYAAAAJ:ZbQVaL1IMbQC:
-    citations: 4077
+    citations: 4079
     title: Quanzeml~ orie der stralllung
     year: '1916'
   qc6CJjYAAAAJ:ZbiiB1Sm8G8C:
@@ -2518,7 +2518,7 @@ papers:
     title: A generalization of the relativistic theory of gravitation
     year: '1945'
   qc6CJjYAAAAJ:_mQi-xiA4oYC:
-    citations: 460
+    citations: 461
     title: "Die Relativit\xE4ts-Theorie"
     year: '1911'
   qc6CJjYAAAAJ:a2necdfpwlEC:
@@ -2526,7 +2526,7 @@ papers:
     title: "Eine Beziehung zwischen dem elastischen Verhalten und der spezifischen W\xE4rme bei festen K\xF6rpern mit einatomigem Molek\xFCl"
     year: '1911'
   qc6CJjYAAAAJ:a9-T7VOCCH8C:
-    citations: 3791
+    citations: 3794
     title: The Science and the Life of Albert Einstein
     year: '1982'
   qc6CJjYAAAAJ:aDdGf5um_jkC:
@@ -2534,7 +2534,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 2 Jun 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:aEPHIGigqugC:
-    citations: 4328
+    citations: 4327
     title: "Physics and Reality, in \u201CIdeas and Opinions\u201D"
     year: '1954'
   qc6CJjYAAAAJ:aEyKTaVlRPYC:
@@ -2606,7 +2606,7 @@ papers:
     title: "Die plancksche theorie der strahlung und die theorie der spezifischen w\xE4rme"
     year: '1906'
   qc6CJjYAAAAJ:bEWYMUwI8FkC:
-    citations: 283
+    citations: 285
     title: Why war?
     year: '1933'
   qc6CJjYAAAAJ:bFuYayV9R1gC:
@@ -2654,7 +2654,7 @@ papers:
     title: "Zur Theorie der Radiometerkr\xE4fte"
     year: '1924'
   qc6CJjYAAAAJ:bnK-pcrLprsC:
-    citations: 31
+    citations: 32
     title: Unified field theory based on Riemannian metrics and distant parallelism
     year: '1930'
   qc6CJjYAAAAJ:boGf3zyra0UC:
@@ -2686,7 +2686,7 @@ papers:
     title: The Fight Against War
     year: '1933'
   qc6CJjYAAAAJ:c4A-nLdbYHEC:
-    citations: 1550
+    citations: 1551
     title: 'Concepts of space: The history of theories of space in physics'
     year: '1969'
   qc6CJjYAAAAJ:c5LcigzBm8MC:
@@ -2702,7 +2702,7 @@ papers:
     title: 'In Memory of Emmy Noether...: Abstract of Address Delivered by Professor Hermann Weyl... and Copy of Letter of Professor Albert Einstein'
     year: '1935'
   qc6CJjYAAAAJ:cNe27ouKFcQC:
-    citations: 7700
+    citations: 7713
     title: "Die grundlage der allgemeinen relativit\xE4tstheorie"
     year: '2006'
   qc6CJjYAAAAJ:cOfwuRB03ygC:
@@ -2714,7 +2714,7 @@ papers:
     title: "Einige Argumente f\xFCr die Annahme einer molekularen Agitation beim absoluten Nullpunkt"
     year: '1913'
   qc6CJjYAAAAJ:cSdaV2aYdYsC:
-    citations: 375
+    citations: 376
     title: Spielen Gravitationsfelder im Aufbau der materiellen Elementarteilchen eine wesentliche Rolle?
     year: '1919'
   qc6CJjYAAAAJ:cTdzRpWJKHEC:
@@ -2766,7 +2766,7 @@ papers:
     title: The establishment of an international bureau of meteorology
     year: '1927'
   qc6CJjYAAAAJ:dBIO0h50nwkC:
-    citations: 47
+    citations: 48
     title: Physics & reality
     year: '2003'
   qc6CJjYAAAAJ:dDz6LBb16w8C:
@@ -2826,7 +2826,7 @@ papers:
     title: 'Albert Einstein] to Hans Albert Einstein: Letter, 4 Nov 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:e84hm74t-eoC:
-    citations: 5799
+    citations: 5797
     title: "Eine neue bestimmung der molek\xFCldimensionen"
     year: '1906'
   qc6CJjYAAAAJ:eAUscmXIlQ8C:
@@ -2842,7 +2842,7 @@ papers:
     title: Besprechungen
     year: '1918'
   qc6CJjYAAAAJ:eJXPG6dFmWUC:
-    citations: 492
+    citations: 493
     title: The theory of relativity
     year: '1996'
   qc6CJjYAAAAJ:eKGuBlYFiu8C:
@@ -2982,7 +2982,7 @@ papers:
     title: Zu Dr. Berliners siebzigstem Geburtstag
     year: '1932'
   qc6CJjYAAAAJ:gV6rEsy15s0C:
-    citations: 3818
+    citations: 3830
     title: Bemerkungen zu der Arbeit
     year: '1914'
   qc6CJjYAAAAJ:gYAb_yFic6IC:
@@ -3010,7 +3010,7 @@ papers:
     title: "Ejn\u0161tejnovskaja teorija otnosite\u013Enosti"
     year: '1972'
   qc6CJjYAAAAJ:hEXC_dOfxuUC:
-    citations: 395
+    citations: 394
     title: Reply to critics
     year: '1949'
   qc6CJjYAAAAJ:hEp1lTclR2YC:
@@ -3022,7 +3022,7 @@ papers:
     title: "\xDCber die formale Beziehung des Riemannschen Kr\xFCmmungstensors zu den Feldgleichungen der Gravitation"
     year: '1927'
   qc6CJjYAAAAJ:hMod-77fHWUC:
-    citations: 5211
+    citations: 5220
     title: "La relativit\xE9"
     year: '1964'
   qc6CJjYAAAAJ:hMwNgRnlwaMC:
@@ -3038,7 +3038,7 @@ papers:
     title: EddingtonsTheorie und Hamiltonsches Prinzip
     year: '1925'
   qc6CJjYAAAAJ:hVd5agGqjXwC:
-    citations: 3801
+    citations: 3802
     title: Physikalische Gesellschaft Zuerich
     year: '1916'
   qc6CJjYAAAAJ:hbz17DqrwuEC:
@@ -3102,7 +3102,7 @@ papers:
     title: Geometria no euclidea y fisica
     year: '1926'
   qc6CJjYAAAAJ:i_7YvbSbtFEC:
-    citations: 8759
+    citations: 8772
     title: "Berichtigung zu meiner Arbeit:\u201EEine neue Bestimmung der Molek\xFCldimensionen\u201D \uFE01"
     year: '2006'
   qc6CJjYAAAAJ:ifIdVpG6JtcC:
@@ -3122,7 +3122,7 @@ papers:
     title: "La th\xE9orie de la relativit\xE9 d'Einstein et la dialectique."
     year: Unknown Year
   qc6CJjYAAAAJ:isC4tDSrTZIC:
-    citations: 4190
+    citations: 4204
     title: "\xDCber Gravitationswellen"
     year: '1918'
   qc6CJjYAAAAJ:it4f3qIuXWYC:
@@ -3178,7 +3178,7 @@ papers:
     title: A memorial to PAM Dirac
     year: '1990'
   qc6CJjYAAAAJ:k4O5U3vRA4YC:
-    citations: 5738
+    citations: 5749
     title: The special and general theory
     year: '1920'
   qc6CJjYAAAAJ:k6nH7jlkaTkC:
@@ -3190,7 +3190,7 @@ papers:
     title: Hedwig und Max Born
     year: '1916'
   qc6CJjYAAAAJ:kFzFP8IdBVAC:
-    citations: 378
+    citations: 379
     title: Einstein's essays in science
     year: '2009'
   qc6CJjYAAAAJ:kGbpvR7Ecy8C:
@@ -3222,7 +3222,7 @@ papers:
     title: "Albert Einstein] to Walter D\xE4llenbach: Letter, after 15 Feb 1917"
     year: Unknown Year
   qc6CJjYAAAAJ:kqeZabM7ilsC:
-    citations: 6923
+    citations: 6930
     title: Preuss, Sitzungsber
     year: '1915'
   qc6CJjYAAAAJ:l0_JBNIuc60C:
@@ -3238,7 +3238,7 @@ papers:
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:l7t_Zn2s7bgC:
-    citations: 656
+    citations: 657
     title: Ether and the Theory of Relativity
     year: '2007'
   qc6CJjYAAAAJ:lAj_JhtUatoC:
@@ -3254,7 +3254,7 @@ papers:
     title: The collecteds of albert einstein v 9 the berlin years correspondence january 1919-april 1920 english translation (paperback)
     year: '2004'
   qc6CJjYAAAAJ:lEqHes_HPG0C:
-    citations: 791
+    citations: 792
     title: 'The principle of relativity: a collection of original memoirs on the special and general theory of relativity'
     year: '1923'
   qc6CJjYAAAAJ:lIaPce-xyHYC:
@@ -3342,7 +3342,7 @@ papers:
     title: Albert Einstein] to Michele Besso:[A second] letter, 21 Jul 1916
     year: Unknown Year
   qc6CJjYAAAAJ:mnAcAzq93VMC:
-    citations: 120
+    citations: 122
     title: Riemannian Geometry with Maintaining the Notion of distant parallelism
     year: '1928'
   qc6CJjYAAAAJ:mpaOjDK6XBIC:
@@ -3418,7 +3418,7 @@ papers:
     title: "Neue Zugangswege zur Entw\xF6hnungs-behandlung in Sachsen, Sachsen-Anhalt und Th\xFCringen"
     year: Unknown Year
   qc6CJjYAAAAJ:nwfoItMF7hMC:
-    citations: 441
+    citations: 442
     title: "Teor\u0131a cu\xE1ntica de gases ideales monoat\xF3micos, Sitz"
     year: '1924'
   qc6CJjYAAAAJ:o4Qvs5Y5TLQC:
@@ -3470,7 +3470,7 @@ papers:
     title: "Einheitliche Theorie von Gravitation und Elektrizit\xE4t. Zweite Abhandlung"
     year: '2006'
   qc6CJjYAAAAJ:oqD4_j7ulsYC:
-    citations: 20513
+    citations: 20507
     title: On the movement of small particles suspended in stationary liquids required by the molecular-kinetic theory of heat
     year: '1905'
   qc6CJjYAAAAJ:osi8XriVlOYC:
@@ -3478,7 +3478,7 @@ papers:
     title: 'Albert Einstein] to Wander and Geertruida de Haas: Letter, 6 Jul 1915'
     year: Unknown Year
   qc6CJjYAAAAJ:oursBaop5wYC:
-    citations: 1516
+    citations: 1506
     title: Zur theorie der brownschen bewegung
     year: '1906'
   qc6CJjYAAAAJ:oy0z8GdgWhYC:
@@ -3574,7 +3574,7 @@ papers:
     title: "Quatre conf\xE9rences sur la th\xE9orie de la relativit\xE9 faites \xE0 l'Universit\xE9 de Princeton"
     year: '2005'
   qc6CJjYAAAAJ:qCpRzq7zkD8C:
-    citations: 2197
+    citations: 2199
     title: "Zur allgemeinen Relativit\xE4tstheorie"
     year: '1915'
   qc6CJjYAAAAJ:qPeb-qHga9sC:
@@ -3606,7 +3606,7 @@ papers:
     title: Geometrie und erfahrung
     year: '1921'
   qc6CJjYAAAAJ:qyhmnyLat1gC:
-    citations: 27746
+    citations: 27770
     title: Can quantum-mechanical description of physical reality be considered complete?
     year: '1935'
   qc6CJjYAAAAJ:qzuIxkxWBNsC:
@@ -3662,7 +3662,7 @@ papers:
     title: A new analysis of molecule dimensions
     year: '1968'
   qc6CJjYAAAAJ:rWqKpwLRvsIC:
-    citations: 3057
+    citations: 3068
     title: Die feldgleichungen der gravitation
     year: Unknown Year
   qc6CJjYAAAAJ:rbgNTKsR3fAC:
@@ -3722,7 +3722,7 @@ papers:
     title: "La th\xE9orie corpusculaire des rayons X et la structure des cristaux."
     year: Unknown Year
   qc6CJjYAAAAJ:sAujV351FBYC:
-    citations: 4861
+    citations: 4863
     title: The meaning of relativity
     year: '1950'
   qc6CJjYAAAAJ:sIDMtVbdO0QC:
@@ -3754,7 +3754,7 @@ papers:
     title: The laws of science and the laws of ethics
     year: '1950'
   qc6CJjYAAAAJ:sgsej9ZJWHMC:
-    citations: 4359
+    citations: 4374
     title: "N\xE4herungsweise Integration der Feldgleichungen der Gravitation"
     year: '1916'
   qc6CJjYAAAAJ:siTy-4AL0AwC:
@@ -3838,7 +3838,7 @@ papers:
     title: "equations of motion\uFB01 one therefore could not doubt that the laws of nature are"
     year: '1907'
   qc6CJjYAAAAJ:uCYQzKCmtZwC:
-    citations: 1230
+    citations: 1229
     title: Out of my later years
     year: '1950'
   qc6CJjYAAAAJ:uH1VZYVfkoQC:
@@ -3922,7 +3922,7 @@ papers:
     title: "Fysika jako dobrodru\u017Estv\xED pozn\xE1n\xED"
     year: '1958'
   qc6CJjYAAAAJ:vV6vV6tmYwMC:
-    citations: 161
+    citations: 160
     title: Living philosophies
     year: '1979'
   qc6CJjYAAAAJ:v_xunPV0uK0C:
@@ -3970,11 +3970,11 @@ papers:
     title: "Introduction aux th\xE8ories de M. Einstein en vue de leur application a l'astronomie"
     year: '1921'
   qc6CJjYAAAAJ:vytXtR8tOLIC:
-    citations: 3277
+    citations: 3283
     title: B. preuss
     year: '1916'
   qc6CJjYAAAAJ:vzY-6mMDyDUC:
-    citations: 87
+    citations: 88
     title: 'The Berlin Years, Correspondence 1914-1918: English Translation'
     year: '1998'
   qc6CJjYAAAAJ:w1G5vK4DiEkC:
@@ -4030,7 +4030,7 @@ papers:
     title: 'Albert Einstein] to Michele Besso: Letter, 6 Sep 1916'
     year: Unknown Year
   qc6CJjYAAAAJ:wuD5JclIwkYC:
-    citations: 238
+    citations: 239
     title: Science and religion
     year: '1940'
   qc6CJjYAAAAJ:wy5MF_2MSNEC:
@@ -4078,7 +4078,7 @@ papers:
     title: 'Albert Einstein] to Gustav Mie: Letter, 29 Dec 1917'
     year: Unknown Year
   qc6CJjYAAAAJ:yIeBiWEAh44C:
-    citations: 1344
+    citations: 1345
     title: "\xDCber den Einflu\xDF der Schwerkraft auf die Ausbreitung des Lichtes"
     year: '2006'
   qc6CJjYAAAAJ:yJjnfzR0HrkC:
@@ -4094,7 +4094,7 @@ papers:
     title: A generalized theory of gravitation
     year: '1948'
   qc6CJjYAAAAJ:yNohvu9kXXYC:
-    citations: 443
+    citations: 444
     title: Quantentheorie des idealen einatomigen Gases, Sitzber
     year: '1924'
   qc6CJjYAAAAJ:yS0fcbgecPsC:

--- a/_plugins/external-posts.rb
+++ b/_plugins/external-posts.rb
@@ -42,7 +42,7 @@ module ExternalPosts
           content: e.content,
           summary: e.summary,
           published: e.published
-        }, src)
+        }, e)
       end
     end
 
@@ -85,7 +85,7 @@ module ExternalPosts
         puts "...fetching #{post['url']}"
         content = fetch_content_from_url(post['url'])
         content[:published] = parse_published_date(post['published_date'])
-        create_document(site, src['name'], post['url'], content, src)
+        create_document(site, src['name'], post['url'], content, post)
       end
     end
 


### PR DESCRIPTION
The create_document() function was not getting the right input to correctly parse each post's tags/categories and other content.

With this fix, each external post entry in blog.md will now correctly display tags and categories. Indexing should also improve now.