### PR TITLE
deps: adopt al_folio_core 1.0.13, document apple_touch_icon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.12'
+    gem 'al_folio_core', '= 1.0.13'
     gem 'al_icons', '= 1.0.0'
     gem 'al_folio_cv', '= 1.0.2'
     gem 'al_folio_distill', '= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.12)
+    al_folio_core (1.0.13)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_cv (1.0.2)
@@ -352,7 +352,7 @@ DEPENDENCIES
   al_cookie (= 1.0.0)
   al_ext_posts (= 1.0.3)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.12)
+  al_folio_core (= 1.0.13)
   al_folio_cv (= 1.0.2)
   al_folio_distill (= 1.0.3)
   al_folio_upgrade (= 1.0.3)
@@ -397,7 +397,7 @@ CHECKSUMS
   al_cookie (1.0.0) sha256=0b36310f84c88e758fb18f2217e8fca8a282b8bd7f5ee9793c6d38ca0cc97348
   al_ext_posts (1.0.3) sha256=c4956d36071958d30de14f6c368863d3e4190dfe312dba08ff79aa685292420d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.12) sha256=1536807fa257c9e8ca60160dc45414d3792afcf6b674518d8583e783336f324e
+  al_folio_core (1.0.13) sha256=e54b861713b949d5f7780ab094042ebcbe6e04e3da163d9bdf15f52cc48bebc2
   al_folio_cv (1.0.2) sha256=d9b8d3624c0c707a04deaa41972fa88395fa164419bccc44e2dc2488400022fa
   al_folio_distill (1.0.3) sha256=3feb669dd669effec127e1be5385158c5f98062c510980b5c9c802227ec2c247
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ footer_text: >
 keywords: jekyll, jekyll-theme, academic-website, portfolio-website # add your own keywords or leave empty
 lang: en # the language of your site (for example: en, fr, cn, ru, etc.)
 icon: ⚛️ # the emoji used as the favicon (alternatively, provide image name in /assets/img/)
+apple_touch_icon: # image name in /assets/img/ (or a rooted path / absolute URL) used for iOS home-screen bookmarks; needs a real 180x180 PNG, since Safari ignores the emoji favicon above. Left empty, iOS falls back to a screenshot of the page.
 
 url: https://alshedivat.github.io # the base hostname & protocol for your site
 baseurl: /al-folio # the subpath of your site, e.g. /blog/. Leave blank for root


### PR DESCRIPTION
Published after al-org-dev/al-folio-core#36 merged. `al_folio_core` **1.0.12 → 1.0.13**.

## What 1.0.13 brings

- **`apple-touch-icon` support** (#2774) — iOS home-screen bookmarks previously got a screenshot of the page, because Safari ignores the inline SVG data URI the emoji favicon uses.
- **Video publication previews** (#3564) — `bib.liquid` rendered `entry.preview` as an `<img>` unconditionally, so an `.mp4`/`.webm`/`.ogg`/`.mov` preview showed a broken image. Those now delegate to the video include.
- **A latent favicon bug.** `{% elsif site.icon != blank %}` is *always* true in plain Liquid: the `blank` literal compares by calling `blank?` on the other operand, and neither `NilClass` nor `String` defines it without ActiveSupport, which Jekyll doesn't load. **A site with no `icon` set was emitting `<link rel="shortcut icon" href="/assets/img/">` on every page** — a 404 per pageview. Verified directly against liquid 4.0.4 before accepting it:

  ```
  String responds to blank?: false
  nil -> TRUE    "" -> TRUE    "a" -> TRUE
  ```

## `apple_touch_icon` is documented, not populated

The key is added to `_config.yml` and left empty, matching how `og_image` and the site-verification keys ship.

**No asset ships with it, and that's deliberate** — I said earlier I'd ship a 180×180 PNG, and on reflection that's the wrong call. The gem emits the tag only when a real raster image exists (an explicit `apple_touch_icon`, or an `icon` that's already `.png`/`.jpg`) and emits nothing otherwise, so an empty key costs nothing. The starter's `icon` is the atom emoji, so there's no existing image to point at, and inventing one would put an arbitrary binary into a template every user inherits and would immediately want to replace. Documenting the key gives users the feature; picking their icon for them doesn't.

## Verified

Built both ways rather than trusting the template:

- **key empty + emoji icon** → no `apple-touch-icon` tag at all (no 404), emoji favicon still renders
- **key set** → `<link rel="apple-touch-icon" href="/al-folio/assets/img/prof_pic_color.png?v=de9fb034...">`

All six `test/integration_*.sh` pass, `lint:prettier` and `lint:style-contract` pass, `al-folio upgrade audit` reports **Blocking: 0**.

`Gemfile.lock` records `sha256=e54b8617…`, confirmed against the published artifact — that's the check I missed on #3687, which took out five CI jobs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_