### PR TITLE
ci: rebase and retry when main moves during a chart refresh

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -51,4 +51,19 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add assets/img/star-history-light.svg assets/img/star-history-dark.svg
           git commit -m "chore: refresh star history chart [skip ci]"
-          git push
+          # Regenerating the chart takes about a minute, and update-tocs.yml
+          # triggers on the same push and commits to main in ~15s, so main can
+          # move underneath this job. That is a plain non-fast-forward, not a
+          # permissions problem, so rebase onto the new tip and retry instead of
+          # failing the run. Only the two generated SVGs are in flight here, and
+          # nothing else writes them, so the rebase cannot conflict in practice.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Push rejected (main moved); rebasing onto origin/main and retrying."
+            git pull --rebase origin main
+          done
+          echo "::error::Could not push the refreshed chart after 3 attempts."
+          exit 1


### PR DESCRIPTION
The first real run of the star-history workflow (from the #3684 merge) **failed**. Fixing it.

## Not what I expected

I'd flagged branch protection as the likely failure mode. It wasn't — the chart generated fine (61s, exit 0) and the push was rejected as a plain non-fast-forward:

```
error: failed to push some refs to 'https://github.com/alshedivat/al-folio'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

## It's a race between two workflows that both commit to main

```
03:28:52  star-history checks out ffee0cd6
03:29:05  update-tocs pushes 5808e067 "Auto update markdown TOC"   ← main moves
03:29:55  star-history finishes generating (61s of API sampling)
03:29:56  push rejected — main had moved 51 seconds earlier
```

`update-tocs.yml` triggers on the same push and finishes in ~15s; chart generation takes ~61s because it samples 29 pages of the stargazers API. Any merge touching markdown fires both, so **this would recur routinely** — it isn't a one-off.

Worth noting the two guards I built in did work as designed: `paths-ignore` and the `GITHUB_TOKEN` rule prevent the workflow retriggering *itself*. Neither addresses a *sibling* workflow moving the ref, which is what happened.

## Fix

Rebase onto the new tip and retry, up to three attempts:

```bash
for attempt in 1 2 3; do
  if git push; then
    echo "Pushed on attempt ${attempt}."
    exit 0
  fi
  echo "Push rejected (main moved); rebasing onto origin/main and retrying."
  git pull --rebase origin main
done
echo "::error::Could not push the refreshed chart after 3 attempts."
exit 1
```

Only the two generated SVGs are ever in flight, and nothing else writes them, so the rebase has no realistic conflict. A genuine failure after three attempts still fails the run loudly rather than silently skipping the refresh.

## Note on the current chart

`main`'s committed SVGs are from the PR branch and are slightly stale (they were generated before the last few stars). The next successful run — this merge will trigger one — refreshes them. Nothing is broken in the meantime: the README renders the committed assets either way, which was the point of self-hosting.

`prettier --check` clean; workflow YAML parses.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_