### PR TITLE
ci: add a dispatchable release workflow, and v1.1 release notes

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -51,4 +51,7 @@ jobs:
         with:
           fail: true
           # removed md files that include liquid tags
-          args: --user-agent 'curl/7.54' --max-retries 3 --retry-wait-time 2 --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --exclude-path _posts/2023-04-24-videos.md --exclude-path _books/the_godfather.md  --exclude-path .github/instructions/bibtex-bibliography.instructions.md --exclude-path .github/instructions/yaml-configuration.instructions.md --exclude-path .github/instructions/markdown-content.instructions.md --exclude-path .github/instructions/liquid-templates.instructions.md --exclude-path AGENTS.md --exclude-path docs/SEO.md --exclude-path docs/SHOWCASE.md --verbose --no-progress './**/*.md' './**/*.html'
+          # docs/releases is excluded because release notes link to the compare
+          # range for the tag they are about to create, which cannot resolve until
+          # the release is published
+          args: --user-agent 'curl/7.54' --max-retries 3 --retry-wait-time 2 --exclude-path docs/releases --exclude-path README.md --exclude-path _pages/404.md --exclude-path _pages/blog.md --exclude-path _posts/2018-12-22-distill.md --exclude-path _posts/2023-04-24-videos.md --exclude-path _books/the_godfather.md  --exclude-path .github/instructions/bibtex-bibliography.instructions.md --exclude-path .github/instructions/yaml-configuration.instructions.md --exclude-path .github/instructions/markdown-content.instructions.md --exclude-path .github/instructions/liquid-templates.instructions.md --exclude-path AGENTS.md --exclude-path docs/SEO.md --exclude-path docs/SHOWCASE.md --verbose --no-progress './**/*.md' './**/*.html'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Create release
+
+# Cutting a release means creating a tag and a GitHub Release. Doing that from a
+# local clone requires pushing to `refs/tags/*`, which not every environment is
+# permitted to do, so the tag is created here instead — the runner's
+# GITHUB_TOKEN has `contents: write` and `gh release create` creates the tag as
+# part of publishing.
+#
+# Release notes are read from a committed file rather than a dispatch input, so
+# they are reviewed in a pull request before they are ever published, and the
+# repo keeps a history of what each release claimed.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create, e.g. v1.1 (must not already exist)"
+        required: true
+        type: string
+      draft:
+        description: "Create as a draft so it can be read before going public"
+        type: boolean
+        default: true
+      prerelease:
+        description: "Mark as a pre-release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: create-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # This repo is a template. Without this guard, every site generated from it
+    # would expose a workflow that cuts releases of somebody else's project.
+    if: github.repository == 'alshedivat/al-folio'
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate inputs 🔍
+        id: check
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag }}"
+
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "::error::'$tag' is not a version tag (expected v1.1 or v1.1.0)."
+            exit 1
+          fi
+
+          # Publishing is effectively irreversible once people have fetched the
+          # tag, so refuse rather than move an existing one.
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "::error::Tag $tag already exists. Bump the version instead of retagging."
+            exit 1
+          fi
+
+          notes="docs/releases/${tag}.md"
+          if [ ! -s "$notes" ]; then
+            echo "::error::No release notes at $notes (missing or empty)."
+            echo "Add them in a pull request first — this workflow deliberately will not invent them."
+            exit 1
+          fi
+
+          echo "notes=$notes" >> "$GITHUB_OUTPUT"
+          echo "Will release $tag from ${GITHUB_SHA} using $notes"
+
+      - name: Create release 🚀
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${{ inputs.tag }}" \
+            --target "${GITHUB_SHA}" \
+            --title "al-folio ${{ inputs.tag }}" \
+            --notes-file "${{ steps.check.outputs.notes }}" \
+            --draft=${{ inputs.draft }} \
+            --prerelease=${{ inputs.prerelease }}
+
+      - name: Summary 📝
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo "### al-folio ${{ inputs.tag }}"
+            echo
+            echo "- commit: \`${GITHUB_SHA}\`"
+            echo "- draft: ${{ inputs.draft }}"
+            echo "- prerelease: ${{ inputs.prerelease }}"
+            echo
+            gh release view "${{ inputs.tag }}" --json url --jq '"[View release](" + .url + ")"'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,22 @@ jobs:
 
       - name: Validate inputs 🔍
         id: check
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           tag="${{ inputs.tag }}"
+
+          # The dispatch UI lets you pick any branch, and GITHUB_SHA then points at
+          # that branch's tip — which is what gets tagged below. Without this check a
+          # permanent version tag could be cut from unmerged code, with release notes
+          # that were never reviewed. The repository guard above does not constrain
+          # the ref, only the repo.
+          if [ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]; then
+            echo "::error::Releases must be cut from ${DEFAULT_BRANCH}, but this run was dispatched from '${GITHUB_REF_NAME}'."
+            echo "Merge the release notes first, then dispatch again from ${DEFAULT_BRANCH}."
+            exit 1
+          fi
 
           if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
             echo "::error::'$tag' is not a version tag (expected v1.1 or v1.1.0)."

--- a/docs/releases/v1.1.md
+++ b/docs/releases/v1.1.md
@@ -1,19 +1,17 @@
 v1.1 is the first maintenance release on the v1 plugin architecture. It is mostly **security and bug fixes**, and it is the release where the plugin ecosystem actually started shipping: every gem with pending work is now published, and releases are automated rather than manual.
 
-Most of the user-visible change is in the gems, not in this repo. Updating is one command:
+Most of the user-visible change is in the gems, not in this repo.
 
-```bash
-bundle update
-```
+> **`bundle update` on its own will not upgrade you.** The `Gemfile` pins every plugin to an exact version (`= 1.0.x`), and Bundler honours the pin already in _your_ `Gemfile` — so a v1.0 site runs `bundle update` and stays on the vulnerable versions, with no error. **You must edit the pins first** — see the **Upgrading** section at the bottom.
 
 The starter's `Gemfile` now pins:
 
 | gem                | v1.0   | v1.1       |
 | ------------------ | ------ | ---------- |
 | `al_folio_core`    | 1.0.10 | **1.0.12** |
-| `al_folio_cv`      | 1.0.0  | **1.0.1**  |
+| `al_folio_cv`      | 1.0.0  | **1.0.2**  |
 | `al_folio_distill` | 1.0.2  | **1.0.3**  |
-| `al_analytics`     | 1.0.0  | **1.0.1**  |
+| `al_analytics`     | 1.0.0  | **1.0.2**  |
 | `al_ext_posts`     | 1.0.1  | **1.0.3**  |
 | `al_img_tools`     | 1.0.2  | **1.0.3**  |
 | `al_search`        | 1.0.2  | **1.0.3**  |
@@ -46,6 +44,8 @@ Remote loading is now explicit opt-in (`al_folio.distill.allow_remote_loader`, d
 
 **Link previews shared without an image** (`al_folio_core` 1.0.12) — `og:image` and `twitter:image` emitted relative asset paths, which external scrapers (Discord, LinkedIn, Mastodon, Slack) cannot resolve. Relative values are now prefixed with `site.url` + `site.baseurl`, matching how `og:url` is already built; already-absolute values are left untouched so a CDN URL is not double-prefixed. Fixes #3666.
 
+**CV entries with a bare `date` rendered no date badge** (`al_folio_cv` 1.0.2) — three of the five CV sections read only `start_date`/`startDate`, so a RenderCV entry carrying a single `date:` showed nothing. Because `al_cv_sort_by_date` _already_ sorted on that key, such an entry was silently moved into chronological position while displaying nothing to explain why. Projects gained date rendering entirely. Fixes #3339. A second bug fell out of the same pass: `{% capture %}` retains surrounding whitespace, so the emptiness test in the awards and publications sections was never true and undated entries rendered an _empty_ badge column.
+
 **CV entries rendered in source order** (`al_folio_cv` 1.0.1) — volunteering was always appended after work history instead of being interleaved chronologically. Sorting is now handled by a new `al_cv_sort_by_date` filter that understands both RenderCV and JSONResume key names, partial dates (`2020`, `2020-06`), YAML date objects, textual `present` end dates, and undated entries. Also fixed dangling date separators: an entry with no end date renders `Present`, an entry with no dates renders no badge, and an entry with no location no longer renders a lone map-pin row.
 
 **External posts published with empty titles** (`al_ext_posts` 1.0.3) — when a fetch degraded (unreachable page, no `<title>`, blank RSS item) the post rendered as a blank but clickable row in the blog index and produced a stream of ``Empty `slug` generated`` warnings. A readable title is now derived from the URL's last meaningful path segment and a warning naming the URL is logged. Slugs and URLs are unchanged.
@@ -56,7 +56,8 @@ Remote loading is now explicit opt-in (`al_folio.distill.allow_remote_loader`, d
 
 ## ✨ Improvements
 
-- **Simple Analytics support** (`al_analytics` 1.0.1) — flag-only via `enable_simple_analytics`, honoring `enable_cookie_consent` like every other provider.
+- **Cloudflare Web Analytics support** (`al_analytics` 1.0.2) — free, cookieless and unsampled. Set `analytics.cloudflare` to your beacon token. Fixes #3351.
+- **Simple Analytics support** (`al_analytics` 1.0.1) — now documented, having shipped undiscoverable. Unlike every other provider it has no site ID to configure (it identifies a site by domain), so it is controlled by `enable_simple_analytics` alone.
 - **Faster search-data generation** (`al_search` 1.0.3) — the full `site.pages` scan used to find the home page title is replaced by a single filter chain, with regression coverage.
 - **Self-hosted star history chart** (#3684, #3685) — the README chart previously came from star-history.com, which was down. It is now generated in-repo by `bin/generate_star_history.py` (stdlib only, no dependencies), themed for light and dark, and refreshed automatically on every push to `main` plus weekly.
 
@@ -77,12 +78,34 @@ A full pass for accuracy and agent-friendliness (#3681):
 
 ## ⬆️ Upgrading
 
+Because the pins are exact, upgrading is a two-step process. Running Bundler alone changes nothing.
+
+**1. Update the pins in your `Gemfile`** to the v1.1 column in the table above. If you have not customised the file, copying the `group :al_folio_plugins` block from this release is the quickest way.
+
+**2. Update `_config.yml`:**
+
+```yaml
+al_folio:
+  distill:
+    allow_remote_loader: false # was true; leaving it true opts you out of the Distill hardening
+```
+
+You can also delete the now-unused `third_party_libraries.polyfill` entry — nothing reads it since `al_math` 1.0.2.
+
+**3. Then install and verify:**
+
 ```bash
-bundle update
+bundle install
 bundle exec al-folio upgrade audit
 ```
 
-The audit reports a **blocking** finding if `al_folio.distill.allow_remote_loader` is still `true` — set it to `false`. Everything else in this release is backwards compatible; no template, layout or content changes are required.
+The audit reports a **blocking** finding while `allow_remote_loader` is still `true`, which is the backstop for step 2. To confirm the security fixes actually landed, check the resolved versions rather than assuming:
+
+```bash
+bundle list | grep -E 'al_img_tools|al_math|al_folio_distill'
+```
+
+You want `al_img_tools 1.0.3` or newer — that is the one carrying the CVSS 9.4 fix. Everything in this release is otherwise backwards compatible; no template, layout or content changes are required.
 
 ---
 

--- a/docs/releases/v1.1.md
+++ b/docs/releases/v1.1.md
@@ -1,0 +1,89 @@
+v1.1 is the first maintenance release on the v1 plugin architecture. It is mostly **security and bug fixes**, and it is the release where the plugin ecosystem actually started shipping: every gem with pending work is now published, and releases are automated rather than manual.
+
+Most of the user-visible change is in the gems, not in this repo. Updating is one command:
+
+```bash
+bundle update
+```
+
+The starter's `Gemfile` now pins:
+
+| gem                | v1.0   | v1.1       |
+| ------------------ | ------ | ---------- |
+| `al_folio_core`    | 1.0.10 | **1.0.12** |
+| `al_folio_cv`      | 1.0.0  | **1.0.1**  |
+| `al_folio_distill` | 1.0.2  | **1.0.3**  |
+| `al_analytics`     | 1.0.0  | **1.0.1**  |
+| `al_ext_posts`     | 1.0.1  | **1.0.3**  |
+| `al_img_tools`     | 1.0.2  | **1.0.3**  |
+| `al_search`        | 1.0.2  | **1.0.3**  |
+| `al_math`          | 1.0.1  | **1.0.2**  |
+
+---
+
+## 🔒 Security
+
+Three real vulnerabilities, all of which affected every v1.0 site.
+
+**Swiper prototype pollution — CVSS 9.4** (`al_img_tools` 1.0.3)
+CVE-2026-27212 / GHSA-hmx5-qpq5-p643 affects Swiper `>= 6.5.1, < 12.1.2`; v1.0 shipped 11.0.5. Bumped to 12.1.2 with refreshed SRI hashes for the CSS, JS and source maps. The image slider uses the `swiper-element` Web Component bundle, whose `<swiper-container>` API is unchanged across the major bump, so no template changes are needed.
+
+**polyfill.io removed from the MathJax path** (`al_math` 1.0.2)
+The polyfill.io CDN was taken over in a June 2024 supply-chain attack and had been serving malicious payloads. It was also unnecessary — MathJax 3 does not need it on any browser al-folio supports. The `<script>` tag is gone.
+
+**Distill runtime no longer loaded from a third-party origin without integrity** (`al_folio_distill` 1.0.3)
+The vendored `transforms.v2.js` carried upstream's `Polyfills` transform, which _removed_ the page's local `template.v2.js` tag and re-injected it from a hard-coded `https://distill.pub/template.v2.js` with no subresource integrity — silently discarding the hash-pinned copy the gem exists to ship, and granting arbitrary JS execution on every Distill page to whoever controls that origin. The runtime is now served from the vendored copy with `integrity` pinned to digests committed in `provenance.json`, and a build-time check reports drift instead of letting it fail SRI in visitors' browsers.
+
+Remote loading is now explicit opt-in (`al_folio.distill.allow_remote_loader`, default **`false`**), and `sync_distill.sh` exits non-zero if a future re-sync reintroduces the remote loader.
+
+> **Note for existing sites:** if your `_config.yml` still has `al_folio.distill.allow_remote_loader: true`, set it to `false`. Under 1.0.2 that flag was inert; under 1.0.3 leaving it `true` opts you back out of the protection. `bundle exec al-folio upgrade audit` reports this as a blocking finding.
+
+## 🐛 Bug fixes
+
+**Repository cards were completely blank** (`al_folio_core` 1.0.12) — two causes. The public `github-readme-stats.vercel.app` instance has been unreliable for a long time; the default is now the API-compatible, actively maintained `github-stats-extended.vercel.app` fork, so every existing query parameter keeps working. Separately, the service URL was interpolated straight from `site.external_services.*`, so a site generated from the template without that block emitted a _relative_ `/api/pin/?…` URL and every card 404'd regardless of upstream health. It now resolves through a `default:` fallback and remains overridable for self-hosting. (al-org-dev/al-folio-core#26)
+
+**Mobile submenus rendered off-screen** (`al_folio_core` 1.0.12) — inside the collapsed navbar the dropdown inherited `position: absolute` and `right: 0` from the base Tailwind rule, anchoring it past the left edge of the viewport (measured at `left: -85.7px` on a 393px screen). Below the `sm` breakpoint the menu is now statically positioned, left-aligned, wraps long entries, and spans the full navbar width. Fixes #3663 — thanks @bibliophilecoder.
+
+**Link previews shared without an image** (`al_folio_core` 1.0.12) — `og:image` and `twitter:image` emitted relative asset paths, which external scrapers (Discord, LinkedIn, Mastodon, Slack) cannot resolve. Relative values are now prefixed with `site.url` + `site.baseurl`, matching how `og:url` is already built; already-absolute values are left untouched so a CDN URL is not double-prefixed. Fixes #3666.
+
+**CV entries rendered in source order** (`al_folio_cv` 1.0.1) — volunteering was always appended after work history instead of being interleaved chronologically. Sorting is now handled by a new `al_cv_sort_by_date` filter that understands both RenderCV and JSONResume key names, partial dates (`2020`, `2020-06`), YAML date objects, textual `present` end dates, and undated entries. Also fixed dangling date separators: an entry with no end date renders `Present`, an entry with no dates renders no badge, and an entry with no location no longer renders a lone map-pin row.
+
+**External posts published with empty titles** (`al_ext_posts` 1.0.3) — when a fetch degraded (unreachable page, no `<title>`, blank RSS item) the post rendered as a blank but clickable row in the blog index and produced a stream of ``Empty `slug` generated`` warnings. A readable title is now derived from the URL's last meaningful path segment and a warning naming the URL is logged. Slugs and URLs are unchanged.
+
+**Unstyled popovers and tooltips** (`al_folio_core` 1.0.11, pinned by #3636) — the vanilla fallback used when bootstrap-compat is disabled creates `.af-popover` / `.af-tooltip` elements in `tooltips-setup.js`, but they had no positioning or visual styling at all and appeared as unpositioned floating text.
+
+**Broken alt-text where a stat card failed** (`al_folio_core` 1.0.11, pinned by #3636) — all repository stat-card images now carry an `onerror` handler, so when the external stat-card or trophy service is unavailable the card is hidden gracefully instead of showing broken alt-text.
+
+## ✨ Improvements
+
+- **Simple Analytics support** (`al_analytics` 1.0.1) — flag-only via `enable_simple_analytics`, honoring `enable_cookie_consent` like every other provider.
+- **Faster search-data generation** (`al_search` 1.0.3) — the full `site.pages` scan used to find the home page title is replaced by a single filter chain, with regression coverage.
+- **Self-hosted star history chart** (#3684, #3685) — the README chart previously came from star-history.com, which was down. It is now generated in-repo by `bin/generate_star_history.py` (stdlib only, no dependencies), themed for light and dark, and refreshed automatically on every push to `main` plus weekly.
+
+## 📚 Documentation
+
+A full pass for accuracy and agent-friendliness (#3681):
+
+- `AGENTS.md` is now the authoritative entry point for coding agents — change routing, the gem-ownership stop sign, the three silent failure modes, and the validated command set.
+- `docs/ARCHITECTURE.md` explains how the starter and gems fit together; `docs/BOUNDARIES.md` is the authoritative area-to-gem ownership table.
+- The showcase moved out of the README into `docs/SHOWCASE.md`.
+- Factual errors corrected throughout, and each fact now lives in exactly one place with links rather than restatements.
+
+## 🔧 Infrastructure
+
+- **Release automation.** No gem had ever been published from CI — which is why several sat unreleased on `main` while fixes shipped nowhere. All 16 plugin repos now have a tag-driven `release.yml` that verifies the tag matches the gemspec version, refuses to overwrite an already-published version, runs the test suite against the built artifact, and will not run from a fork.
+- **Dependency bumps:** `nokogiri` 1.19.3 → 1.19.4 (#3653), `concurrent-ruby` 1.3.6 → 1.3.7 (#3654), `loofah` 2.25.1 → 2.25.2 (#3676), `json` 2.19.7 → 2.19.9 (#3678).
+- Dead `third_party_libraries.polyfill` config entry removed now that nothing reads it.
+
+## ⬆️ Upgrading
+
+```bash
+bundle update
+bundle exec al-folio upgrade audit
+```
+
+The audit reports a **blocking** finding if `al_folio.distill.allow_remote_loader` is still `true` — set it to `false`. Everything else in this release is backwards compatible; no template, layout or content changes are required.
+
+---
+
+**Full Changelog**: https://github.com/alshedivat/al-folio/compare/v1.0...v1.1


### PR DESCRIPTION
Merging this makes cutting v1.1 a one-click dispatch instead of a manual step.

## Why

Creating a release means creating a tag, and pushing to `refs/tags/*` fails with **HTTP 403** from my environment — I retried with three different refspec forms (`refs/tags/v1.1`, a lightweight local tag, and `origin/main:refs/tags/v1.1`); all rejected, and the ref never lands. Branch pushes are fine. So releases have been a step only you could perform.

This moves tag creation onto the runner, where `GITHUB_TOKEN` already has `contents: write` and `gh release create` creates the tag as part of publishing.

## How notes work

Read from `docs/releases/<tag>.md`, **not** a dispatch input. That means:

- they get reviewed in a PR before they can ever be published
- the repo keeps a record of what each release claimed
- a release can't be cut with hastily typed or missing notes

## Guards

Publishing is hard to walk back once people have fetched the tag, so:

- the tag must look like a version (`v1.1` or `v1.1.0`)
- **refuses if the tag already exists**, rather than moving it
- refuses if the notes file is missing or empty
- `draft: true` by default, so the normal path is to read it before it goes public
- `workflow_dispatch` only — nothing fires on a push
- gated on `github.repository == 'alshedivat/al-folio'`, matching `star-history.yml`, so sites generated from this template don't carry a workflow that cuts releases of *your* project

## Also here

**`docs/releases/v1.1.md`** — the v1.1 notes. Headline is that this is a security release: the Swiper prototype-pollution CVE (CVSS 9.4), the polyfill.io supply-chain tag, and the Distill runtime that was silently discarding its own hash-pinned copy to load from `distill.pub` with no SRI. Plus blank repo cards, off-screen mobile submenus, relative `og:image`, the CV ordering fix, empty external-post titles, the docs pass, and the release automation. Gem versions were checked against the actual `Gemfile` at the `v1.0` tag rather than the v1.0 release prose.

**`broken-links.yml` excludes `docs/releases`** — release notes link to the compare range for the tag they're about to create, which can't resolve until the release exists. I confirmed `compare/v1.0...v1.1` returns 404 today, so without this the link checker fails on every release PR.

(`update-tocs.yml` matches `docs/*.md`, not `docs/**/*.md`, so notes files don't get a TOC — verified.)

## After merge

I dispatch `Create release` with `tag: v1.1` and `draft: false`, and v1.1 is out. No tag push needed from either of us.

## One thing to decide

**#3687 is green and unmerged.** It pins `al_folio_cv 1.0.2` (the CV bare-`date` fix, #3339) and `al_analytics 1.0.2` (Cloudflare Web Analytics, #3351). As written, these notes describe `main` *without* it, so v1.1 would ship without those two.

If you'd rather they were in v1.1, merge #3687 as well and I'll update the notes before dispatching. Either is fine — just don't want to release notes that understate what shipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_