### PR TITLE
docs: rewrite the README features section, automate screenshot refresh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,3 +110,14 @@ jobs:
             echo
             gh release view "${{ inputs.tag }}" --json url --jq '"[View release](" + .url + ")"'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Refresh the README screenshots against the release, since the theme has most
+  # likely moved. This has to be an explicit call: the release above is created
+  # with GITHUB_TOKEN, and GitHub suppresses workflow runs for events raised by
+  # that token, so a `release: published` trigger over there would never fire.
+  screenshots:
+    needs: release
+    if: inputs.draft == false
+    uses: ./.github/workflows/update-screenshots.yml
+    permissions:
+      contents: write

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -15,9 +15,16 @@ on:
         description: "Space-separated shot names to refresh (blank = all)"
         type: string
         default: ""
-  # Refresh after a release, when the theme has most likely moved.
-  release:
-    types: [published]
+  # Called by release.yml after it publishes. It cannot be a `release` trigger:
+  # that release is created with GITHUB_TOKEN, and GitHub suppresses workflow
+  # runs for events raised by that token, so the trigger would never fire.
+  workflow_call:
+    inputs:
+      shots:
+        description: "Space-separated shot names to refresh (blank = all)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -36,6 +43,11 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
+        with:
+          # Check out the branch by name. Called from release.yml the ref can be
+          # a tag, which would leave a detached HEAD and make the push below
+          # fail with "not currently on a branch".
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Ruby 💎
         uses: ruby/setup-ruby@v1
@@ -75,6 +87,8 @@ jobs:
           node bin/capture_screenshots.js http://127.0.0.1:4000/al-folio readme_preview ${{ inputs.shots }}
 
       - name: Commit if changed 💾
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           rm -rf _screenshot_site
@@ -90,12 +104,12 @@ jobs:
           # branch can move under a job that takes minutes. A non-fast-forward
           # here is a race, not a permissions problem — rebase and retry.
           for attempt in 1 2 3; do
-            if git push; then
+            if git push origin "HEAD:${DEFAULT_BRANCH}"; then
               echo "Pushed on attempt ${attempt}."
               exit 0
             fi
-            echo "Push rejected (main moved); rebasing onto origin/main and retrying."
-            git pull --rebase origin main
+            echo "Push rejected (main moved); rebasing onto origin/${DEFAULT_BRANCH} and retrying."
+            git pull --rebase origin "${DEFAULT_BRANCH}"
           done
           echo "::error::Could not push refreshed screenshots after 3 attempts."
           exit 1

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -1,0 +1,101 @@
+name: Update README screenshots
+
+# The README screenshots go stale quietly — nothing fails when the theme changes
+# underneath them, so they drifted a whole major version behind before anyone
+# noticed. This regenerates them from a real build.
+#
+# It runs here rather than locally because the pages pull webfonts, FontAwesome,
+# Academicons and the GitHub stat-card service from external origins. A capture
+# taken anywhere those are blocked loses its icons and emoji, and the result
+# looks like a broken theme rather than an outdated one.
+on:
+  workflow_dispatch:
+    inputs:
+      shots:
+        description: "Space-separated shot names to refresh (blank = all)"
+        type: string
+        default: ""
+  # Refresh after a release, when the theme has most likely moved.
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-screenshots
+  cancel-in-progress: false
+
+jobs:
+  screenshots:
+    runs-on: ubuntu-latest
+    # This repo is a template; without the guard every generated site would
+    # burn Actions minutes screenshotting its own pages into a README it does
+    # not have.
+    if: github.repository == 'alshedivat/al-folio'
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby 💎
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Setup Node 🟩
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install JS deps 📦
+        run: npm ci
+
+      - name: Install Chromium 🌐
+        run: npx playwright install --with-deps chromium
+
+      - name: Build site 🏗️
+        # The site's baseurl is /al-folio, so build into a directory of that
+        # name and serve its parent — otherwise every absolute asset URL 404s.
+        run: |
+          set -euo pipefail
+          bundle exec jekyll build --destination _screenshot_site/al-folio
+
+      - name: Serve and capture 📸
+        run: |
+          set -euo pipefail
+          python3 -m http.server 4000 --directory _screenshot_site &
+          server=$!
+          trap 'kill $server' EXIT
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null http://127.0.0.1:4000/al-folio/; then break; fi
+            sleep 1
+          done
+          node bin/capture_screenshots.js http://127.0.0.1:4000/al-folio readme_preview ${{ inputs.shots }}
+
+      - name: Commit if changed 💾
+        run: |
+          set -euo pipefail
+          rm -rf _screenshot_site
+          if git diff --quiet -- readme_preview; then
+            echo "Screenshots unchanged; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add readme_preview
+          git commit -m "chore: refresh README screenshots [skip ci]"
+          # update-tocs.yml and the star-history job also commit to main, so the
+          # branch can move under a job that takes minutes. A non-fast-forward
+          # here is a race, not a permissions problem — rebase and retry.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Push rejected (main moved); rebasing onto origin/main and retrying."
+            git pull --rebase origin main
+          done
+          echo "::error::Could not push refreshed screenshots after 3 attempts."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -164,27 +164,27 @@ Comprehensive guides for all aspects of your al-folio website:
 
 ## Features
 
-Everything below ships with the starter and is on by default unless noted. Each feature is owned by a versioned plugin — see [`docs/BOUNDARIES.md`](docs/BOUNDARIES.md) for the full ownership table, and [Plugin Ecosystem](#plugin-ecosystem) for how to add or remove one.
+Everything below ships with the starter. Rows marked **setup** render nothing until you supply a key, ID or credential — bundling a plugin is not the same as switching the feature on. Each feature is owned by a versioned plugin — see [`docs/BOUNDARIES.md`](docs/BOUNDARIES.md) for the full ownership table, and [Plugin Ecosystem](#plugin-ecosystem) for how to add or remove one.
 
-| Feature                                                             | Plugin                           | Configure                                                                           |
-| ------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| Pages, layouts, navigation, light/dark mode, theming                | `al_folio_core`                  | [Changing theme color](docs/CUSTOMIZE.md#changing-theme-color)                      |
-| Publications from BibTeX                                            | `al_folio_core` + jekyll-scholar | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
-| CV from RenderCV or JSONResume                                      | `al_folio_cv`                    | [Modifying the CV information](docs/CUSTOMIZE.md#modifying-the-cv-information)      |
-| Distill-style posts                                                 | `al_folio_distill`               | [the example post](https://alshedivat.github.io/al-folio/blog/2021/distill/)        |
-| Math, TikZ diagrams                                                 | `al_math`                        | [the math post](https://alshedivat.github.io/al-folio/blog/2015/math/)              |
-| Charts, mermaid, plotly                                             | `al_charts`                      | [the charts post](https://alshedivat.github.io/al-folio/blog/2025/plotly/)          |
-| Image zoom, galleries, sliders, lightbox                            | `al_img_tools`                   | [the images post](https://alshedivat.github.io/al-folio/blog/2024/advanced-images/) |
-| Full-text search (<kbd>ctrl</kbd> <kbd>k</kbd>)                     | `al_search`                      | `search_enabled` in [\_config.yml](_config.yml)                                     |
-| Comments (Giscus or Disqus)                                         | `al_comments`                    | `giscus:` in [\_config.yml](_config.yml)                                            |
-| Analytics — Google, Cronitor, Pirsch, Openpanel, Cloudflare, Simple | `al_analytics`                   | [docs/ANALYTICS.md](docs/ANALYTICS.md)                                              |
-| GDPR cookie consent, gating analytics until opt-in                  | `al_cookie`                      | [GDPR Cookie Consent Dialog](docs/CUSTOMIZE.md#gdpr-cookie-consent-dialog)          |
-| Newsletter signup                                                   | `al_newsletter`                  | `newsletter:` in [\_config.yml](_config.yml)                                        |
-| Citation counts, altmetric/dimensions badges                        | `al_citations`                   | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
-| FontAwesome, Academicons, scholar icons                             | `al_icons`                       | `third_party_libraries` in [\_config.yml](_config.yml)                              |
-| Posts syndicated from Medium and other feeds                        | `al_ext_posts`                   | `external_sources:` in [\_config.yml](_config.yml)                                  |
-| Legacy Bootstrap markup (opt-in, removed in v2.0)                   | `al_folio_bootstrap_compat`      | `al_folio.compat.bootstrap` in [\_config.yml](_config.yml)                          |
-| Upgrade audits and codemods                                         | `al_folio_upgrade`               | `bundle exec al-folio upgrade audit`                                                |
+| Feature                                                                         | Plugin                           | Configure                                                                           |
+| ------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
+| Pages, layouts, navigation, light/dark mode, theming                            | `al_folio_core`                  | [Changing theme color](docs/CUSTOMIZE.md#changing-theme-color)                      |
+| Publications from BibTeX                                                        | `al_folio_core` + jekyll-scholar | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
+| CV from RenderCV or JSONResume                                                  | `al_folio_cv`                    | [Modifying the CV information](docs/CUSTOMIZE.md#modifying-the-cv-information)      |
+| Distill-style posts                                                             | `al_folio_distill`               | [the example post](https://alshedivat.github.io/al-folio/blog/2021/distill/)        |
+| Math, TikZ diagrams                                                             | `al_math`                        | [the math post](https://alshedivat.github.io/al-folio/blog/2015/math/)              |
+| Charts, mermaid, plotly                                                         | `al_charts`                      | [the charts post](https://alshedivat.github.io/al-folio/blog/2025/plotly/)          |
+| Image zoom, galleries, sliders, lightbox                                        | `al_img_tools`                   | [the images post](https://alshedivat.github.io/al-folio/blog/2024/advanced-images/) |
+| Full-text search (<kbd>ctrl</kbd> <kbd>k</kbd>)                                 | `al_search`                      | `search_enabled` in [\_config.yml](_config.yml)                                     |
+| Comments (Giscus or Disqus) — **setup**                                         | `al_comments`                    | `giscus:` in [\_config.yml](_config.yml)                                            |
+| Analytics — Google, Cronitor, Pirsch, Openpanel, Cloudflare, Simple — **setup** | `al_analytics`                   | [docs/ANALYTICS.md](docs/ANALYTICS.md)                                              |
+| GDPR cookie consent, gating analytics until opt-in — **setup**                  | `al_cookie`                      | [GDPR Cookie Consent Dialog](docs/CUSTOMIZE.md#gdpr-cookie-consent-dialog)          |
+| Newsletter signup — **setup**                                                   | `al_newsletter`                  | `newsletter:` in [\_config.yml](_config.yml)                                        |
+| Citation counts, altmetric/dimensions badges                                    | `al_citations`                   | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
+| FontAwesome, Academicons, scholar icons                                         | `al_icons`                       | `third_party_libraries` in [\_config.yml](_config.yml)                              |
+| Posts syndicated from Medium and other feeds                                    | `al_ext_posts`                   | `external_sources:` in [\_config.yml](_config.yml)                                  |
+| Legacy Bootstrap markup (opt-in, removed in v2.0)                               | `al_folio_bootstrap_compat`      | `al_folio.compat.bootstrap` in [\_config.yml](_config.yml)                          |
+| Upgrade audits and codemods                                                     | `al_folio_upgrade`               | `bundle exec al-folio upgrade audit`                                                |
 
 Also included: Open Graph and schema.org previews, an Atom feed at `/feed.xml`, related posts, tabbed content, typograms, responsive image generation, and a Google Scholar citation-refresh workflow.
 

--- a/README.md
+++ b/README.md
@@ -63,29 +63,17 @@ Want to learn more about Jekyll? Check out [this tutorial](https://www.taniarasc
     - [Copilot And Other Agents](#copilot-and-other-agents)
   - [Documentation](#documentation)
   - [Features](#features)
-    - [Light/Dark Mode](#lightdark-mode)
-    - [CV](#cv)
-    - [People](#people)
-    - [Publications](#publications)
-    - [Collections](#collections)
-    - [Layouts](#layouts)
-      - [The iconic style of Distill](#the-iconic-style-of-distill)
-      - [Full support for math &amp; code](#full-support-for-math--code)
-      - [Photos, Audio, Video and more](#photos-audio-video-and-more)
-    - [Other features](#other-features)
-      - [GitHub's repositories and user stats](#githubs-repositories-and-user-stats)
-      - [Theming](#theming)
-      - [Social media previews](#social-media-previews)
-      - [Atom (RSS-like) Feed](#atom-rss-like-feed)
-      - [Related posts](#related-posts)
-      - [Code quality checks](#code-quality-checks)
-      - [GDPR Cookie Consent Dialog](#gdpr-cookie-consent-dialog)
+    - [Light and dark mode](#light-and-dark-mode)
+    - [The pages you get out of the box](#the-pages-you-get-out-of-the-box)
+    - [Writing](#writing)
+    - [GitHub repositories and stats](#github-repositories-and-stats)
   - [User community](#user-community)
   - [Lighthouse PageSpeed Insights](#lighthouse-pagespeed-insights)
     - [Desktop](#desktop)
     - [Mobile](#mobile)
   - [FAQ](#faq)
   - [Contributing](#contributing)
+    - [Code quality checks](#code-quality-checks)
     - [Maintainers](#maintainers)
     - [All Contributors](#all-contributors)
   - [Star History](#star-history)
@@ -176,9 +164,33 @@ Comprehensive guides for all aspects of your al-folio website:
 
 ## Features
 
-### Light/Dark Mode
+Everything below ships with the starter and is on by default unless noted. Each feature is owned by a versioned plugin — see [`docs/BOUNDARIES.md`](docs/BOUNDARIES.md) for the full ownership table, and [Plugin Ecosystem](#plugin-ecosystem) for how to add or remove one.
 
-This template has a built-in light/dark mode. It detects the user preferred color scheme and automatically switches to it. You can also manually switch between light and dark mode by clicking on the sun/moon icon in the top right corner of the page.
+| Feature                                                             | Plugin                           | Configure                                                                           |
+| ------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
+| Pages, layouts, navigation, light/dark mode, theming                | `al_folio_core`                  | [Changing theme color](docs/CUSTOMIZE.md#changing-theme-color)                      |
+| Publications from BibTeX                                            | `al_folio_core` + jekyll-scholar | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
+| CV from RenderCV or JSONResume                                      | `al_folio_cv`                    | [Modifying the CV information](docs/CUSTOMIZE.md#modifying-the-cv-information)      |
+| Distill-style posts                                                 | `al_folio_distill`               | [the example post](https://alshedivat.github.io/al-folio/blog/2021/distill/)        |
+| Math, TikZ diagrams                                                 | `al_math`                        | [the math post](https://alshedivat.github.io/al-folio/blog/2015/math/)              |
+| Charts, mermaid, plotly                                             | `al_charts`                      | [the charts post](https://alshedivat.github.io/al-folio/blog/2025/plotly/)          |
+| Image zoom, galleries, sliders, lightbox                            | `al_img_tools`                   | [the images post](https://alshedivat.github.io/al-folio/blog/2024/advanced-images/) |
+| Full-text search (<kbd>ctrl</kbd> <kbd>k</kbd>)                     | `al_search`                      | `search_enabled` in [\_config.yml](_config.yml)                                     |
+| Comments (Giscus or Disqus)                                         | `al_comments`                    | `giscus:` in [\_config.yml](_config.yml)                                            |
+| Analytics — Google, Cronitor, Pirsch, Openpanel, Cloudflare, Simple | `al_analytics`                   | [docs/ANALYTICS.md](docs/ANALYTICS.md)                                              |
+| GDPR cookie consent, gating analytics until opt-in                  | `al_cookie`                      | [GDPR Cookie Consent Dialog](docs/CUSTOMIZE.md#gdpr-cookie-consent-dialog)          |
+| Newsletter signup                                                   | `al_newsletter`                  | `newsletter:` in [\_config.yml](_config.yml)                                        |
+| Citation counts, altmetric/dimensions badges                        | `al_citations`                   | [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication)              |
+| FontAwesome, Academicons, scholar icons                             | `al_icons`                       | `third_party_libraries` in [\_config.yml](_config.yml)                              |
+| Posts syndicated from Medium and other feeds                        | `al_ext_posts`                   | `external_sources:` in [\_config.yml](_config.yml)                                  |
+| Legacy Bootstrap markup (opt-in, removed in v2.0)                   | `al_folio_bootstrap_compat`      | `al_folio.compat.bootstrap` in [\_config.yml](_config.yml)                          |
+| Upgrade audits and codemods                                         | `al_folio_upgrade`               | `bundle exec al-folio upgrade audit`                                                |
+
+Also included: Open Graph and schema.org previews, an Atom feed at `/feed.xml`, related posts, tabbed content, typograms, responsive image generation, and a Google Scholar citation-refresh workflow.
+
+### Light and dark mode
+
+The theme follows the visitor's system preference and can be toggled with the sun/moon control in the navbar. The choice persists across visits.
 
 <p align="center">
 <img src="readme_preview/light.png" width=400>
@@ -187,138 +199,47 @@ This template has a built-in light/dark mode. It detects the user preferred colo
 
 ---
 
-### CV
+### The pages you get out of the box
 
-Your CV can be generated in one of two modern formats: **RenderCV** (recommended, with automatic PDF generation) or **JSONResume** (standardized JSON format). You can use both simultaneously and switch between them, or maintain just the one you prefer.
-
-[![CV Preview](readme_preview/cv.png)](https://alshedivat.github.io/al-folio/cv/)
-
-For setup and customization details, see [Modifying the CV information](docs/CUSTOMIZE.md#modifying-the-cv-information) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-### People
-
-You can create a people page if you want to feature more than one person. Each person can have its own short bio, profile picture, and you can also set if every person will appear at the same or opposite sides.
-
-[![People Preview](readme_preview/people.png)](https://alshedivat.github.io/al-folio/people/)
-
----
-
-### Publications
-
-Your publications page is generated automatically from your BibTeX bibliography. You can customize publication display, add extra information like PDFs, and control sorting behavior.
-
-[![Publications Preview](readme_preview/publications.png)](https://alshedivat.github.io/al-folio/publications/)
-
-For setup, BibTeX field documentation, and customization options, see [Adding a new publication](docs/CUSTOMIZE.md#adding-a-new-publication) and [Managing publication display](docs/CUSTOMIZE.md#managing-publication-display) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-### Collections
-
-al-folio uses Jekyll `collections` to organize content into categories. The starter comes with four default collections — `news`, `projects`, `books`, and `teachings` — all declared under `collections:` in [\_config.yml](_config.yml). You can easily create your own collections for apps, stories, courses, or any other creative work.
-
-[![Projects Preview](readme_preview/projects.png)](https://alshedivat.github.io/al-folio/projects/)
-
-For detailed instructions on creating and customizing collections, see [Adding Collections](docs/CUSTOMIZE.md#adding-collections) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-### Layouts
-
-**al-folio** comes with stylish layouts for pages and blog posts.
-
-#### The iconic style of Distill
-
-The theme allows you to create blog posts in the [distill.pub](https://distill.pub/) style:
-
-[![Distill Preview](readme_preview/distill.png)](https://alshedivat.github.io/al-folio/blog/2021/distill/)
-
-For more details on how to create distill-styled posts using `<d-*>` tags, please refer to [the example](https://alshedivat.github.io/al-folio/blog/2021/distill/).
-
-#### Full support for math & code
-
-**al-folio** supports fast math typesetting through [MathJax](https://www.mathjax.org/) and code syntax highlighting using [GitHub style](https://github.com/jwarby/jekyll-pygments-themes). Also supports [chartjs charts](https://www.chartjs.org/), [mermaid diagrams](https://mermaid-js.github.io/mermaid/#/), and [TikZ figures](https://tikzjax.com/).
+Publications are generated from your BibTeX bibliography, the CV from a single `cv.yml` or `resume.json`, and the people page from `_data`. Everything is content-driven — you edit data files, not templates.
 
 <p align="center">
-<a href="https://alshedivat.github.io/al-folio/blog/2015/math/" target="_blank"><img src="readme_preview/math.png" width=400></a>
-<a href="https://alshedivat.github.io/al-folio/blog/2015/code/" target="_blank"><img src="readme_preview/code.png" width=400></a>
+  <a href="https://alshedivat.github.io/al-folio/publications/"><img src="readme_preview/publications.png" width=400></a>
+  <a href="https://alshedivat.github.io/al-folio/cv/"><img src="readme_preview/cv.png" width=400></a>
+</p>
+<p align="center">
+  <a href="https://alshedivat.github.io/al-folio/projects/"><img src="readme_preview/projects.png" width=400></a>
+  <a href="https://alshedivat.github.io/al-folio/people/"><img src="readme_preview/people.png" width=400></a>
 </p>
 
-#### Photos, Audio, Video and more
+Projects are one of four Jekyll `collections` the starter ships (`news`, `projects`, `books`, `teachings`). You can add your own for courses, talks, or anything else — see [Adding Collections](docs/CUSTOMIZE.md#adding-collections).
 
-Photo formatting is made simple using Tailwind-first responsive layout utilities. Easily create beautiful grids within your blog posts and project pages, also with support for [video](https://alshedivat.github.io/al-folio/blog/2023/videos/) and [audio](https://alshedivat.github.io/al-folio/blog/2023/audios/) embeds:
+---
+
+### Writing
+
+Posts support the [distill.pub](https://distill.pub/) layout, MathJax and TikZ, syntax-highlighted code, Jupyter notebooks, charts, image galleries, video and audio embeds.
 
 <p align="center">
-  <a href="https://alshedivat.github.io/al-folio/projects/1_project/">
-    <img src="readme_preview/photos-screenshot.png" width="75%">
-  </a>
+  <a href="https://alshedivat.github.io/al-folio/blog/2021/distill/"><img src="readme_preview/distill.png" width=400></a>
+  <a href="https://alshedivat.github.io/al-folio/blog/2015/math/"><img src="readme_preview/math.png" width=400></a>
+</p>
+<p align="center">
+  <a href="https://alshedivat.github.io/al-folio/blog/2015/code/"><img src="readme_preview/code.png" width=400></a>
+  <a href="https://alshedivat.github.io/al-folio/projects/1_project/"><img src="readme_preview/photos-screenshot.png" width=400></a>
 </p>
 
 ---
 
-### Other features
+### GitHub repositories and stats
 
-#### GitHub's repositories and user stats
+The `/repositories/` page renders repository and profile cards via [github-stats-extended](https://github.com/stats-organization/github-stats-extended) and [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy).
 
-**al-folio** displays GitHub repositories and user stats on the `/repositories/` page using [github-stats-extended](https://github.com/stats-organization/github-stats-extended) and [github-profile-trophy](https://github.com/ryo-ma/github-profile-trophy).
+<p align="center">
+  <a href="https://alshedivat.github.io/al-folio/repositories/"><img src="readme_preview/repositories.png" width="75%"></a>
+</p>
 
-[![Repositories Preview](readme_preview/repositories.png)](https://alshedivat.github.io/al-folio/repositories/)
-
-To configure which repositories and GitHub profiles to display, see [Modifying the user and repository information](docs/CUSTOMIZE.md#modifying-the-user-and-repository-information) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-#### Theming
-
-**al-folio** offers a variety of beautiful theme colors to choose from. The default is purple, but you can customize colors, fonts, spacing, and more to match your style.
-
-For detailed customization instructions, see [Changing theme color](docs/CUSTOMIZE.md#changing-theme-color) and [Customizing fonts, spacing, and more](docs/CUSTOMIZE.md#customizing-fonts-spacing-and-more) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-#### Social media previews
-
-**al-folio** supports Open Graph preview images on social media. When enabled, your site's pages display rich preview objects with images, titles, and descriptions when shared.
-
-For setup and customization, see [Social media previews](docs/CUSTOMIZE.md#social-media-previews) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-#### Atom (RSS-like) Feed
-
-It generates an Atom (RSS-like) feed of your posts, useful for Atom and RSS readers. The feed is reachable simply by typing after your homepage `/feed.xml`. E.g. assuming your website mountpoint is the main folder, you can type `yourusername.github.io/feed.xml`
-
----
-
-#### Related posts
-
-By default, blog posts display related posts at the bottom. These are selected by finding the most recent posts that share tags with the current post. You can customize this behavior on a per-post or site-wide basis.
-
-For configuration details, see [Related posts](docs/CUSTOMIZE.md#related-posts) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
-
----
-
-#### Code quality checks
-
-Currently, we run some checks to ensure that the code quality and generated site are good. The checks are done using GitHub Actions and the following tools:
-
-- [Prettier](https://prettier.io/) - check if the formatting of the code follows the style guide
-- [lychee](https://lychee.cli.rs/) - check for broken links
-- [Axe](https://github.com/dequelabs/axe-core) (need to run manually) - do some accessibility testing
-
-We decided to keep `Axe` runs manual because fixing the issues are not straightforward and might be hard for people without web development knowledge.
-
----
-
-#### GDPR Cookie Consent Dialog
-
-**al-folio** includes a GDPR-compliant cookie consent dialog provided by the `al_cookie` plugin to ensure your website respects visitor privacy. The dialog is powered by [Vanilla Cookie Consent](https://cookieconsent.orestbida.com/) and integrates seamlessly with all supported analytics providers.
-
-When enabled, analytics scripts are blocked until the user explicitly consents, and user preferences are saved across visits. This is essential for websites serving visitors in the European Union and other regions with strict privacy regulations.
-
-For complete setup and customization details, see [GDPR Cookie Consent Dialog](docs/CUSTOMIZE.md#gdpr-cookie-consent-dialog) in [docs/CUSTOMIZE.md](docs/CUSTOMIZE.md).
+Configure which repositories and profiles appear under [Modifying the user and repository information](docs/CUSTOMIZE.md#modifying-the-user-and-repository-information).
 
 ## User community
 
@@ -351,6 +272,17 @@ For frequently asked questions, please refer to [docs/FAQ.md](docs/FAQ.md).
 Contributions to al-folio are very welcome! Before you get started, please take a look at [the guidelines](docs/CONTRIBUTING.md).
 
 If you would like to improve documentation or fix a minor inconsistency or bug, please feel free to send a PR directly to `main`. For more complex issues/bugs or feature requests, please open an issue using the appropriate template.
+
+### Code quality checks
+
+CI runs the following on every pull request:
+
+- [Prettier](https://prettier.io/) — formatting, including Liquid templates
+- [lychee](https://lychee.cli.rs/) — broken links
+- `npm run lint:style-contract` — enforces the thin-starter boundary described in [AGENTS.md](AGENTS.md)
+- the six `test/integration_*.sh` scripts, and Playwright visual-regression checks
+
+[Axe](https://github.com/dequelabs/axe-core) accessibility checks are run manually, because the fixes are not always straightforward for contributors without web development experience.
 
 ### Maintainers
 

--- a/bin/capture_screenshots.js
+++ b/bin/capture_screenshots.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Regenerates the screenshots used by README.md.
+//
+// Run via `.github/workflows/update-screenshots.yml` rather than locally: the
+// pages pull webfonts, FontAwesome, Academicons and the GitHub stat-card
+// service from external origins, and a screenshot taken somewhere those are
+// unreachable silently loses its icons and emoji. CI has unrestricted egress,
+// so the shots match what a visitor actually sees.
+//
+//   node bin/capture_screenshots.js <base-url> <out-dir> [name ...]
+//
+// Passing one or more names limits the run to those shots.
+
+const { chromium } = require("playwright");
+const path = require("path");
+
+const BASE = (process.argv[2] || "http://127.0.0.1:4000/al-folio").replace(/\/$/, "");
+const OUT = process.argv[3] || "readme_preview";
+const ONLY = process.argv.slice(4);
+
+// height is the capture viewport, chosen per page so the shot ends on a
+// sensible boundary instead of mid-paragraph. Full-page captures were tried and
+// render as unreadable ribbons in the README.
+const SHOTS = [
+  { name: "al-folio-preview", url: "/", theme: "light", height: 900 },
+  { name: "light", url: "/", theme: "light", height: 1000 },
+  { name: "dark", url: "/", theme: "dark", height: 1000 },
+  { name: "cv", url: "/cv/", theme: "light", height: 1100 },
+  { name: "people", url: "/people/", theme: "light", height: 950 },
+  { name: "publications", url: "/publications/", theme: "light", height: 1100 },
+  { name: "projects", url: "/projects/", theme: "light", height: 1000 },
+  { name: "blog", url: "/blog/", theme: "light", height: 1100 },
+  { name: "repositories", url: "/repositories/", theme: "light", height: 1100, settle: 9000 },
+  { name: "distill", url: "/blog/2021/distill/", theme: "light", height: 1100 },
+  { name: "math", url: "/blog/2015/math/", theme: "light", height: 1000, settle: 6000 },
+  { name: "code", url: "/blog/2015/code/", theme: "light", height: 1000 },
+  { name: "jupyter", url: "/blog/2023/jupyter-notebook/", theme: "light", height: 1000 },
+  { name: "photos-screenshot", url: "/projects/1_project/", theme: "light", height: 1100, settle: 6000 },
+];
+
+(async () => {
+  const browser = await chromium.launch({ args: ["--no-sandbox"] });
+  let failures = 0;
+
+  for (const shot of SHOTS) {
+    if (ONLY.length && !ONLY.includes(shot.name)) continue;
+
+    const ctx = await browser.newContext({
+      viewport: { width: 1280, height: shot.height },
+      // Retina capture; GitHub downscales cleanly and the text stays crisp.
+      deviceScaleFactor: 2,
+      colorScheme: shot.theme === "dark" ? "dark" : "light",
+      reducedMotion: "reduce",
+    });
+
+    // The theme is driven by localStorage -> data-theme-setting on <html>.
+    // Setting it before first paint avoids capturing a flash of the wrong theme.
+    await ctx.addInitScript((t) => {
+      try {
+        localStorage.setItem("theme", t);
+      } catch (e) {
+        /* private mode */
+      }
+    }, shot.theme);
+
+    const page = await ctx.newPage();
+    const failedRequests = [];
+    page.on("requestfailed", (r) => failedRequests.push(`${r.url()} (${(r.failure() || {}).errorText})`));
+
+    try {
+      await page.goto(BASE + shot.url, { waitUntil: "load", timeout: 60000 });
+    } catch (err) {
+      console.error(`FAIL ${shot.name}: ${err.message.split("\n")[0]}`);
+      failures++;
+      await ctx.close();
+      continue;
+    }
+
+    // Let webfonts, MathJax, charts and lazy images settle.
+    await page.waitForTimeout(shot.settle || 4000);
+    try {
+      await page.evaluate(() => document.fonts && document.fonts.ready);
+    } catch (e) {
+      /* older engines */
+    }
+
+    // A screenshot missing its icons or emoji is worse than a stale one, so
+    // surface that here instead of letting it land in the README unnoticed.
+    const broken = await page.evaluate(() =>
+      Array.from(document.images)
+        .filter((img) => img.complete && img.naturalWidth === 0)
+        .map((img) => img.src)
+    );
+
+    await page.screenshot({ path: path.join(OUT, `${shot.name}.png`) });
+
+    const notes = [];
+    if (broken.length) notes.push(`${broken.length} broken image(s): ${broken.slice(0, 3).join(", ")}`);
+    if (failedRequests.length) notes.push(`${failedRequests.length} failed request(s): ${failedRequests.slice(0, 3).join(", ")}`);
+    if (notes.length) {
+      console.error(`WARN ${shot.name}: ${notes.join(" | ")}`);
+      failures++;
+    } else {
+      console.log(`OK   ${shot.name}`);
+    }
+
+    await ctx.close();
+  }
+
+  await browser.close();
+
+  if (failures) {
+    console.error(`\n${failures} shot(s) rendered with missing assets. Not treating these as usable.`);
+    process.exit(1);
+  }
+})();

--- a/bin/capture_screenshots.js
+++ b/bin/capture_screenshots.js
@@ -65,7 +65,15 @@ const SHOTS = [
 
     const page = await ctx.newPage();
     const failedRequests = [];
+    // `requestfailed` only covers transport-level failures. A stylesheet or
+    // webfont that answers 404 or 503 completes normally and never fires it,
+    // and a missing CSS file is invisible to the broken-image check below — so
+    // watch response status codes too, or the exact degradation this script
+    // exists to catch slips through.
     page.on("requestfailed", (r) => failedRequests.push(`${r.url()} (${(r.failure() || {}).errorText})`));
+    page.on("response", (res) => {
+      if (res.status() >= 400) failedRequests.push(`${res.url()} (HTTP ${res.status()})`);
+    });
 
     try {
       await page.goto(BASE + shot.url, { waitUntil: "load", timeout: 60000 });


### PR DESCRIPTION
## The screenshots

Every image in `readme_preview/` dates from **2026-01-26** — before v1.0 shipped on 2026-06-02. They show the old Bootstrap monolith, so the README has been advertising a theme that no longer exists for a whole major version.

Nothing failed when the theme changed underneath them, which is exactly why they drifted that far. So rather than replace them by hand and let them rot again, this adds `bin/capture_screenshots.js` plus a workflow that regenerates them from a real build.

**It runs in CI rather than locally on purpose.** The pages pull webfonts, FontAwesome, Academicons and the GitHub stat-card service from external origins. A capture taken somewhere those are blocked silently loses its icons and emoji — it looks like a *broken* theme rather than an outdated one. I hit exactly that when I tried to generate them from here:

```
18 failed requests — fonts.googleapis.com, all.min.css, academicons.min.css
5 of 6 images broken
```

That's why there are no new PNGs in this diff. Committing those would have been worse than leaving the stale ones. The script now **fails the run** when a page renders with missing assets, so a degraded shot can't land unnoticed.

Triggers on manual dispatch and after a release, when the theme has most likely moved. Same `github.repository` guard as `star-history.yml` so generated sites don't run it, and the same rebase-and-retry push, since `main` can move during a job that takes minutes.

## The features section

It described a subset of what actually ships. Sixteen plugins are active in `_config.yml`, but the section never mentioned **search, comments, newsletter, citations, image tools, icons, tabs or typograms** — a reader had no way to know those existed.

Replaced the flat list of fourteen subsections with a table mapping each feature to its owning plugin and its configuration entry point, then four grouped visual sections. That removes eight repetitions of *"For details, see X in docs/CUSTOMIZE.md"* and ties the feature list to the v1 ownership model, so it's obvious which repo a given behavior lives in.

Also in here:

- **Moved "Code quality checks" under Contributing**, where it belongs — it describes CI for contributors, not a feature of the theme — and brought it up to date with the style contract, integration tests and visual regression.
- **Fixed two demo links pointing at posts that don't exist** (`blog/2020/plotly`, `blog/2024/image-galleries`). All eleven demo links in the section are now verified against a local build; the real paths are `blog/2025/plotly` and `blog/2024/advanced-images`.
- Rebuilt the table of contents.

## After merge

Dispatch **Update README screenshots** and the images regenerate against the live theme. I can run that as soon as this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_