### PR TITLE
fix: point repo cards at the maintained github-stats-extended service

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Photo formatting is made simple using Tailwind-first responsive layout utilities
 
 #### GitHub's repositories and user stats
 
-**al-folio** displays GitHub repositories and user stats on the `/repositories/` page using [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) and [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy).
+**al-folio** displays GitHub repositories and user stats on the `/repositories/` page using [github-stats-extended](https://github.com/stats-organization/github-stats-extended) and [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy).
 
 [![Repositories Preview](readme_preview/repositories.png)](https://alshedivat.github.io/al-folio/repositories/)
 

--- a/_config.yml
+++ b/_config.yml
@@ -29,8 +29,8 @@ back_to_top: true # set to false to disable the back to top button
 # -----------------------------------------------------------------------------
 
 # repo color theme
-repo_theme_light: default # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
-repo_theme_dark: dark # https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md
+repo_theme_light: default # https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md
+repo_theme_dark: dark # https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md
 repo_trophies:
   enabled: true
   theme_light: flat # https://github.com/ryo-ma/github-profile-trophy
@@ -40,7 +40,7 @@ repo_trophies:
 # To use a different instance or service for displaying GitHub stats and trophies,
 # update these URLs. These are used in the repository templates.
 external_services:
-  github_readme_stats_url: https://github-readme-stats.vercel.app
+  github_readme_stats_url: https://github-stats-extended.vercel.app
   github_profile_trophy_url: https://github-profile-trophy.vercel.app
 
 # -----------------------------------------------------------------------------

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -396,7 +396,7 @@ The user and repository information is defined in [\_data/repositories.yml](../_
 
 The repository page uses external services to display GitHub statistics and trophies. By default, these are:
 
-- `github-readme-stats.vercel.app` for user stats and repository cards
+- `github-stats-extended.vercel.app` for user stats and repository cards
 - `github-profile-trophy.vercel.app` for GitHub profile trophies
 
 **Important:** These default services are hosted by third parties and may not be available 100% of the time. For better reliability, privacy, and customization, you can self-host these services and configure your website to use your own instances.
@@ -405,16 +405,29 @@ To use your own instances of these services, configure the URLs in [\_config.yml
 
 ```yaml
 external_services:
-  github_readme_stats_url: https://github-readme-stats.vercel.app
+  github_readme_stats_url: https://github-stats-extended.vercel.app
   github_profile_trophy_url: https://github-profile-trophy.vercel.app
 ```
 
 To self-host these services, follow the deployment instructions in their respective repositories:
 
-- [github-readme-stats](https://github.com/anuraghazra/github-readme-stats)
+- [github-stats-extended](https://github.com/stats-organization/github-stats-extended)
 - [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy)
 
 Once deployed, update the URLs above to point to your custom deployment.
+
+#### Migrating from github-readme-stats
+
+Earlier versions of al-folio defaulted to `github-readme-stats.vercel.app`. That public instance is no longer reliably available, which is why repository cards render blank on some sites. The default is now [github-stats-extended](https://github.com/stats-organization/github-stats-extended), an actively maintained, API-compatible successor.
+
+If your site was created before this change, your `_config.yml` still pins the old host. Update it by hand:
+
+```yaml
+external_services:
+  github_readme_stats_url: https://github-stats-extended.vercel.app
+```
+
+Only the domain changes — the endpoints and every query parameter al-folio sends (`theme`, `locale`, `show_owner`, `description_lines_count`, `show_icons`) are unchanged, so your cards keep the same appearance and your `repo_theme_light` / `repo_theme_dark` settings continue to work.
 
 ## Creating new pages
 

--- a/test/visual/helpers.js
+++ b/test/visual/helpers.js
@@ -18,7 +18,7 @@ async function applyNetworkStubs(page) {
 
   await page.route("**/*", (route) => {
     const url = route.request().url();
-    if (url.includes("github-readme-stats.vercel.app")) {
+    if (url.includes("github-stats-extended.vercel.app") || url.includes("github-readme-stats.vercel.app")) {
       route.fulfill({
         status: 200,
         contentType: "image/svg+xml",

--- a/test/visual/interactions.spec.js
+++ b/test/visual/interactions.spec.js
@@ -63,7 +63,11 @@ test("repositories page renders external stat cards with deterministic fixtures"
   expect(await renderedCount(statCards)).toBeGreaterThan(0);
   await expect(page.locator('img[src*="github-readme-stats"]')).toHaveCount(0);
 
-  const trophies = page.locator('img[src*="github-profile-trophy"]');
+  // repo_trophies.liquid emits three responsive variants of each trophy
+  // (d-md-block / d-sm-block d-md-none / d-block d-sm-none), so a bare .first()
+  // is always the >=md one and is display:none on the mobile project. Match the
+  // variant actually shown at this viewport instead.
+  const trophies = page.locator('img[src*="github-profile-trophy"]:visible');
   await expect(trophies.first()).toBeVisible();
   expect(await renderedCount(trophies)).toBeGreaterThan(0);
 });

--- a/test/visual/interactions.spec.js
+++ b/test/visual/interactions.spec.js
@@ -51,11 +51,21 @@ test("repositories page renders external stat cards with deterministic fixtures"
   await page.goto("/al-folio/repositories/", { waitUntil: "networkidle" });
   await stabilizeVisuals(page);
 
-  const repoImages = page.locator('img[src*="github-stats-extended"], img[src*="github-readme-stats"], img[src*="github-profile-trophy"]');
-  await expect(repoImages.first()).toBeVisible();
+  const renderedCount = (locator) => locator.evaluateAll((images) => images.filter((img) => img.complete && img.naturalWidth > 0).length);
 
-  const renderedCount = await repoImages.evaluateAll((images) => images.filter((img) => img.complete && img.naturalWidth > 0).length);
-  expect(renderedCount).toBeGreaterThan(0);
+  // Assert the stat-card host explicitly: this spec only ever loads the candidate
+  // site, so accepting the deprecated github-readme-stats host here (or letting
+  // trophy images satisfy the assertion on their own) would let a _config.yml
+  // regression pass unnoticed — helpers.js stubs both hosts, so the network
+  // would stay silent about it.
+  const statCards = page.locator('img[src*="github-stats-extended"]');
+  await expect(statCards.first()).toBeVisible();
+  expect(await renderedCount(statCards)).toBeGreaterThan(0);
+  await expect(page.locator('img[src*="github-readme-stats"]')).toHaveCount(0);
+
+  const trophies = page.locator('img[src*="github-profile-trophy"]');
+  await expect(trophies.first()).toBeVisible();
+  expect(await renderedCount(trophies)).toBeGreaterThan(0);
 });
 
 test("blog pagination uses core Tailwind-native styling contract", async ({ page }) => {

--- a/test/visual/interactions.spec.js
+++ b/test/visual/interactions.spec.js
@@ -51,7 +51,7 @@ test("repositories page renders external stat cards with deterministic fixtures"
   await page.goto("/al-folio/repositories/", { waitUntil: "networkidle" });
   await stabilizeVisuals(page);
 
-  const repoImages = page.locator('img[src*="github-readme-stats"], img[src*="github-profile-trophy"]');
+  const repoImages = page.locator('img[src*="github-stats-extended"], img[src*="github-readme-stats"], img[src*="github-profile-trophy"]');
   await expect(repoImages.first()).toBeVisible();
 
   const renderedCount = await repoImages.evaluateAll((images) => images.filter((img) => img.complete && img.naturalWidth > 0).length);


### PR DESCRIPTION
Closes #3629 (the service-switch half of it).

## Problem

The `/repositories/` page points its stat cards at the public **github-readme-stats** instance, which has been unreliable for a long time — cards come back blank. Reported in #3539, #3388 and #2625.

In #3629 a maintainer of **[github-stats-extended](https://github.com/stats-organization/github-stats-extended)**, the actively maintained successor fork, proposed switching to it and offered to help. This is the starter-side half of that switch.

## The swap

Per the fork's [compatibility notes](https://github.com/stats-organization/github-stats-extended/blob/master/docs/fork.md#compatibility-notes):

> "you can change an existing stats card url from github-readme-stats to GitHub-Stats-Extended simply by changing the domain […] The card will look the same."

Only the host changes — `/api/` and `/api/pin/` and every query parameter stay identical.

### Parameter mapping

| Parameter | Old | New | Note |
| --- | --- | --- | --- |
| `username` | ✓ | ✓ | identical |
| `repo` | ✓ | ✓ | identical |
| `theme` | ✓ | ✓ | `repo_theme_light` / `repo_theme_dark` keep working; the fork ships the same [inbuilt theme names](https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md) |
| `locale` | ✓ | ✓ | same codes, now at [`docs/advanced_documentation.md#available-locales`](https://github.com/stats-organization/github-stats-extended/blob/master/docs/advanced_documentation.md#available-locales) |
| `show_owner` | ✓ | ✓ | identical |
| `description_lines_count` | ✓ | ✓ | identical |
| `show_icons` | ✓ | ✓ | identical |
| `anon` | not sent | n/a | al-folio has never sent this |

**No parameter lost an equivalent.** The one documented rendering difference is improved line wrapping for long repository descriptions.

Trophies are unchanged — `github-profile-trophy` is a separate project and out of scope.

## Ownership

Per `docs/BOUNDARIES.md`, the includes that build these URLs are owned by `al_folio_core`, so the runtime change lives in **al-org-dev/al-folio-core#29**. This PR only touches starter wiring, docs and the visual tests.

## Changes

- **`_config.yml`** — `external_services.github_readme_stats_url` → `https://github-stats-extended.vercel.app`; `repo_theme_*` comments repointed at the fork's theme list
- **`docs/CUSTOMIZE.md`** — updated the external-services section, plus a new *Migrating from github-readme-stats* subsection, since existing sites have the old host pinned in their own `_config.yml` and need to change it by hand
- **`README.md`** — feature description links to the new project
- **`test/visual/helpers.js`**, **`test/visual/interactions.spec.js`** — stub and match **both** hosts. This matters: the visual-regression job diffs the candidate against a **v0.16.3 baseline** site that still points at github-readme-stats, so both sides must be intercepted or the parity comparison stops being deterministic.

## Testing

- `npm run lint:prettier` — *All matched files use Prettier code style!*
- `npm run lint:style-contract` — *Starter style contract check passed.*
- `bundle exec jekyll build --baseurl /al-folio` — succeeds; the rendered `/repositories/` page emits the new host for all 9 example repos and both user cards, e.g.

  ```
  https://github-stats-extended.vercel.app/api/pin/?username=alshedivat&repo=al-folio&theme=default&locale=en&show_owner=false&description_lines_count=2
  https://github-stats-extended.vercel.app/api/pin/?username=jekyll&repo=jekyll&theme=dark&locale=en&show_owner=true&description_lines_count=2
  https://github-stats-extended.vercel.app/api/?username=alshedivat&theme=default&locale=en&show_icons=true
  ```

  with `show_owner` correctly `true`/`false` per repo, both light (`theme=default`) and dark (`theme=dark`) variants present, and trophy URLs untouched.

  (Three unrelated environment gaps had to be worked around for that build — no `jupyter-nbconvert`, no ImageMagick `convert`, and no outbound network for `al_ext_posts` — none of them related to this change.)

### Live service check — not possible here

**I could not obtain live HTTP status codes.** This session's egress policy rejects both hosts at the proxy with `403` on `CONNECT`, before anything reaches the service:

```
github-stats-extended.vercel.app  → curl: (56) CONNECT tunnel failed, response 403
github-readme-stats.vercel.app    → curl: (56) CONNECT tunnel failed, response 403
```

The **old** host is blocked identically, so this is a sandbox restriction and is not evidence about either service. **The 403s are the proxy's, not the service's — please open one of the URLs above before merging to confirm a card actually renders.**

## Dependency between the two PRs

They are **independent** — neither blocks the other:

- **This PR alone** already switches the starter site, because the includes read the URL from `_config.yml` and that works on the currently pinned `al_folio_core = 1.0.11`.
- **al-org-dev/al-folio-core#29** changes the built-in *default* (for sites with no `external_services:` block, which previously got a broken relative URL) and repoints the in-template doc links.

The `Gemfile` pin is deliberately left at `= 1.0.11` here, since 1.0.12 is not published yet. Once core#29 is released, bump it to `= 1.0.12` in a follow-up.

## Not addressed

#3629 also floats a second idea — an optional integration with [github-readme-stats-action](https://github.com/stats-organization/github-readme-stats-action), which commits generated SVGs from a workflow instead of hotlinking a live service. That is a separate feature and is not part of this PR; the issue is worth keeping open for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_