### PR TITLE
ci: keep auto-generated TOCs Prettier-clean

### DIFF
--- a/.github/workflows/update-tocs.yml
+++ b/.github/workflows/update-tocs.yml
@@ -56,7 +56,12 @@ jobs:
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          npm install --save-dev --save-exact prettier @shopify/prettier-plugin-liquid
+          # `npm ci` installs from the lockfile and does not touch package.json or
+          # package-lock.json. `npm install --save-dev` would rewrite the caret
+          # ranges to exact pins and upgrade them, and because the auto-commit step
+          # below sets no file_pattern (default `.`), those dependency changes would
+          # be committed to main under the message "Auto update markdown TOC".
+          npm ci
           for file in ${ALL_CHANGED_FILES}; do
             if [[ "$file" != *.md ]]; then
               continue

--- a/.github/workflows/update-tocs.yml
+++ b/.github/workflows/update-tocs.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           fetch-depth: 0 # OR "2" -> To retrieve the preceding commit.
 
+      - uses: actions/setup-node@v4
+
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
@@ -45,6 +47,22 @@ jobs:
             ./gh-md-toc --indent 2 --insert --no-backup --hide-footer $file
           done
           rm gh-md-toc
+
+      # gh-md-toc and Prettier disagree about escaping in link text: the TOC
+      # generator emits `_config.yml` where Prettier requires `\_config.yml`.
+      # Without this step the auto-commit lands unformatted and prettier.yml
+      # immediately goes red on main. Prettier gets the last word.
+      - name: Normalize TOC formatting 🎨
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          npm install --save-dev --save-exact prettier @shopify/prettier-plugin-liquid
+          for file in ${ALL_CHANGED_FILES}; do
+            if [[ "$file" != *.md ]]; then
+              continue
+            fi
+            npx prettier --write "$file"
+          done
 
       - name: Commit changes
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This is the **authoritative** description of how the `al-folio` v1 starter and i
   - [What the starter is](#what-the-starter-is)
   - [Failure modes that produce no error message](#failure-modes-that-produce-no-error-message)
     - [1. Features fail silently when the gem or the flag is missing](#1-features-fail-silently-when-the-gem-or-the-flag-is-missing)
-    - [2. Gemfile and _config.yml are two lists that must agree](#2-gemfile-and-_configyml-are-two-lists-that-must-agree)
+    - [2. Gemfile and \_config.yml are two lists that must agree](#2-gemfile-and-_configyml-are-two-lists-that-must-agree)
     - [3. This repo's effective baseurl is /al-folio](#3-this-repos-effective-baseurl-is-al-folio)
   - [Wrapper to tag to gem delegation](#wrapper-to-tag-to-gem-delegation)
   - [How feature gems ship their assets](#how-feature-gems-ship-their-assets)

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -66,7 +66,7 @@ Here we will give you some tips on how to customize the website. One important t
     - [How it works](#how-it-works)
     - [Configuration](#configuration-1)
     - [Disable related posts for a specific post](#disable-related-posts-for-a-specific-post)
-    - [Additional configuration in _config.yml](#additional-configuration-in-_configyml)
+    - [Additional configuration in \_config.yml](#additional-configuration-in-_configyml)
   - [Managing publication display](#managing-publication-display)
   - [Adding a Google Calendar](#adding-a-google-calendar)
     - [Basic usage](#basic-usage)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,7 +28,7 @@ Here are some frequently asked questions. If you have a different question, plea
   - [How can I update icon library versions on the template](#how-can-i-update-icon-library-versions-on-the-template)
   - [How should I name plugins in v1.x?](#how-should-i-name-plugins-in-v1x)
   - [How can I propose featuring my plugin in al-folio?](#how-can-i-propose-featuring-my-plugin-in-al-folio)
-  - [Why does plugin integration use Gemfile + _config.yml instead of a gemspec?](#why-does-plugin-integration-use-gemfile--_configyml-instead-of-a-gemspec)
+  - [Why does plugin integration use Gemfile + \_config.yml instead of a gemspec?](#why-does-plugin-integration-use-gemfile--_configyml-instead-of-a-gemspec)
   - [What do all these GitHub actions/workflows mean?](#what-do-all-these-github-actionsworkflows-mean)
   - [How can I use Google Search Console ID on the template?](#how-can-i-use-google-search-console-id-on-the-template)
   - [What are Code Wiki and DeepWiki?](#what-are-code-wiki-and-deepwiki)
@@ -329,7 +329,7 @@ Build and deployment:
   - [How can I update icon library versions on the template](#how-can-i-update-icon-library-versions-on-the-template)
   - [How should I name plugins in v1.x?](#how-should-i-name-plugins-in-v1x)
   - [How can I propose featuring my plugin in al-folio?](#how-can-i-propose-featuring-my-plugin-in-al-folio)
-  - [Why does plugin integration use Gemfile + _config.yml instead of a gemspec?](#why-does-plugin-integration-use-gemfile--_configyml-instead-of-a-gemspec)
+  - [Why does plugin integration use Gemfile + \_config.yml instead of a gemspec?](#why-does-plugin-integration-use-gemfile--_configyml-instead-of-a-gemspec)
   - [What do all these GitHub actions/workflows mean?](#what-do-all-these-github-actionsworkflows-mean)
   - [How can I use Google Search Console ID on the template?](#how-can-i-use-google-search-console-id-on-the-template)
   - [What are Code Wiki and DeepWiki?](#what-are-code-wiki-and-deepwiki)
@@ -337,4 +337,3 @@ Build and deployment:
     - [What they do](#what-they-do)
     - [Limitations](#limitations)
     - [Access these tools](#access-these-tools)
-


### PR DESCRIPTION
**`prettier.yml` is currently red on `main`.** This fixes it, and the underlying conflict that caused it.

## What happened

#3681 fixed the `update-tocs.yml` `paths`/`files` globs so they finally match `docs/*.md` — that was the right fix, since every TOC under `docs/` had been silently stale. The knock-on: the generator now rewrites those files, and it escapes markdown link text differently than Prettier does.

`gh-md-toc` emits:

```
- [2. Gemfile and _config.yml are two lists that must agree](#...)
```

Prettier requires the escaped underscore:

```
- [2. Gemfile and \_config.yml are two lists that must agree](#...)
```

So the auto-commit `ff4c43c6 "Auto update markdown TOC"` landed unformatted, and Prettier has been failing on `main` ever since — on `docs/ARCHITECTURE.md`, `docs/CUSTOMIZE.md` and `docs/FAQ.md`.

I confirmed this is pre-existing and not caused by any open PR: stashing all local changes and running `npm run lint:prettier` against clean `origin/main` reproduces the same three failures.

## Fix

Run Prettier over the changed markdown **after** the TOC pass and **before** the auto-commit, so the two tools can't disagree about the same text again. Prettier gets the last word. Also adds `actions/setup-node`, which the new step needs.

Plus the one-time reformat of the three files that are currently failing.

## Verified

- `npm run lint:prettier` → *All matched files use Prettier code style!* (was: 3 files failing)
- `npm run lint:style-contract` → passed
- `update-tocs.yml` parses; step order is checkout → setup-node → changed-files → TOC → **normalize** → commit

Worth noting this class of bug is self-inflicting by design: a workflow that commits generated content will fight any formatter that also owns that content, and the failure only shows up on `main` after the merge — never on the PR that enabled it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_