### PR TITLE
fix: make the screenshot workflow actually build the site

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -55,6 +55,12 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
 
+      - name: Setup Python 🐍
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
       - name: Setup Node 🟩
         uses: actions/setup-node@v4
         with:
@@ -72,11 +78,22 @@ jobs:
         # name and serve its parent — otherwise every absolute asset URL 404s.
         run: |
           set -euo pipefail
+          # Same toolchain deploy.yml installs. Without ImageMagick the responsive
+          # variants are never generated and every srcset entry 404s; without
+          # nbconvert (which brings the `jupyter` CLI) the notebook post aborts
+          # the whole build. Both would otherwise surface as a broken-looking
+          # theme in the screenshots rather than as an obvious CI failure.
+          sudo apt-get update && sudo apt-get install -y imagemagick
+          pip3 install --upgrade nbconvert
+
           # jekyll-imagemagick's generator calls a non-recursive Dir.mkdir on the
           # destination, so a two-level path fails with ENOENT unless the parent
           # already exists. Jekyll alone would have created it, but the generator
           # runs first.
           mkdir -p _screenshot_site/al-folio
+
+          # Production matches what visitors see, which is what the README depicts.
+          export JEKYLL_ENV=production
           bundle exec jekyll build --destination _screenshot_site/al-folio
 
       - name: Serve and capture 📸

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -72,6 +72,11 @@ jobs:
         # name and serve its parent — otherwise every absolute asset URL 404s.
         run: |
           set -euo pipefail
+          # jekyll-imagemagick's generator calls a non-recursive Dir.mkdir on the
+          # destination, so a two-level path fails with ENOENT unless the parent
+          # already exists. Jekyll alone would have created it, but the generator
+          # runs first.
+          mkdir -p _screenshot_site/al-folio
           bundle exec jekyll build --destination _screenshot_site/al-folio
 
       - name: Serve and capture 📸

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -99,7 +99,10 @@ jobs:
       - name: Serve and capture 📸
         run: |
           set -euo pipefail
-          python3 -m http.server 4000 --directory _screenshot_site &
+          # Silence the access log: it emits a line per asset per page, which
+          # buries the capture script's own OK/WARN output and makes a failed
+          # run undiagnosable.
+          python3 -m http.server 4000 --directory _screenshot_site >/dev/null 2>&1 &
           server=$!
           trap 'kill $server' EXIT
           for i in $(seq 1 30); do


### PR DESCRIPTION
The first real run of `update-screenshots.yml` failed. Three separate bugs, all mine, found by running it rather than reasoning about it.

**The screenshots are already refreshed on `main`** (`8b9c8be9`) — I dispatched the fixed workflow from this branch, which checks out `main` for content, so only the workflow definition came from here. This PR makes those fixes permanent.

## 1. The build never started

```
jekyll-imagemagick/generator.rb:35:in `mkdir': No such file or directory
  @ dir_s_mkdir - .../_screenshot_site/al-folio (Errno::ENOENT)
```

`jekyll-imagemagick` calls a **non-recursive** `Dir.mkdir` from a generator, which runs before Jekyll would have created the tree itself. The destination here is two levels deep — `_screenshot_site` exists only to hold an `al-folio` directory so the `/al-folio` baseurl resolves when served — so it hit a missing parent. A normal build never trips this because `_site` is one level under an existing root. `mkdir -p`.

## 2. Two missing build dependencies

```
Conversion error: JekyllJupyterNotebook ... 'assets/jupyter/blog.ipynb':
  No such file or directory - jupyter
Imagemagick: Command returned pid 3178 exit 127 ... sh: 1: convert: not found
```

The jupyter one is fatal. **ImageMagick is only a warning, which is worse**: the build would have "succeeded" while generating zero responsive variants, so every `srcset` entry 404s and the screenshots come out with missing images — exactly the degraded capture this workflow exists to prevent, arriving through the back door.

`deploy.yml` already installs both and is green on every push to `main`, so this mirrors it rather than inventing a second recipe: `actions/setup-python`, `apt-get install imagemagick`, `pip3 install nbconvert` (which brings the `jupyter` CLI). Also exports `JEKYLL_ENV=production` to match — the README should depict what visitors actually see.

## 3. The logs were unreadable

`python3 -m http.server` logs a line per asset per page across fourteen pages, which buried the capture script's own `OK`/`WARN` output and made the first failure impossible to diagnose without pulling the entire log. Redirected to `/dev/null`.

## What the asset guard caught

With the build fixed, 12 of 14 shots came back clean. The other two failed the check, and **both are real breakage on the live demo site, not capture problems**:

- **`repositories`** — all 12 trophy images return **HTTP 402 Payment Required** from `github-profile-trophy.vercel.app`. The repo cards (github-stats-extended) load fine; it's only the trophy row.
- **`distill`** — `stamen-tiles.a.ssl.fastly.net` returns `ERR_FAILED`. Stamen retired that tile endpoint; the Leaflet map in the demo post is dead.

So the 12 good shots are refreshed and those two deliberately still show their January state rather than shipping a screenshot of a broken page. Both need their own fix (the trophy service is `al_folio_core`'s `repo_trophies.liquid`; the tiles are demo content) — worth filing separately.

⚠️ One consequence: until those are fixed, a full `shots: ""` run will always exit non-zero. That's the guard working correctly, but it means the post-release auto-refresh will fail. Options are fixing the two upstreams, or allowlisting known-degraded third-party origins as warn-only. I'd rather fix the upstreams — happy to take that on.

## Verified

Four dispatched runs, each isolating one failure, ending in a green run that committed 12 refreshed PNGs to `main`. Spot-checked the committed `light.png`: correct Roboto webfont, real emoji, and the FontAwesome search/theme icons present — all three of which were missing or broken in the captures I attempted locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_