### PR TITLE
Add self-contained HTML5 physics simulations

### DIFF
--- a/assets/html/collisions.html
+++ b/assets/html/collisions.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Elastic Collisions</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:#0a0e14; cursor:crosshair; }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    button { width:100%; margin-top:0.5rem; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); cursor:pointer; }
+    button:hover { border-color:var(--accent); }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.7; font-variant-numeric:tabular-nums; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Elastic Collisions</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Restitution <span class="val" id="rVal">1.00</span></label>
+      <input type="range" id="restitution" min="0.5" max="1" step="0.01" value="1">
+      <label>Ball count <span class="val" id="nVal">8</span></label>
+      <input type="range" id="count" min="2" max="20" step="1" value="8">
+      <button id="reset">Reset</button>
+      <button id="pause">Pause</button>
+      <div class="stats" id="stats">Click canvas to add a ball.<br>Momentum and energy tracked below.</div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H;
+    let balls = [];
+    let paused = false;
+    let restitution = 1;
+
+    const COLORS = ['#58a6ff','#3fb950','#f0883e','#d2a8ff','#ff7b72','#79c0ff','#e3b341','#56d364'];
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = rect.width; H = rect.height;
+      canvas.width = W * DPR; canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    function randBall(x, y) {
+      const r = 12 + Math.random() * 14;
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 80 + Math.random() * 180;
+      return {
+        x: x ?? r + Math.random() * (W - 2 * r),
+        y: y ?? r + Math.random() * (H - 2 * r),
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed,
+        r,
+        m: r * r,
+        color: COLORS[Math.floor(Math.random() * COLORS.length)]
+      };
+    }
+
+    function init(n) {
+      balls = [];
+      for (let i = 0; i < n; i++) balls.push(randBall());
+    }
+
+    function resolveWall(b) {
+      if (b.x - b.r < 0) { b.x = b.r; b.vx = -b.vx * restitution; }
+      if (b.x + b.r > W) { b.x = W - b.r; b.vx = -b.vx * restitution; }
+      if (b.y - b.r < 0) { b.y = b.r; b.vy = -b.vy * restitution; }
+      if (b.y + b.r > H) { b.y = H - b.r; b.vy = -b.vy * restitution; }
+    }
+
+    function resolvePair(a, b) {
+      const dx = b.x - a.x, dy = b.y - a.y;
+      const dist = Math.hypot(dx, dy);
+      const minDist = a.r + b.r;
+      if (dist === 0 || dist >= minDist) return;
+      const nx = dx / dist, ny = dy / dist;
+      const overlap = minDist - dist;
+      const totalM = a.m + b.m;
+      a.x -= nx * overlap * (b.m / totalM);
+      a.y -= ny * overlap * (b.m / totalM);
+      b.x += nx * overlap * (a.m / totalM);
+      b.y += ny * overlap * (a.m / totalM);
+      const dvn = (a.vx - b.vx) * nx + (a.vy - b.vy) * ny;
+      if (dvn > 0) return;
+      const j = -(1 + restitution) * dvn / (1 / a.m + 1 / b.m);
+      a.vx += j * nx / a.m; a.vy += j * ny / a.m;
+      b.vx -= j * nx / b.m; b.vy -= j * ny / b.m;
+    }
+
+    function totals() {
+      let px = 0, py = 0, ke = 0;
+      balls.forEach(b => {
+        px += b.m * b.vx; py += b.m * b.vy;
+        ke += 0.5 * b.m * (b.vx * b.vx + b.vy * b.vy);
+      });
+      return { px, py, ke };
+    }
+
+    function step(dt) {
+      balls.forEach(b => {
+        b.x += b.vx * dt;
+        b.y += b.vy * dt;
+        resolveWall(b);
+      });
+      for (let i = 0; i < balls.length; i++) {
+        for (let j = i + 1; j < balls.length; j++) resolvePair(balls[i], balls[j]);
+      }
+    }
+
+    function draw() {
+      ctx.fillStyle = '#0a0e14';
+      ctx.fillRect(0, 0, W, H);
+      ctx.strokeStyle = '#30363d';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(1, 1, W - 2, H - 2);
+
+      balls.forEach(b => {
+        ctx.fillStyle = b.color;
+        ctx.beginPath();
+        ctx.arc(b.x, b.y, b.r, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+        ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+        ctx.beginPath();
+        ctx.moveTo(b.x, b.y);
+        ctx.lineTo(b.x + b.vx * 0.08, b.y + b.vy * 0.08);
+        ctx.stroke();
+      });
+
+      const t = totals();
+      document.getElementById('stats').innerHTML =
+        `Balls: ${balls.length}<br>` +
+        `pₓ = ${t.px.toFixed(0)} · pᵧ = ${t.py.toFixed(0)}<br>` +
+        `KE = ${(t.ke / 1000).toFixed(2)} kJ<br><br>` +
+        `Click to add a ball.`;
+    }
+
+    canvas.addEventListener('click', e => {
+      const rect = canvas.getBoundingClientRect();
+      balls.push(randBall(e.clientX - rect.left, e.clientY - rect.top));
+    });
+
+    let last = performance.now();
+    function loop(now) {
+      const dt = Math.min((now - last) / 1000, 0.032);
+      last = now;
+      if (!paused) step(dt);
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('restitution').oninput = e => {
+      restitution = +e.target.value;
+      document.getElementById('rVal').textContent = restitution.toFixed(2);
+    };
+    document.getElementById('count').oninput = e => {
+      document.getElementById('nVal').textContent = e.target.value;
+    };
+    document.getElementById('reset').onclick = () => init(+document.getElementById('count').value);
+    document.getElementById('pause').onclick = () => {
+      paused = !paused;
+      document.getElementById('pause').textContent = paused ? 'Resume' : 'Pause';
+    };
+
+    init(8);
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>

--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>HTML5 Physics Simulations</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --muted: #8b949e;
+      --accent: #58a6ff;
+      --accent-2: #3fb950;
+      --accent-3: #d2a8ff;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(ellipse at top, #1a2332 0%, var(--bg) 55%);
+      color: var(--text);
+      min-height: 100vh;
+      line-height: 1.5;
+    }
+    header {
+      text-align: center;
+      padding: 3rem 1.5rem 2rem;
+      border-bottom: 1px solid var(--border);
+    }
+    header h1 {
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    header p {
+      color: var(--muted);
+      max-width: 640px;
+      margin: 0.75rem auto 0;
+    }
+    .badge {
+      display: inline-block;
+      margin-top: 1rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      font-size: 0.8rem;
+      color: var(--accent);
+    }
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 3rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 1.25rem;
+    }
+    a.card {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.25rem 1.35rem;
+      transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+    }
+    a.card:hover {
+      border-color: var(--accent);
+      transform: translateY(-2px);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    }
+    .card-icon {
+      font-size: 1.75rem;
+      margin-bottom: 0.5rem;
+    }
+    .card h2 {
+      font-size: 1.1rem;
+      margin-bottom: 0.35rem;
+    }
+    .card p {
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .tag {
+      display: inline-block;
+      margin-top: 0.75rem;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--accent-2);
+    }
+    footer {
+      text-align: center;
+      padding: 1.5rem;
+      color: var(--muted);
+      font-size: 0.85rem;
+      border-top: 1px solid var(--border);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>HTML5 Physics Simulations</h1>
+    <p>Interactive demonstrations of classical and relativistic mechanics. Each simulation is a single self-contained file using the Canvas API and vanilla JavaScript — no external libraries.</p>
+    <span class="badge">Canvas 2D · requestAnimationFrame · RK4 integration</span>
+  </header>
+  <main>
+    <div class="grid">
+      <a class="card" href="pendulum.html">
+        <div class="card-icon">🎯</div>
+        <h2>Pendulum</h2>
+        <p>Simple and double pendulum with Runge–Kutta integration. Watch deterministic chaos emerge from coupled oscillators.</p>
+        <span class="tag">Classical mechanics</span>
+      </a>
+      <a class="card" href="projectile.html">
+        <div class="card-icon">🚀</div>
+        <h2>Projectile Motion</h2>
+        <p>Launch trajectories under gravity with optional quadratic air drag. Live readouts for range, apex, and flight time.</p>
+        <span class="tag">Kinematics</span>
+      </a>
+      <a class="card" href="waves.html">
+        <div class="card-icon">🌊</div>
+        <h2>Wave Interference</h2>
+        <p>Superposition of two point sources on a 2D wave field. Constructive and destructive interference patterns in real time.</p>
+        <span class="tag">Wave optics</span>
+      </a>
+      <a class="card" href="collisions.html">
+        <div class="card-icon">⚪</div>
+        <h2>Elastic Collisions</h2>
+        <p>Billiard-ball physics with momentum-conserving impulse resolution. Click to spawn balls and watch energy transfer.</p>
+        <span class="tag">Conservation laws</span>
+      </a>
+      <a class="card" href="orbits.html">
+        <div class="card-icon">🪐</div>
+        <h2>Gravitational Orbits</h2>
+        <p>N-body gravity with presets for binary stars, solar system, and the figure-eight three-body solution.</p>
+        <span class="tag">Celestial mechanics</span>
+      </a>
+      <a class="card" href="springs.html">
+        <div class="card-icon">🔗</div>
+        <h2>Spring–Mass Chain</h2>
+        <p>Coupled harmonic oscillators connected by Hookean springs with adjustable damping. Pluck the chain to excite modes.</p>
+        <span class="tag">Oscillations</span>
+      </a>
+      <a class="card" href="relativity.html">
+        <div class="card-icon">⚡</div>
+        <h2>Special Relativity</h2>
+        <p>Lorentz factor, time dilation, length contraction, and a light-clock thought experiment at relativistic speeds.</p>
+        <span class="tag">Modern physics</span>
+      </a>
+    </div>
+  </main>
+  <footer>Self-contained HTML5 · No external dependencies · Open in any modern browser</footer>
+</body>
+</html>

--- a/assets/html/orbits.html
+++ b/assets/html/orbits.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gravitational Orbits</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:#000; cursor:grab; }
+    canvas:active { cursor:grabbing; }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    select, button { width:100%; margin-top:0.5rem; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); cursor:pointer; font-size:0.85rem; }
+    button:hover, select:hover { border-color:var(--accent); }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.7; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Gravitational Orbits</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Preset</label>
+      <select id="preset">
+        <option value="binary">Binary star</option>
+        <option value="solar">Mini solar system</option>
+        <option value="figure8">Figure-eight (3-body)</option>
+        <option value="random">Random cluster</option>
+      </select>
+      <label>G (gravity) <span class="val" id="gVal">1.0</span></label>
+      <input type="range" id="gravity" min="0.1" max="5" step="0.1" value="1">
+      <label>Time scale <span class="val" id="tVal">1.0×</span></label>
+      <input type="range" id="timescale" min="0.1" max="5" step="0.1" value="1">
+      <label>Softening <span class="val" id="sVal">5</span></label>
+      <input type="range" id="softening" min="1" max="30" step="1" value="5">
+      <button id="reset">Load preset</button>
+      <button id="pause">Pause</button>
+      <div class="stats" id="stats">N-body gravity: F = G·m₁·m₂ / r²</div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H, cx, cy;
+    let bodies = [];
+    let trails = [];
+    let paused = false;
+    let G = 1, timeScale = 1, softening = 5;
+    let panX = 0, panY = 0, zoom = 1;
+    let dragging = false, lastMouse = { x: 0, y: 0 };
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = rect.width; H = rect.height;
+      canvas.width = W * DPR; canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      cx = W / 2; cy = H / 2;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    const PRESETS = {
+      binary: () => [
+        { x: -60, y: 0, vx: 0, vy: -35, m: 100, color: '#f0883e', r: 14 },
+        { x: 60, y: 0, vx: 0, vy: 35, m: 100, color: '#58a6ff', r: 14 }
+      ],
+      solar: () => [
+        { x: 0, y: 0, vx: 0, vy: 0, m: 500, color: '#f0883e', r: 20 },
+        { x: 80, y: 0, vx: 0, vy: 55, m: 2, color: '#8b949e', r: 4 },
+        { x: 130, y: 0, vx: 0, vy: 42, m: 5, color: '#3fb950', r: 7 },
+        { x: 180, y: 0, vx: 0, vy: 35, m: 3, color: '#58a6ff', r: 5 },
+        { x: 240, y: 0, vx: 0, vy: 28, m: 8, color: '#d2a8ff', r: 9 }
+      ],
+      figure8: () => [
+        { x: 0.97000436 * 70, y: -0.24308753 * 70, vx: -0.466203685 * 70, vy: -0.43236573 * 70, m: 1, color: '#58a6ff', r: 8 },
+        { x: -0.97000436 * 70, y: 0.24308753 * 70, vx: -0.466203685 * 70, vy: -0.43236573 * 70, m: 1, color: '#3fb950', r: 8 },
+        { x: 0, y: 0, vx: 0.93240737 * 70, vy: 0.86473146 * 70, m: 1, color: '#f0883e', r: 8 }
+      ],
+      random: () => {
+        const n = 6 + Math.floor(Math.random() * 5);
+        const arr = [];
+        for (let i = 0; i < n; i++) {
+          const angle = Math.random() * Math.PI * 2;
+          const dist = 50 + Math.random() * 150;
+          const m = 5 + Math.random() * 30;
+          arr.push({
+            x: Math.cos(angle) * dist, y: Math.sin(angle) * dist,
+            vx: -Math.sin(angle) * 20 + (Math.random() - 0.5) * 10,
+            vy: Math.cos(angle) * 20 + (Math.random() - 0.5) * 10,
+            m, color: ['#58a6ff','#3fb950','#f0883e','#d2a8ff'][i % 4], r: 4 + Math.sqrt(m)
+          });
+        }
+        return arr;
+      }
+    };
+
+    function loadPreset(name) {
+      bodies = PRESETS[name]();
+      trails = bodies.map(() => []);
+      panX = 0; panY = 0; zoom = 1;
+    }
+
+    function step(dt) {
+      const eps2 = softening * softening;
+      const ax = new Array(bodies.length).fill(0);
+      const ay = new Array(bodies.length).fill(0);
+
+      for (let i = 0; i < bodies.length; i++) {
+        for (let j = i + 1; j < bodies.length; j++) {
+          const dx = bodies[j].x - bodies[i].x;
+          const dy = bodies[j].y - bodies[i].y;
+          const dist2 = dx * dx + dy * dy + eps2;
+          const dist = Math.sqrt(dist2);
+          const f = G * bodies[i].m * bodies[j].m / dist2;
+          const fx = f * dx / dist, fy = f * dy / dist;
+          ax[i] += fx / bodies[i].m; ay[i] += fy / bodies[i].m;
+          ax[j] -= fx / bodies[j].m; ay[j] -= fy / bodies[j].m;
+        }
+      }
+
+      for (let i = 0; i < bodies.length; i++) {
+        bodies[i].vx += ax[i] * dt;
+        bodies[i].vy += ay[i] * dt;
+        bodies[i].x += bodies[i].vx * dt;
+        bodies[i].y += bodies[i].vy * dt;
+        if (trails[i].length > 400) trails[i].shift();
+        trails[i].push({ x: bodies[i].x, y: bodies[i].y });
+      }
+    }
+
+    function toScreen(x, y) {
+      return { x: cx + panX + x * zoom, y: cy + panY + y * zoom };
+    }
+
+    function draw() {
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, W, H);
+
+      for (let s = 0; s < 80; s++) {
+        const sx = (s * 137.5) % W, sy = (s * 97.3) % H;
+        ctx.fillStyle = `rgba(255,255,255,${0.15 + (s % 5) * 0.08})`;
+        ctx.fillRect(sx, sy, 1.5, 1.5);
+      }
+
+      bodies.forEach((b, i) => {
+        ctx.beginPath();
+        trails[i].forEach((p, j) => {
+          const s = toScreen(p.x, p.y);
+          if (j === 0) ctx.moveTo(s.x, s.y);
+          else ctx.lineTo(s.x, s.y);
+        });
+        ctx.strokeStyle = b.color + '55';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+
+        const s = toScreen(b.x, b.y);
+        const grad = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, b.r * zoom * 2);
+        grad.addColorStop(0, b.color);
+        grad.addColorStop(1, 'transparent');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, b.r * zoom * 2, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = b.color;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, b.r * zoom, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      document.getElementById('stats').innerHTML =
+        `Bodies: ${bodies.length}<br>` +
+        `Total mass: ${bodies.reduce((s, b) => s + b.m, 0).toFixed(1)}<br>` +
+        `Drag to pan · Scroll to zoom`;
+    }
+
+    canvas.addEventListener('wheel', e => {
+      e.preventDefault();
+      zoom *= e.deltaY > 0 ? 0.9 : 1.1;
+      zoom = Math.max(0.2, Math.min(5, zoom));
+    }, { passive: false });
+    canvas.addEventListener('mousedown', e => { dragging = true; lastMouse = { x: e.clientX, y: e.clientY }; });
+    window.addEventListener('mouseup', () => dragging = false);
+    window.addEventListener('mousemove', e => {
+      if (!dragging) return;
+      panX += e.clientX - lastMouse.x;
+      panY += e.clientY - lastMouse.y;
+      lastMouse = { x: e.clientX, y: e.clientY };
+    });
+
+    let last = performance.now();
+    function loop(now) {
+      const dt = Math.min((now - last) / 1000, 0.032) * timeScale;
+      last = now;
+      if (!paused) {
+        for (let s = 0; s < 3; s++) step(dt / 3);
+      }
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('gravity').oninput = e => {
+      G = +e.target.value;
+      document.getElementById('gVal').textContent = G.toFixed(1);
+    };
+    document.getElementById('timescale').oninput = e => {
+      timeScale = +e.target.value;
+      document.getElementById('tVal').textContent = timeScale.toFixed(1) + '×';
+    };
+    document.getElementById('softening').oninput = e => {
+      softening = +e.target.value;
+      document.getElementById('sVal').textContent = softening;
+    };
+    document.getElementById('reset').onclick = () => loadPreset(document.getElementById('preset').value);
+    document.getElementById('pause').onclick = () => {
+      paused = !paused;
+      document.getElementById('pause').textContent = paused ? 'Resume' : 'Pause';
+    };
+
+    loadPreset('binary');
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>

--- a/assets/html/pendulum.html
+++ b/assets/html/pendulum.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pendulum Simulation</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; flex-wrap:wrap; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:#0a0e14; cursor:crosshair; }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    button, select { width:100%; margin-top:0.5rem; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); cursor:pointer; font-size:0.85rem; }
+    button:hover { border-color:var(--accent); }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.7; font-variant-numeric:tabular-nums; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Pendulum Simulation</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Mode</label>
+      <select id="mode">
+        <option value="single">Simple pendulum</option>
+        <option value="double" selected>Double pendulum</option>
+      </select>
+      <label>Gravity <span class="val" id="gVal">9.81</span></label>
+      <input type="range" id="gravity" min="1" max="20" step="0.1" value="9.81">
+      <label>Length L₁ <span class="val" id="l1Val">120</span></label>
+      <input type="range" id="len1" min="60" max="200" step="1" value="120">
+      <label>Length L₂ <span class="val" id="l2Val">120</span></label>
+      <input type="range" id="len2" min="60" max="200" step="1" value="120">
+      <label>Damping <span class="val" id="dVal">0.000</span></label>
+      <input type="range" id="damping" min="0" max="0.05" step="0.001" value="0">
+      <label>Initial angle θ₁ <span class="val" id="a1Val">120°</span></label>
+      <input type="range" id="angle1" min="-180" max="180" step="1" value="120">
+      <button id="reset">Reset</button>
+      <button id="pause">Pause</button>
+      <div class="stats" id="stats"></div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H, pivotX, pivotY;
+    let paused = false;
+    let trail = [];
+    const MAX_TRAIL = 800;
+
+    const state = { t1: 0, w1: 0, t2: 0, w2: 0 };
+    const params = { g: 9.81, L1: 120, L2: 120, damp: 0, mode: 'double' };
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = rect.width; H = rect.height;
+      canvas.width = W * DPR; canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      pivotX = W / 2; pivotY = H * 0.28;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    function pos1() {
+      return { x: pivotX + params.L1 * Math.sin(state.t1), y: pivotY + params.L1 * Math.cos(state.t1) };
+    }
+    function pos2() {
+      const p1 = pos1();
+      return { x: p1.x + params.L2 * Math.sin(state.t2), y: p1.y + params.L2 * Math.cos(state.t2) };
+    }
+
+    function derivSingle(y) {
+      const [t, w] = y;
+      const g = params.g * 50 / params.L1;
+      return [w, -(g / 100) * Math.sin(t) - params.damp * w];
+    }
+
+    function derivDouble(y) {
+      const [t1, w1, t2, w2] = y;
+      const m1 = 1, m2 = 1;
+      const L1 = params.L1 / 100, L2 = params.L2 / 100;
+      const g = params.g;
+      const d = t1 - t2;
+      const den1 = (m1 + m2) * L1 - m2 * L1 * Math.cos(d) * Math.cos(d);
+      const den2 = (L2 / L1) * den1;
+      const a1 = (m2 * L1 * w1 * w1 * Math.sin(d) * Math.cos(d)
+        + m2 * g * Math.sin(t2) * Math.cos(d)
+        + m2 * L2 * w2 * w2 * Math.sin(d)
+        - (m1 + m2) * g * Math.sin(t1)) / den1 - params.damp * w1;
+      const a2 = (-m2 * L2 * w2 * w2 * Math.sin(d) * Math.cos(d)
+        + (m1 + m2) * g * Math.sin(t1) * Math.cos(d)
+        - (m1 + m2) * L1 * w1 * w1 * Math.sin(d)
+        - (m1 + m2) * g * Math.sin(t2)) / den2 - params.damp * w2;
+      return [w1, a1, w2, a2];
+    }
+
+    function rk4(deriv, y, dt) {
+      const k1 = deriv(y);
+      const y2 = y.map((v, i) => v + 0.5 * dt * k1[i]);
+      const k2 = deriv(y2);
+      const y3 = y.map((v, i) => v + 0.5 * dt * k2[i]);
+      const k3 = deriv(y3);
+      const y4 = y.map((v, i) => v + dt * k3[i]);
+      const k4 = deriv(y4);
+      return y.map((v, i) => v + (dt / 6) * (k1[i] + 2 * k2[i] + 2 * k3[i] + k4[i]));
+    }
+
+    function reset() {
+      const a1 = +document.getElementById('angle1').value * Math.PI / 180;
+      state.t1 = a1; state.w1 = 0;
+      state.t2 = a1 * 0.7 + 0.01; state.w2 = 0;
+      trail = [];
+    }
+
+    function step(dt) {
+      if (params.mode === 'single') {
+        const y = rk4(derivSingle, [state.t1, state.w1], dt);
+        state.t1 = y[0]; state.w1 = y[1];
+      } else {
+        const y = rk4(derivDouble, [state.t1, state.w1, state.t2, state.w2], dt);
+        [state.t1, state.w1, state.t2, state.w2] = y;
+      }
+    }
+
+    function energy() {
+      const g = params.g;
+      const L1 = params.L1 / 100, L2 = params.L2 / 100;
+      if (params.mode === 'single') {
+        const h = L1 * (1 - Math.cos(state.t1));
+        const ke = 0.5 * L1 * L1 * state.w1 * state.w1;
+        return { pe: g * h, ke, total: g * h + ke };
+      }
+      const p1 = pos1(), p2 = pos2();
+      const y1 = (p1.y - pivotY) / 100, y2 = (p2.y - pivotY) / 100;
+      const v1x = params.L1 * state.w1 * Math.cos(state.t1) / 100;
+      const v1y = -params.L1 * state.w1 * Math.sin(state.t1) / 100;
+      const v2x = v1x + params.L2 * state.w2 * Math.cos(state.t2) / 100;
+      const v2y = v1y - params.L2 * state.w2 * Math.sin(state.t2) / 100;
+      const ke = 0.5 * (v1x * v1x + v1y * v1y) + 0.5 * (v2x * v2x + v2y * v2y);
+      const pe = -g * y1 - g * y2;
+      return { pe, ke, total: pe + ke };
+    }
+
+    function draw() {
+      ctx.fillStyle = '#0a0e14';
+      ctx.fillRect(0, 0, W, H);
+
+      ctx.strokeStyle = '#21262d';
+      ctx.lineWidth = 1;
+      for (let x = 0; x < W; x += 40) { ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke(); }
+      for (let y = 0; y < H; y += 40) { ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke(); }
+
+      const p1 = pos1();
+      const bob = params.mode === 'single' ? p1 : pos2();
+
+      if (params.mode === 'double') {
+        if (trail.length >= MAX_TRAIL) trail.shift();
+        trail.push({ x: bob.x, y: bob.y });
+        ctx.beginPath();
+        trail.forEach((p, i) => {
+          if (i === 0) ctx.moveTo(p.x, p.y);
+          else ctx.lineTo(p.x, p.y);
+        });
+        ctx.strokeStyle = 'rgba(88,166,255,0.35)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+
+      ctx.strokeStyle = '#8b949e';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(pivotX, pivotY);
+      ctx.lineTo(p1.x, p1.y);
+      if (params.mode === 'double') ctx.lineTo(bob.x, bob.y);
+      ctx.stroke();
+
+      ctx.fillStyle = '#30363d';
+      ctx.beginPath();
+      ctx.arc(pivotX, pivotY, 6, 0, Math.PI * 2);
+      ctx.fill();
+
+      if (params.mode === 'double') {
+        ctx.fillStyle = '#58a6ff';
+        ctx.beginPath();
+        ctx.arc(p1.x, p1.y, 10, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.fillStyle = params.mode === 'single' ? '#58a6ff' : '#3fb950';
+      ctx.beginPath();
+      ctx.arc(bob.x, bob.y, 14, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+
+      const e = energy();
+      document.getElementById('stats').innerHTML =
+        `<strong>State</strong><br>` +
+        `θ₁ = ${(state.t1 * 180 / Math.PI).toFixed(1)}°<br>` +
+        (params.mode === 'double' ? `θ₂ = ${(state.t2 * 180 / Math.PI).toFixed(1)}°<br>` : '') +
+        `KE = ${e.ke.toFixed(3)} J<br>PE = ${e.pe.toFixed(3)} J<br>E = ${e.total.toFixed(3)} J`;
+    }
+
+    let last = performance.now();
+    function loop(now) {
+      const dt = Math.min((now - last) / 1000, 0.032);
+      last = now;
+      if (!paused) {
+        for (let i = 0; i < 4; i++) step(dt / 4);
+      }
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('gravity').oninput = e => {
+      params.g = +e.target.value;
+      document.getElementById('gVal').textContent = params.g.toFixed(2);
+    };
+    document.getElementById('len1').oninput = e => {
+      params.L1 = +e.target.value;
+      document.getElementById('l1Val').textContent = params.L1;
+    };
+    document.getElementById('len2').oninput = e => {
+      params.L2 = +e.target.value;
+      document.getElementById('l2Val').textContent = params.L2;
+    };
+    document.getElementById('damping').oninput = e => {
+      params.damp = +e.target.value;
+      document.getElementById('dVal').textContent = params.damp.toFixed(3);
+    };
+    document.getElementById('angle1').oninput = e => {
+      document.getElementById('a1Val').textContent = e.target.value + '°';
+    };
+    document.getElementById('mode').onchange = e => {
+      params.mode = e.target.value;
+      reset();
+    };
+    document.getElementById('reset').onclick = reset;
+    document.getElementById('pause').onclick = () => {
+      paused = !paused;
+      document.getElementById('pause').textContent = paused ? 'Resume' : 'Pause';
+    };
+
+    reset();
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>

--- a/assets/html/projectile.html
+++ b/assets/html/projectile.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projectile Motion</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:linear-gradient(to bottom,#0a1628 0%,#0a0e14 40%,#1a1208 40%,#0f0a06 100%); }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    button { width:100%; margin-top:0.75rem; padding:0.55rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); cursor:pointer; }
+    button:hover { border-color:var(--accent); }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.8; font-variant-numeric:tabular-nums; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Projectile Motion</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Launch angle <span class="val" id="angVal">45°</span></label>
+      <input type="range" id="angle" min="5" max="85" step="1" value="45">
+      <label>Initial speed <span class="val" id="spdVal">50 m/s</span></label>
+      <input type="range" id="speed" min="10" max="100" step="1" value="50">
+      <label>Gravity <span class="val" id="gVal">9.81 m/s²</span></label>
+      <input type="range" id="gravity" min="1" max="20" step="0.1" value="9.81">
+      <label>Drag coefficient <span class="val" id="dragVal">0.00</span></label>
+      <input type="range" id="drag" min="0" max="0.15" step="0.005" value="0">
+      <button id="fire">Launch</button>
+      <button id="clear">Clear trails</button>
+      <div class="stats" id="stats">Adjust parameters and launch.</div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H, groundY, scale;
+
+    const params = { angle: 45, speed: 50, g: 9.81, drag: 0 };
+    let projectile = null;
+    let trails = [];
+    let currentTrail = [];
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = rect.width; H = rect.height;
+      canvas.width = W * DPR; canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      groundY = H * 0.72;
+      scale = Math.min(W, H) / 120;
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    function launch() {
+      const rad = params.angle * Math.PI / 180;
+      projectile = {
+        x: W * 0.08, y: groundY,
+        vx: params.speed * Math.cos(rad) * scale * 0.12,
+        vy: -params.speed * Math.sin(rad) * scale * 0.12,
+        t: 0
+      };
+      currentTrail = [{ x: projectile.x, y: projectile.y }];
+    }
+
+    function step(dt) {
+      if (!projectile) return;
+      const p = projectile;
+      const speed = Math.hypot(p.vx, p.vy);
+      const dragF = params.drag * speed * speed * 0.001;
+      const ax = speed > 0 ? -dragF * p.vx / speed : 0;
+      const ay = params.g * scale * 0.012 + (speed > 0 ? -dragF * p.vy / speed : 0);
+      p.vx += ax * dt;
+      p.vy += ay * dt;
+      p.x += p.vx * dt * 60;
+      p.y += p.vy * dt * 60;
+      p.t += dt;
+      currentTrail.push({ x: p.x, y: p.y });
+      if (p.y >= groundY) {
+        p.y = groundY;
+        trails.push([...currentTrail]);
+        currentTrail = [];
+        projectile = null;
+      }
+    }
+
+    function analyticNoDrag() {
+      const rad = params.angle * Math.PI / 180;
+      const v0 = params.speed;
+      const g = params.g;
+      const tFlight = 2 * v0 * Math.sin(rad) / g;
+      const range = v0 * v0 * Math.sin(2 * rad) / g;
+      const maxH = v0 * v0 * Math.sin(rad) * Math.sin(rad) / (2 * g);
+      return { tFlight, range, maxH };
+    }
+
+    function draw() {
+      ctx.fillStyle = '#0a1628';
+      ctx.fillRect(0, 0, W, groundY);
+      ctx.fillStyle = '#1a1208';
+      ctx.fillRect(0, groundY, W, H - groundY);
+      ctx.strokeStyle = '#3d2e1a';
+      ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.moveTo(0, groundY); ctx.lineTo(W, groundY); ctx.stroke();
+
+      ctx.strokeStyle = 'rgba(88,166,255,0.25)';
+      ctx.lineWidth = 1.5;
+      trails.forEach(trail => {
+        ctx.beginPath();
+        trail.forEach((pt, i) => { if (i === 0) ctx.moveTo(pt.x, pt.y); else ctx.lineTo(pt.x, pt.y); });
+        ctx.stroke();
+      });
+      if (currentTrail.length > 1) {
+        ctx.strokeStyle = '#58a6ff';
+        ctx.beginPath();
+        currentTrail.forEach((pt, i) => { if (i === 0) ctx.moveTo(pt.x, pt.y); else ctx.lineTo(pt.x, pt.y); });
+        ctx.stroke();
+      }
+
+      const launchX = W * 0.08;
+      ctx.fillStyle = '#8b949e';
+      ctx.fillRect(launchX - 4, groundY - 30, 8, 30);
+      ctx.fillStyle = '#58a6ff';
+      ctx.beginPath();
+      ctx.arc(launchX, groundY - 32, 8, 0, Math.PI * 2);
+      ctx.fill();
+
+      if (projectile) {
+        ctx.fillStyle = '#f0883e';
+        ctx.beginPath();
+        ctx.arc(projectile.x, projectile.y, 7, 0, Math.PI * 2);
+        ctx.fill();
+        const a = analyticNoDrag();
+        document.getElementById('stats').innerHTML =
+          `<strong>In flight</strong><br>t = ${projectile.t.toFixed(2)} s<br>` +
+          `x = ${((projectile.x - launchX) / scale / 0.12).toFixed(1)} m<br>` +
+          `y = ${((groundY - projectile.y) / scale / 0.12).toFixed(1)} m<br><br>` +
+          `<strong>No-drag theory</strong><br>Range = ${a.range.toFixed(1)} m<br>` +
+          `Max height = ${a.maxH.toFixed(1)} m<br>Flight time = ${a.tFlight.toFixed(2)} s`;
+      }
+    }
+
+    let last = performance.now();
+    function loop(now) {
+      step(Math.min((now - last) / 1000, 0.032));
+      last = now;
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('angle').oninput = e => {
+      params.angle = +e.target.value;
+      document.getElementById('angVal').textContent = params.angle + '°';
+    };
+    document.getElementById('speed').oninput = e => {
+      params.speed = +e.target.value;
+      document.getElementById('spdVal').textContent = params.speed + ' m/s';
+    };
+    document.getElementById('gravity').oninput = e => {
+      params.g = +e.target.value;
+      document.getElementById('gVal').textContent = params.g.toFixed(2) + ' m/s²';
+    };
+    document.getElementById('drag').oninput = e => {
+      params.drag = +e.target.value;
+      document.getElementById('dragVal').textContent = params.drag.toFixed(3);
+    };
+    document.getElementById('fire').onclick = launch;
+    document.getElementById('clear').onclick = () => { trails = []; currentTrail = []; };
+
+    const a = analyticNoDrag();
+    document.getElementById('stats').innerHTML =
+      `<strong>No-drag theory</strong><br>Range = ${a.range.toFixed(1)} m<br>` +
+      `Max height = ${a.maxH.toFixed(1)} m<br>Flight time = ${a.tFlight.toFixed(2)} s`;
+
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>

--- a/assets/html/relativity.html
+++ b/assets/html/relativity.html
@@ -1,10 +1,256 @@
-<html>
-  <body>
-    <center>
-      <h2>Relativity: the Special and General Theory</h2>
-      <h5>Albert Einstein</h5>
-      <br />
-      Insert HTML document here.
-    </center>
-  </body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Special Relativity</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; flex-wrap:wrap; }
+    .panel { flex:1; min-width:320px; display:flex; flex-direction:column; border-right:1px solid var(--border); }
+    .panel:last-child { border-right:none; }
+    .panel h2 { font-size:0.85rem; padding:0.75rem 1rem; border-bottom:1px solid var(--border); color:var(--muted); text-transform:uppercase; letter-spacing:0.06em; }
+    canvas { flex:1; display:block; background:#0a0e14; min-height:220px; }
+    aside { width:100%; border-top:1px solid var(--border); background:var(--surface); padding:1rem 1.25rem; display:flex; flex-wrap:wrap; gap:1.5rem; align-items:flex-end; }
+    .control { flex:1; min-width:180px; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin-bottom:0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { color:var(--accent); font-variant-numeric:tabular-nums; }
+    .formula { padding:0.75rem 1rem; font-size:0.85rem; line-height:1.8; font-family:"Courier New",monospace; color:var(--muted); border-top:1px solid var(--border); }
+    .formula em { color:var(--accent); font-style:normal; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Special Relativity</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <div class="panel">
+      <h2>Lorentz factor γ(v)</h2>
+      <canvas id="graph"></canvas>
+      <div class="formula" id="formulas"></div>
+    </div>
+    <div class="panel">
+      <h2>Light clock (rest vs moving frame)</h2>
+      <canvas id="clock"></canvas>
+    </div>
+  </div>
+  <aside>
+    <div class="control">
+      <label>Velocity v/c <span class="val" id="vVal">0.60</span></label>
+      <input type="range" id="velocity" min="0" max="0.999" step="0.001" value="0.6">
+    </div>
+    <div class="control">
+      <label>γ (Lorentz factor) <span class="val" id="gVal">1.25</span></label>
+    </div>
+    <div class="control">
+      <label>Time dilation Δt/Δt₀ <span class="val" id="tVal">1.25</span></label>
+    </div>
+    <div class="control">
+      <label>Length contraction L/L₀ <span class="val" id="lVal">0.80</span></label>
+    </div>
+  </aside>
+  <script>
+    const graphCanvas = document.getElementById('graph');
+    const clockCanvas = document.getElementById('clock');
+    const gCtx = graphCanvas.getContext('2d');
+    const cCtx = clockCanvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let beta = 0.6;
+    let time = 0;
+
+    function gamma(v) { return 1 / Math.sqrt(1 - v * v); }
+
+    function setupCanvas(canvas, ctx) {
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * DPR;
+      canvas.height = rect.height * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      return { W: rect.width, H: rect.height };
+    }
+
+    function drawGraph() {
+      const { W, H } = setupCanvas(graphCanvas, gCtx);
+      gCtx.fillStyle = '#0a0e14';
+      gCtx.fillRect(0, 0, W, H);
+
+      const pad = { l: 50, r: 20, t: 20, b: 40 };
+      const plotW = W - pad.l - pad.r, plotH = H - pad.t - pad.b;
+
+      gCtx.strokeStyle = '#30363d';
+      gCtx.lineWidth = 1;
+      gCtx.beginPath();
+      gCtx.moveTo(pad.l, pad.t);
+      gCtx.lineTo(pad.l, pad.t + plotH);
+      gCtx.lineTo(pad.l + plotW, pad.t + plotH);
+      gCtx.stroke();
+
+      gCtx.fillStyle = '#8b949e';
+      gCtx.font = '11px system-ui';
+      gCtx.fillText('0', pad.l - 8, pad.t + plotH + 14);
+      gCtx.fillText('1', pad.l + plotW - 4, pad.t + plotH + 14);
+      gCtx.fillText('γ', pad.l - 30, pad.t + 10);
+      gCtx.fillText('v/c', pad.l + plotW / 2 - 10, H - 8);
+
+      const maxGamma = 10;
+      gCtx.strokeStyle = '#58a6ff';
+      gCtx.lineWidth = 2;
+      gCtx.beginPath();
+      for (let i = 0; i <= plotW; i++) {
+        const v = i / plotW;
+        const g = Math.min(gamma(v), maxGamma);
+        const x = pad.l + i;
+        const y = pad.t + plotH - (g / maxGamma) * plotH;
+        if (i === 0) gCtx.moveTo(x, y);
+        else gCtx.lineTo(x, y);
+      }
+      gCtx.stroke();
+
+      const g = gamma(beta);
+      const markerX = pad.l + beta * plotW;
+      const markerY = pad.t + plotH - (Math.min(g, maxGamma) / maxGamma) * plotH;
+      gCtx.strokeStyle = '#f0883e';
+      gCtx.setLineDash([4, 4]);
+      gCtx.beginPath();
+      gCtx.moveTo(markerX, pad.t + plotH);
+      gCtx.lineTo(markerX, markerY);
+      gCtx.lineTo(pad.l, markerY);
+      gCtx.stroke();
+      gCtx.setLineDash([]);
+      gCtx.fillStyle = '#f0883e';
+      gCtx.beginPath();
+      gCtx.arc(markerX, markerY, 5, 0, Math.PI * 2);
+      gCtx.fill();
+
+      gCtx.strokeStyle = '#3fb950';
+      gCtx.lineWidth = 1.5;
+      gCtx.setLineDash([6, 4]);
+      gCtx.beginPath();
+      for (let i = 0; i <= plotW; i++) {
+        const v = i / plotW;
+        const lc = Math.sqrt(1 - v * v);
+        const x = pad.l + i;
+        const y = pad.t + plotH - lc * plotH * 0.5;
+        if (i === 0) gCtx.moveTo(x, y);
+        else gCtx.lineTo(x, y);
+      }
+      gCtx.stroke();
+      gCtx.setLineDash([]);
+      gCtx.fillStyle = '#3fb950';
+      gCtx.fillText('L/L₀ (length contraction)', pad.l + 10, pad.t + 20);
+      gCtx.fillStyle = '#58a6ff';
+      gCtx.fillText('γ (time dilation)', pad.l + 10, pad.t + 36);
+    }
+
+    function drawClock() {
+      const { W, H } = setupCanvas(clockCanvas, cCtx);
+      cCtx.fillStyle = '#0a0e14';
+      cCtx.fillRect(0, 0, W, H);
+
+      const g = gamma(beta);
+      const halfW = W / 2;
+
+      function lightClock(ctx, cx, cy, height, label, contracted) {
+        const h = contracted ? height / g : height;
+        const w = contracted ? 50 / g : 50;
+        ctx.strokeStyle = '#8b949e';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(cx - w / 2, cy - h, w, h);
+        ctx.fillStyle = '#e6edf3';
+        ctx.font = '12px system-ui';
+        ctx.textAlign = 'center';
+        ctx.fillText(label, cx, cy + 24);
+
+        const period = contracted ? 2 * h : 2 * height;
+        const phase = (time * 120) % period;
+        const goingUp = phase < (contracted ? h : height);
+        const y = goingUp
+          ? cy - phase
+          : cy - (contracted ? h : height) - (phase - (contracted ? h : height));
+
+        if (contracted) {
+          const zigPhase = (time * 120) % (2 * h);
+          const dx = w / 2;
+          let px, py;
+          if (zigPhase < h) {
+            px = cx + dx * (zigPhase / h);
+            py = cy - zigPhase;
+          } else {
+            px = cx + dx - dx * ((zigPhase - h) / h);
+            py = cy - h - (zigPhase - h);
+          }
+          ctx.strokeStyle = '#f0883e';
+          ctx.beginPath();
+          ctx.moveTo(cx, cy);
+          ctx.lineTo(px, py);
+          ctx.stroke();
+          ctx.fillStyle = '#f0883e';
+          ctx.beginPath();
+          ctx.arc(px, py, 5, 0, Math.PI * 2);
+          ctx.fill();
+        } else {
+          ctx.strokeStyle = '#58a6ff';
+          ctx.beginPath();
+          ctx.moveTo(cx, cy);
+          ctx.lineTo(cx, y);
+          ctx.stroke();
+          ctx.fillStyle = '#58a6ff';
+          ctx.beginPath();
+          ctx.arc(cx, y, 5, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+
+      lightClock(cCtx, halfW * 0.5, H * 0.65, H * 0.35, 'Rest frame (v = 0)', false);
+      lightClock(cCtx, halfW * 1.5, H * 0.65, H * 0.35, `Moving frame (v = ${(beta * 100).toFixed(1)}% c)`, true);
+
+      cCtx.textAlign = 'left';
+      cCtx.fillStyle = '#8b949e';
+      cCtx.font = '11px system-ui';
+      cCtx.fillText('Proper time Δt₀ = 2h/c', 12, 20);
+      cCtx.fillText(`Dilated time Δt = γ·Δt₀ = ${g.toFixed(2)}·Δt₀`, 12, 36);
+    }
+
+    function updateReadouts() {
+      const g = gamma(beta);
+      document.getElementById('vVal').textContent = beta.toFixed(3);
+      document.getElementById('gVal').textContent = g.toFixed(3);
+      document.getElementById('tVal').textContent = g.toFixed(3);
+      document.getElementById('lVal').textContent = (1 / g).toFixed(3);
+      document.getElementById('formulas').innerHTML =
+        `γ = 1/√(1 − v²/c²) = <em>${g.toFixed(4)}</em><br>` +
+        `Δt = γ·Δt₀ = <em>${g.toFixed(4)}</em> · Δt₀<br>` +
+        `L = L₀/γ = <em>${(1/g).toFixed(4)}</em> · L₀`;
+    }
+
+    function draw() {
+      drawGraph();
+      drawClock();
+      updateReadouts();
+    }
+
+    document.getElementById('velocity').oninput = e => {
+      beta = +e.target.value;
+      draw();
+    };
+
+    let last = performance.now();
+    function loop(now) {
+      time += Math.min((now - last) / 1000, 0.032);
+      last = now;
+      drawClock();
+      requestAnimationFrame(loop);
+    }
+
+    window.addEventListener('resize', draw);
+    draw();
+    requestAnimationFrame(loop);
+  </script>
+</body>
 </html>

--- a/assets/html/springs.html
+++ b/assets/html/springs.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Spring–Mass Chain</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:#0a0e14; cursor:pointer; }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    button { width:100%; margin-top:0.5rem; padding:0.5rem; border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--text); cursor:pointer; }
+    button:hover { border-color:var(--accent); }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.7; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Spring–Mass Chain</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Masses <span class="val" id="nVal">12</span></label>
+      <input type="range" id="count" min="3" max="24" step="1" value="12">
+      <label>Spring k <span class="val" id="kVal">80</span></label>
+      <input type="range" id="springK" min="10" max="200" step="5" value="80">
+      <label>Damping <span class="val" id="dVal">0.02</span></label>
+      <input type="range" id="damping" min="0" max="0.2" step="0.005" value="0.02">
+      <label>Rest length <span class="val" id="lVal">40</span></label>
+      <input type="range" id="restLen" min="20" max="80" step="1" value="40">
+      <button id="reset">Reset chain</button>
+      <div class="stats">Click or drag on the canvas to pluck a mass. The chain models F = −k·Δx with velocity damping.</div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H;
+    let masses = [];
+    let k = 80, damp = 0.02, restLen = 40, anchorY;
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = rect.width; H = rect.height;
+      canvas.width = W * DPR; canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      anchorY = H * 0.35;
+      initMasses(+document.getElementById('count').value);
+    }
+    window.addEventListener('resize', resize);
+
+    function initMasses(n) {
+      const spacing = restLen;
+      const totalW = (n - 1) * spacing;
+      const startX = (W - totalW) / 2;
+      masses = [];
+      for (let i = 0; i < n; i++) {
+        masses.push({ x: startX + i * spacing, y: anchorY, vx: 0, vy: 0, pinned: i === 0 || i === n - 1 });
+      }
+    }
+
+    function step(dt) {
+      const forces = masses.map(() => ({ fx: 0, fy: 0 }));
+
+      for (let i = 0; i < masses.length - 1; i++) {
+        const a = masses[i], b = masses[i + 1];
+        const dx = b.x - a.x, dy = b.y - a.y;
+        const dist = Math.hypot(dx, dy) || 0.001;
+        const stretch = dist - restLen;
+        const fx = k * stretch * dx / dist;
+        const fy = k * stretch * dy / dist;
+        forces[i].fx += fx; forces[i].fy += fy;
+        forces[i + 1].fx -= fx; forces[i + 1].fy -= fy;
+      }
+
+      masses.forEach((m, i) => {
+        if (m.pinned) return;
+        m.vx += (forces[i].fx - damp * m.vx) * dt;
+        m.vy += (forces[i].fy - damp * m.vy) * dt;
+        m.x += m.vx * dt * 60;
+        m.y += m.vy * dt * 60;
+      });
+    }
+
+    function draw() {
+      ctx.fillStyle = '#0a0e14';
+      ctx.fillRect(0, 0, W, H);
+
+      ctx.strokeStyle = '#58a6ff';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      masses.forEach((m, i) => { if (i === 0) ctx.moveTo(m.x, m.y); else ctx.lineTo(m.x, m.y); });
+      ctx.stroke();
+
+      masses.forEach((m, i) => {
+        ctx.fillStyle = m.pinned ? '#8b949e' : '#3fb950';
+        ctx.beginPath();
+        ctx.arc(m.x, m.y, m.pinned ? 8 : 10, 0, Math.PI * 2);
+        ctx.fill();
+        if (m.pinned) {
+          ctx.strokeStyle = '#30363d';
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.moveTo(m.x, m.y - 30);
+          ctx.lineTo(m.x, m.y);
+          ctx.stroke();
+        }
+      });
+    }
+
+    function pluck(x, y) {
+      let best = -1, bestD = 40;
+      masses.forEach((m, i) => {
+        if (m.pinned) return;
+        const d = Math.hypot(m.x - x, m.y - y);
+        if (d < bestD) { bestD = d; best = i; }
+      });
+      if (best >= 0) {
+        masses[best].vy -= 300;
+        masses[best].vx += (Math.random() - 0.5) * 100;
+      }
+    }
+
+    let dragging = false;
+    canvas.addEventListener('mousedown', e => { dragging = true; pluck(e.offsetX, e.offsetY); });
+    canvas.addEventListener('mousemove', e => { if (dragging) pluck(e.offsetX, e.offsetY); });
+    canvas.addEventListener('mouseup', () => dragging = false);
+    canvas.addEventListener('mouseleave', () => dragging = false);
+
+    let last = performance.now();
+    function loop(now) {
+      const dt = Math.min((now - last) / 1000, 0.032);
+      last = now;
+      for (let i = 0; i < 4; i++) step(dt / 4);
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('springK').oninput = e => {
+      k = +e.target.value;
+      document.getElementById('kVal').textContent = k;
+    };
+    document.getElementById('damping').oninput = e => {
+      damp = +e.target.value;
+      document.getElementById('dVal').textContent = damp.toFixed(3);
+    };
+    document.getElementById('restLen').oninput = e => {
+      restLen = +e.target.value;
+      document.getElementById('lVal').textContent = restLen;
+    };
+    document.getElementById('count').oninput = e => {
+      document.getElementById('nVal').textContent = e.target.value;
+    };
+    document.getElementById('reset').onclick = () => initMasses(+document.getElementById('count').value);
+
+    resize();
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>

--- a/assets/html/waves.html
+++ b/assets/html/waves.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Wave Interference</title>
+  <style>
+    :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+    * { box-sizing:border-box; margin:0; padding:0; }
+    body { font-family:system-ui,sans-serif; background:var(--bg); color:var(--text); min-height:100vh; display:flex; flex-direction:column; }
+    header { padding:1rem 1.25rem; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:1rem; }
+    header h1 { font-size:1.15rem; flex:1; }
+    header a { color:var(--accent); text-decoration:none; font-size:0.85rem; }
+    .layout { display:flex; flex:1; min-height:0; }
+    canvas { flex:1; display:block; background:#000; image-rendering:pixelated; }
+    aside { width:280px; border-left:1px solid var(--border); background:var(--surface); padding:1rem; overflow-y:auto; }
+    label { display:block; font-size:0.78rem; color:var(--muted); margin:0.75rem 0 0.25rem; text-transform:uppercase; letter-spacing:0.05em; }
+    input[type=range] { width:100%; accent-color:var(--accent); }
+    .val { float:right; color:var(--accent); font-variant-numeric:tabular-nums; }
+    .stats { margin-top:1rem; padding:0.75rem; background:var(--bg); border-radius:8px; font-size:0.82rem; line-height:1.7; }
+    @media (max-width:700px) { .layout { flex-direction:column; } aside { width:100%; border-left:none; border-top:1px solid var(--border); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Wave Interference</h1>
+    <a href="index.html">← All simulations</a>
+  </header>
+  <div class="layout">
+    <canvas id="c"></canvas>
+    <aside>
+      <label>Frequency <span class="val" id="fVal">2.0 Hz</span></label>
+      <input type="range" id="freq" min="0.5" max="5" step="0.1" value="2">
+      <label>Wavelength <span class="val" id="wVal">80 px</span></label>
+      <input type="range" id="wavelength" min="30" max="150" step="1" value="80">
+      <label>Source separation <span class="val" id="sVal">120 px</span></label>
+      <input type="range" id="sep" min="40" max="250" step="1" value="120">
+      <label>Phase offset <span class="val" id="pVal">0°</span></label>
+      <input type="range" id="phase" min="0" max="360" step="1" value="0">
+      <label>Wave speed <span class="val" id="vVal">160 px/s</span></label>
+      <input type="range" id="speed" min="50" max="400" step="10" value="160">
+      <div class="stats">
+        Two coherent point sources emit circular waves. The color map shows instantaneous displacement; bright bands indicate constructive interference, dark regions destructive.
+      </div>
+    </aside>
+  </div>
+  <script>
+    const canvas = document.getElementById('c');
+    const ctx = canvas.getContext('2d');
+    const DPR = window.devicePixelRatio || 1;
+    let W, H, imgData;
+
+    const params = { freq: 2, wavelength: 80, sep: 120, phase: 0, speed: 160 };
+    let time = 0;
+
+    function resize() {
+      const rect = canvas.getBoundingClientRect();
+      W = Math.floor(rect.width);
+      H = Math.floor(rect.height);
+      canvas.width = W * DPR;
+      canvas.height = H * DPR;
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+      imgData = ctx.createImageData(W, H);
+    }
+    window.addEventListener('resize', resize);
+    resize();
+
+    function waveColor(amp) {
+      const t = (amp + 2) / 4;
+      const r = Math.floor(20 + 60 * t);
+      const g = Math.floor(80 + 120 * t);
+      const b = Math.floor(180 + 75 * (1 - t));
+      return [r, g, b];
+    }
+
+    function draw() {
+      const k = 2 * Math.PI / params.wavelength;
+      const omega = 2 * Math.PI * params.freq;
+      const cx = W / 2, cy = H / 2;
+      const s1x = cx - params.sep / 2, s2x = cx + params.sep / 2;
+      const sy = cy;
+      const phase2 = params.phase * Math.PI / 180;
+      const data = imgData.data;
+      const step = 2;
+
+      for (let y = 0; y < H; y += step) {
+        for (let x = 0; x < W; x += step) {
+          const r1 = Math.hypot(x - s1x, y - sy);
+          const r2 = Math.hypot(x - s2x, y - sy);
+          const amp = Math.sin(k * r1 - omega * time) + Math.sin(k * r2 - omega * time + phase2);
+          const [r, g, b] = waveColor(amp);
+          for (let dy = 0; dy < step && y + dy < H; dy++) {
+            for (let dx = 0; dx < step && x + dx < W; dx++) {
+              const idx = ((y + dy) * W + (x + dx)) * 4;
+              data[idx] = r; data[idx + 1] = g; data[idx + 2] = b; data[idx + 3] = 255;
+            }
+          }
+        }
+      }
+      ctx.putImageData(imgData, 0, 0);
+
+      ctx.fillStyle = '#fff';
+      ctx.beginPath(); ctx.arc(s1x, sy, 5, 0, Math.PI * 2); ctx.fill();
+      ctx.beginPath(); ctx.arc(s2x, sy, 5, 0, Math.PI * 2); ctx.fill();
+    }
+
+    let last = performance.now();
+    function loop(now) {
+      time += Math.min((now - last) / 1000, 0.032);
+      last = now;
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    document.getElementById('freq').oninput = e => {
+      params.freq = +e.target.value;
+      document.getElementById('fVal').textContent = params.freq.toFixed(1) + ' Hz';
+    };
+    document.getElementById('wavelength').oninput = e => {
+      params.wavelength = +e.target.value;
+      document.getElementById('wVal').textContent = params.wavelength + ' px';
+    };
+    document.getElementById('sep').oninput = e => {
+      params.sep = +e.target.value;
+      document.getElementById('sVal').textContent = params.sep + ' px';
+    };
+    document.getElementById('phase').oninput = e => {
+      params.phase = +e.target.value;
+      document.getElementById('pVal').textContent = params.phase + '°';
+    };
+    document.getElementById('speed').oninput = e => {
+      params.speed = +e.target.value;
+      document.getElementById('vVal').textContent = params.speed + ' px/s';
+    };
+
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Create a suite of interactive physics demos in assets/html/ using only Canvas 2D and vanilla JavaScript — no external libraries.

Simulations:
- index.html: hub page linking all demos
- pendulum.html: simple and double pendulum (RK4)
- projectile.html: trajectories with optional air drag
- waves.html: two-source wave interference
- collisions.html: elastic billiard-ball collisions
- orbits.html: N-body gravitational presets
- springs.html: coupled spring-mass chain
- relativity.html: Lorentz factor and light-clock visualization

## Summary

Describe what changed and why.

## Ownership Routing

- [ ] I confirmed this PR targets the correct repo based on `docs/BOUNDARIES.md`.
- [ ] This PR only changes starter-owned scope (`al-folio`) **or** I am porting a routed change and linked the owning repo issue/PR.

Owning repo (if not starter): <!-- e.g., al-org-dev/al-folio-core -->
Related issue/PR: <!-- link -->

## Plugin Ecosystem (if applicable)

- [ ] Not applicable
- [ ] This PR proposes a plugin for **featured-only** listing.
- [ ] This PR proposes a plugin for **bundled** starter inclusion.

If plugin-related, provide:

- Plugin repo URL:
- Gem name:
- Jekyll plugin id:
- Compatibility (`al_folio_min`/`al_folio_max`):
- Demo page/post path:
- Maintainer contact:

## Starter Wiring Changes

- [ ] Not applicable
- [ ] Updated `Gemfile` dependency wiring.
- [ ] Updated `_config.yml` plugin activation/config.
- [ ] Updated `_data/featured_plugins.yml` metadata.

## Validation

- [ ] `npm ci`
- [ ] `bundle exec jekyll build`
- [ ] `npm run lint:prettier`
- [ ] `npm run lint:style-contract`
- [ ] Integration tests (`test/integration_*.sh`) as needed
- [ ] Visual tests (`npm run test:visual`) as needed

## Notes

Compatibility, migration implications, and follow-ups:
