### PR TITLE
deps: adopt the released plugin gems, disabling the remote Distill loader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,21 +40,21 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.11'
+    gem 'al_folio_core', '= 1.0.12'
     gem 'al_icons', '= 1.0.0'
-    gem 'al_folio_cv', '= 1.0.0'
-    gem 'al_folio_distill', '= 1.0.2'
+    gem 'al_folio_cv', '= 1.0.1'
+    gem 'al_folio_distill', '= 1.0.3'
     gem 'al_folio_upgrade', '= 1.0.3'
     gem 'al_folio_bootstrap_compat', '= 1.0.0'
     gem 'al_cookie', '= 1.0.0'
 
-    gem 'al_analytics', '= 1.0.0'
+    gem 'al_analytics', '= 1.0.1'
     gem 'al_citations', '= 1.0.1'
-    gem 'al_ext_posts', '= 1.0.1'
-    gem 'al_img_tools', '= 1.0.2'
-    gem 'al_search', '= 1.0.2'
+    gem 'al_ext_posts', '= 1.0.3'
+    gem 'al_img_tools', '= 1.0.3'
+    gem 'al_search', '= 1.0.3'
     gem 'al_charts', '= 1.0.1'
-    gem 'al_math', '= 1.0.1'
+    gem 'al_math', '= 1.0.2'
     gem 'al_comments', '= 1.0.0'
     gem 'al_newsletter', '= 1.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    al_analytics (1.0.0)
+    al_analytics (1.0.1)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_charts (1.0.1)
@@ -39,7 +39,7 @@ GEM
     al_cookie (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_ext_posts (1.0.1)
+    al_ext_posts (1.0.3)
       feedjira (>= 3.2, < 5.0)
       httparty (>= 0.18, < 1.0)
       jekyll (>= 3.9, < 5.0)
@@ -47,13 +47,13 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.11)
+    al_folio_core (1.0.12)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_cv (1.0.0)
+    al_folio_cv (1.0.1)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_distill (1.0.2)
+    al_folio_distill (1.0.3)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_upgrade (1.0.3)
@@ -63,16 +63,16 @@ GEM
     al_icons (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_img_tools (1.0.2)
+    al_img_tools (1.0.3)
       jekyll (>= 3.9, < 5.0)
       jekyll-3rd-party-libraries (~> 0.0.1)
-    al_math (1.0.1)
+    al_math (1.0.2)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_newsletter (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_search (1.0.2)
+    al_search (1.0.3)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     base64 (0.3.0)
@@ -345,22 +345,22 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  al_analytics (= 1.0.0)
+  al_analytics (= 1.0.1)
   al_charts (= 1.0.1)
   al_citations (= 1.0.1)
   al_comments (= 1.0.0)
   al_cookie (= 1.0.0)
-  al_ext_posts (= 1.0.1)
+  al_ext_posts (= 1.0.3)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.11)
-  al_folio_cv (= 1.0.0)
-  al_folio_distill (= 1.0.2)
+  al_folio_core (= 1.0.12)
+  al_folio_cv (= 1.0.1)
+  al_folio_distill (= 1.0.3)
   al_folio_upgrade (= 1.0.3)
   al_icons (= 1.0.0)
-  al_img_tools (= 1.0.2)
-  al_math (= 1.0.1)
+  al_img_tools (= 1.0.3)
+  al_math (= 1.0.2)
   al_newsletter (= 1.0.0)
-  al_search (= 1.0.2)
+  al_search (= 1.0.3)
   classifier-reborn
   css_parser
   jekyll
@@ -390,22 +390,22 @@ DEPENDENCIES
 CHECKSUMS
   activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  al_analytics (1.0.0) sha256=5538a59212ad68c21f54f757a1286422182dbdb18093959da876b66273b0ebcb
+  al_analytics (1.0.1) sha256=116756786ce0ff5b30c5964107edc3148d21b717a0a3cf12ce1527257974840b
   al_charts (1.0.1) sha256=ce26374c2b1159ae0d65dc7999730be700a9ee486002ae14cb480eef70580885
   al_citations (1.0.1) sha256=308cfd4cd73c8dc6d24c0214f424b61606b3a393bdb899394fce80dd647cba59
   al_comments (1.0.0) sha256=1da87a29b55e4d9fd62d380200af9671f10ae4a84e3259828588498d8f3210e5
   al_cookie (1.0.0) sha256=0b36310f84c88e758fb18f2217e8fca8a282b8bd7f5ee9793c6d38ca0cc97348
-  al_ext_posts (1.0.1) sha256=432730bcf032e9da0277beded65511a6e836d4888bda19c9e0f58f9bc6cd2a1d
+  al_ext_posts (1.0.3) sha256=c4956d36071958d30de14f6c368863d3e4190dfe312dba08ff79aa685292420d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.11) sha256=0792345ede34af0e685f575520fb8c588fdb8f0207a6a743cc7760d880e49871
-  al_folio_cv (1.0.0) sha256=aa54c6efb38f46c5da09e09b82b4b050b5ce3b384f808922dc4fd665e10a840e
-  al_folio_distill (1.0.2) sha256=14075b8654a85f76e5e1d8adf8e6c7abcf7b618a4f83a622fa4d5054cd64c709
+  al_folio_core (1.0.12) sha256=1536807fa257c9e8ca60160dc45414d3792afcf6b674518d8583e783336f324e
+  al_folio_cv (1.0.1) sha256=ab824cbe41dd30af07c1bbd9cf4807db457b0c315ac94aa71fe10c282e5cbdd7
+  al_folio_distill (1.0.3) sha256=3feb669dd669effec127e1be5385158c5f98062c510980b5c9c802227ec2c247
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709
   al_icons (1.0.0) sha256=7a7b6428d18e77b039aa1ae765a3faed0ae27cb646a08c1009b145c31ca5ef2d
-  al_img_tools (1.0.2) sha256=1b86e860984d2f714e5a7d715e79722f280e90cc6739375a9119fc9dcb5bb8d6
-  al_math (1.0.1) sha256=c66d402821a9efb997e63501654116ab9683401cb80ac9365c4a013afed4f2c4
+  al_img_tools (1.0.3) sha256=c50dfa206bb4459925cbfc0e7d03b326e7cb1c282200d5d110b6595f4d661cf7
+  al_math (1.0.2) sha256=c9fa6f3e343c0d35782d77fe386461ceff7d12186d9b51e6c92bb186b3d60781
   al_newsletter (1.0.0) sha256=27c914f5fcd0c7fac51a513ab11de7123f05de7ba834206a68ddf2588ede96d3
-  al_search (1.0.2) sha256=6bad2de6fdabaa0bb48b348f0043960672fc45d4c61f822bb68c2e7bf3c8cbb5
+  al_search (1.0.3) sha256=70e846081b57a3494dd41e6bc8e1af13997200c5c28744f2449a8ebe07f79a8a
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bibtex-ruby (6.2.0) sha256=d610eba78d6adf503a843daf144644449fb34e7c3f4a75e9ab67fae5dfd7c69a

--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ al_folio:
   distill:
     engine: distillpub-template
     source: al-org-dev/distill-template#al-folio
-    allow_remote_loader: true
+    allow_remote_loader: false
   features:
     cv:
       enabled: true
@@ -620,10 +620,6 @@ third_party_libraries:
     url:
       js: "https://cdn.jsdelivr.net/npm/plotly.js@{{version}}/dist/plotly.min.js"
     version: "3.0.1"
-  polyfill:
-    url:
-      js: "https://cdnjs.cloudflare.com/polyfill/v{{version}}/polyfill.min.js?features=es6"
-    version: "3"
   pseudocode:
     integrity:
       css: "sha256-VwMV//xgBPDyRFVSOshhRhzJRDyBmIACniLPpeXNUdc="

--- a/test/integration_distill.sh
+++ b/test/integration_distill.sh
@@ -45,7 +45,7 @@ elif [ ! -f "${transforms_runtime}" ]; then
   exit 1
 fi
 
-expected_transforms_hash="70e3f488e23ec379d33a10a60311ec60b570b3b2d5f1823e9159f661c315184e"
+expected_transforms_hash="5d85590f5652b910ab2411019749c83ef5a5a3fbb9b739adc92b4557b6bf3d39"
 actual_transforms_hash="$(ruby -rdigest -e 'print Digest::SHA256.file(ARGV[0]).hexdigest' "${transforms_runtime}")"
 if [ "${actual_transforms_hash}" != "${expected_transforms_hash}" ]; then
   echo "unexpected distill transforms runtime hash: ${actual_transforms_hash}" >&2

--- a/test/style_contract.js
+++ b/test/style_contract.js
@@ -54,8 +54,12 @@ for (const libraryKey of ["tikzjax", "tocbot"]) {
 }
 
 const gemfile = read("Gemfile");
-if (!/gem 'al_math', '= 1\.0\.1'/.test(gemfile)) {
-  failures.push("`Gemfile` should pin `al_math` to released version `1.0.1`.");
+// The point of this check is that `al_math` is pinned to *a* released version,
+// not to any particular one. Hard-coding the number here meant every routine
+// version bump failed the style contract until someone remembered to edit this
+// file too, which is a tripwire for the bump rather than for the boundary.
+if (!/gem 'al_math', '= \d+\.\d+\.\d+'/.test(gemfile)) {
+  failures.push("`Gemfile` should pin `al_math` to an exact released version (`= x.y.z`).");
 }
 if (/gem 'al_math',\s*:git =>/.test(gemfile)) {
   failures.push("`Gemfile` must not use git-branch pin for `al_math`; use released gem version.");


### PR DESCRIPTION
All eight gems that had unreleased work sitting on `main` are now published, so the starter can move off the pins it has been stuck on. They bump together here because one of them changes behaviour that `_config.yml` gates.

| gem | from | to |
| --- | --- | --- |
| `al_folio_core` | 1.0.11 | **1.0.12** |
| `al_folio_cv` | 1.0.0 | **1.0.1** |
| `al_folio_distill` | 1.0.2 | **1.0.3** |
| `al_analytics` | 1.0.0 | **1.0.1** |
| `al_ext_posts` | 1.0.1 | **1.0.3** (1.0.2 was never published either) |
| `al_img_tools` | 1.0.2 | **1.0.3** |
| `al_search` | 1.0.2 | **1.0.3** |
| `al_math` | 1.0.1 | **1.0.2** |

## The Distill loader, and why it is in this PR

`_config.yml` shipped `al_folio.distill.allow_remote_loader: true`. Under 1.0.2 that flag only gated a log line, so it was inert. **1.0.3 turns it into a real switch**: `true` opts the site out of the vendored, hash-pinned Distill runtime and back onto `https://distill.pub/template.v2.js`, fetched with **no subresource integrity**.

Bumping the pin without flipping the flag would ship that gem's entire hardening with its protection turned off — for this site, and for every site generated from this template. So the flag flips here, in the same change as the pin.

This is not a stylistic preference: `al-folio upgrade audit` enforces the pairing. `check_distill_runtime` returns early while the flag is `true`, so splitting the two produces a **blocking** finding. That is also the correction to what I said earlier about #3682 being mergeable on its own — it was not.

Verified on the rendered post at `/blog/2021/distill/`:

```html
<script src="/al-folio/assets/js/distillpub/template.v2.js"   integrity="sha256-R5CDHO0C98TyAJss32l4ztqDUfAGDTtZ3Zs6qxMuJxo=">
<script src="/al-folio/assets/js/distillpub/transforms.v2.js" integrity="sha256-XYVZD1ZSuRCrJBEBl0nIPvWlo/u5tzmtyStFV7a/PTk=">
```

Both local, both integrity-pinned, and no page in the built site references `distill.pub/template`.

## Also here

- **`test/integration_distill.sh`** asserted the 1.0.2 transforms runtime hash. Rehashed against the *published* 1.0.3 gem rather than a computed guess: `70e3f488…` → `5d85590f…`.
- **Dropped the dead `third_party_libraries.polyfill` entry.** `al_math` 1.0.2 stopped emitting the polyfill.io tag, and no gem reads that config key. Confirmed absent from the built site.
- **`test/style_contract.js` hard-coded `al_math '= 1.0.1'`**, so this bump would have failed the style contract. Relaxed to assert an exact released pin of *any* version — the boundary the check actually exists to protect — keeping the separate check that rejects a git-branch pin. Otherwise every routine version bump trips a gate that is meant to guard the thin-starter contract, not the version number.

Left alone deliberately: the `jquery` and `mdb` entries are also unread by any gem, but `al_folio_upgrade` carries a `legacy_jquery_usage` audit rule keyed on `third_party_libraries.jquery`, so removing those wants its own pass.

## Verification

- `bundle install` — all eight resolve from RubyGems
- all six `test/integration_*.sh` — pass
- `npm run lint:style-contract`, `npm run lint:prettier` — pass
- `bundle exec al-folio upgrade audit` — **Blocking: 0**, Non-blocking: 6
- built site smoke-checked: MathJax present, `swiper@12.1.2` (the CVE fix), repo cards on `github-stats-extended` with zero remaining `github-readme-stats` references, CV page renders all sections