### PR TITLE
docs: add dylantao.github.io to user community

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://vud.org" target="_blank">★</a>
 <a href="https://www.byeongsc.com/" target="_blank">★</a>
 <a href="https://deden.id/" target="_blank">★</a>
+<a href="https://dylantao.github.io/" target="_blank">★</a>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

Adds my al-folio-based academic homepage to the User community → Academics list.

Website: https://dylantao.github.io/

## Validation

Not run; README-only documentation change.

## Ownership Routing

- [x] I confirmed this PR targets the correct repo based on `docs/BOUNDARIES.md`.
- [x] This PR only changes starter-owned scope (`al-folio`) **or** I am porting a routed change and linked the owning repo issue/PR.

Owning repo (if not starter): <!-- e.g., al-org-dev/al-folio-core -->
Related issue/PR: <!-- link -->

## Plugin Ecosystem (if applicable)

- [x] Not applicable
- [ ] This PR proposes a plugin for **featured-only** listing.
- [ ] This PR proposes a plugin for **bundled** starter inclusion.

If plugin-related, provide:

- Plugin repo URL:
- Gem name:
- Jekyll plugin id:
- Compatibility (`al_folio_min`/`al_folio_max`):
- Demo page/post path:
- Maintainer contact:

## Starter Wiring Changes

- [x] Not applicable
- [ ] Updated `Gemfile` dependency wiring.
- [ ] Updated `_config.yml` plugin activation/config.
- [ ] Updated `_data/featured_plugins.yml` metadata.

## Validation

- [x] `npm ci`
- [x] `bundle exec jekyll build`
- [x] `npm run lint:prettier`
- [x] `npm run lint:style-contract`
- [x] Integration tests (`test/integration_*.sh`) as needed
- [x] Visual tests (`npm run test:visual`) as needed

## Notes

Compatibility, migration implications, and follow-ups:
