### PR TITLE
Fix visual regressions: broken repo stat cards and unstyled af-popover/tooltip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.10'
+    gem 'al_folio_core', '= 1.0.11'
     gem 'al_icons', '= 1.0.0'
     gem 'al_folio_cv', '= 1.0.0'
     gem 'al_folio_distill', '= 1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.10)
+    al_folio_core (1.0.11)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_cv (1.0.0)
@@ -352,7 +352,7 @@ DEPENDENCIES
   al_cookie (= 1.0.0)
   al_ext_posts (= 1.0.1)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.10)
+  al_folio_core (= 1.0.11)
   al_folio_cv (= 1.0.0)
   al_folio_distill (= 1.0.2)
   al_folio_upgrade (= 1.0.3)
@@ -397,7 +397,7 @@ CHECKSUMS
   al_cookie (1.0.0) sha256=0b36310f84c88e758fb18f2217e8fca8a282b8bd7f5ee9793c6d38ca0cc97348
   al_ext_posts (1.0.1) sha256=432730bcf032e9da0277beded65511a6e836d4888bda19c9e0f58f9bc6cd2a1d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.10) sha256=13620d361f43e3bc8842f3655025e9688a6e494abb85770f085377bf60cdd678
+  al_folio_core (1.0.11) sha256=0792345ede34af0e685f575520fb8c588fdb8f0207a6a743cc7760d880e49871
   al_folio_cv (1.0.0) sha256=aa54c6efb38f46c5da09e09b82b4b050b5ce3b384f808922dc4fd665e10a840e
   al_folio_distill (1.0.2) sha256=14075b8654a85f76e5e1d8adf8e6c7abcf7b618a4f83a622fa4d5054cd64c709
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709


### PR DESCRIPTION
## What's broken on the demo site

A full-page screenshot audit of every page on https://alshedivat.github.io/al-folio/ surfaced two user-visible bugs introduced or exposed by the v1 upgrade.

### Bug 1 — Repositories page: all stat cards show broken alt-text (HIGH)

Both external services are currently unavailable:
- `github-readme-stats.vercel.app` → HTTP 503 `DEPLOYMENT_PAUSED`
- `github-profile-trophy.vercel.app` → HTTP 402

Every `<img>` on the repositories page fails to load, rendering as a list of broken-image alt-text strings. The templates had no `onerror` fallback.

**Fix (in al_folio_core):** `onerror="this.closest('.repo').style.display='none'"` on every stat-card image in `repo.liquid`, `repo_user.liquid`, and `repo_trophies.liquid`. When a service is unavailable the entire card hides gracefully; when it comes back up cards render normally.

### Bug 2 — `.af-popover` / `.af-tooltip` completely unstyled (MEDIUM)

`tooltips-setup.js` (active by default, since bootstrap-compat is disabled) creates `.af-popover` and `.af-tooltip` elements as its vanilla fallback — for example when hovering the author-info circle icon (ⓘ) on the publications page. These class names had **no CSS rules at all** in `al_folio_core`: no `position`, no styling, no `z-index`. The tooltip/popover appeared as invisible, unpositioned text nodes appended to `document.body`.

(The theme's `_utilities.scss` only defined `.popover` — Bootstrap's class — which is irrelevant without bootstrap-compat loaded.)

**Fix (in al_folio_core):** Added `position: absolute`, `z-index: 1070/1080`, and theme-color styling to both classes. The purgecss safelist in al-folio already protects both names so they survive the deploy pipeline.

## Changes

- `Gemfile` / `Gemfile.lock`: bump `al_folio_core` 1.0.10 → 1.0.11 ([PR #19](https://github.com/al-org-dev/al-folio-core/pull/19), now merged and released)

## Scope

All other pages screenshotted look correct. No other CSS/layout regressions were found beyond these two. The screenshot audit also confirmed:
- The `var(--spacing)` Tailwind fix from #3634 is working correctly in production.
- `main.css` cache-bust hash (`9278fad1…`) is stable and non-empty.
- All blog posts, CV, teaching, people, projects, books pages render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)