### PR TITLE
feat: bundle al_rtl, al_email_protect and al_marimo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,13 +40,13 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.13'
+    gem 'al_folio_core', '= 1.0.14'
     gem 'al_icons', '= 1.0.0'
     gem 'al_folio_cv', '= 1.0.2'
     gem 'al_folio_distill', '= 1.0.3'
     gem 'al_folio_upgrade', '= 1.0.3'
     gem 'al_folio_bootstrap_compat', '= 1.0.0'
-    gem 'al_cookie', '= 1.0.0'
+    gem 'al_cookie', '= 1.0.1'
 
     gem 'al_analytics', '= 1.0.2'
     gem 'al_citations', '= 1.0.1'
@@ -57,4 +57,8 @@ group :al_folio_plugins do
     gem 'al_math', '= 1.0.2'
     gem 'al_comments', '= 1.0.0'
     gem 'al_newsletter', '= 1.0.0'
+
+    gem 'al_email_protect', '= 1.0.0'
+    gem 'al_marimo', '= 1.0.0'
+    gem 'al_rtl', '= 1.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,10 @@ GEM
     al_comments (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_cookie (1.0.0)
+    al_cookie (1.0.1)
+      jekyll (>= 3.9, < 5.0)
+      liquid (>= 4.0, < 6.0)
+    al_email_protect (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_ext_posts (1.0.3)
@@ -47,7 +50,7 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.13)
+    al_folio_core (1.0.14)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_cv (1.0.2)
@@ -66,10 +69,16 @@ GEM
     al_img_tools (1.0.3)
       jekyll (>= 3.9, < 5.0)
       jekyll-3rd-party-libraries (~> 0.0.1)
+    al_marimo (1.0.0)
+      jekyll (>= 3.9, < 5.0)
+      liquid (>= 4.0, < 6.0)
     al_math (1.0.2)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_newsletter (1.0.0)
+      jekyll (>= 3.9, < 5.0)
+      liquid (>= 4.0, < 6.0)
+    al_rtl (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_search (1.0.3)
@@ -349,17 +358,20 @@ DEPENDENCIES
   al_charts (= 1.0.1)
   al_citations (= 1.0.1)
   al_comments (= 1.0.0)
-  al_cookie (= 1.0.0)
+  al_cookie (= 1.0.1)
+  al_email_protect (= 1.0.0)
   al_ext_posts (= 1.0.3)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.13)
+  al_folio_core (= 1.0.14)
   al_folio_cv (= 1.0.2)
   al_folio_distill (= 1.0.3)
   al_folio_upgrade (= 1.0.3)
   al_icons (= 1.0.0)
   al_img_tools (= 1.0.3)
+  al_marimo (= 1.0.0)
   al_math (= 1.0.2)
   al_newsletter (= 1.0.0)
+  al_rtl (= 1.0.0)
   al_search (= 1.0.3)
   classifier-reborn
   css_parser
@@ -394,17 +406,20 @@ CHECKSUMS
   al_charts (1.0.1) sha256=ce26374c2b1159ae0d65dc7999730be700a9ee486002ae14cb480eef70580885
   al_citations (1.0.1) sha256=308cfd4cd73c8dc6d24c0214f424b61606b3a393bdb899394fce80dd647cba59
   al_comments (1.0.0) sha256=1da87a29b55e4d9fd62d380200af9671f10ae4a84e3259828588498d8f3210e5
-  al_cookie (1.0.0) sha256=0b36310f84c88e758fb18f2217e8fca8a282b8bd7f5ee9793c6d38ca0cc97348
+  al_cookie (1.0.1) sha256=2420241497b1fb165311ba1c9e059a9025586925b65dbba429aee225bd91a67f
+  al_email_protect (1.0.0) sha256=539c483657e35ee0b49197b7149df2584ee02fd2282efbf5ac190bf78bb78f26
   al_ext_posts (1.0.3) sha256=c4956d36071958d30de14f6c368863d3e4190dfe312dba08ff79aa685292420d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.13) sha256=e54b861713b949d5f7780ab094042ebcbe6e04e3da163d9bdf15f52cc48bebc2
+  al_folio_core (1.0.14) sha256=22c9b53563c33556697dddc55952bc000eb51f554a651140d0a9b9ac99b39c68
   al_folio_cv (1.0.2) sha256=d9b8d3624c0c707a04deaa41972fa88395fa164419bccc44e2dc2488400022fa
   al_folio_distill (1.0.3) sha256=3feb669dd669effec127e1be5385158c5f98062c510980b5c9c802227ec2c247
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709
   al_icons (1.0.0) sha256=7a7b6428d18e77b039aa1ae765a3faed0ae27cb646a08c1009b145c31ca5ef2d
   al_img_tools (1.0.3) sha256=c50dfa206bb4459925cbfc0e7d03b326e7cb1c282200d5d110b6595f4d661cf7
+  al_marimo (1.0.0) sha256=bbd8ce9650c7e8a3b35cbbde8d98eba983f132647f316b3ba2a9bd8abf502434
   al_math (1.0.2) sha256=c9fa6f3e343c0d35782d77fe386461ceff7d12186d9b51e6c92bb186b3d60781
   al_newsletter (1.0.0) sha256=27c914f5fcd0c7fac51a513ab11de7123f05de7ba834206a68ddf2588ede96d3
+  al_rtl (1.0.0) sha256=dffed3cb05acf0e4f96e7ee2d51cb05fc83a428e0d5e4d697c5da4b7c3fe0f0b
   al_search (1.0.3) sha256=70e846081b57a3494dd41e6bc8e1af13997200c5c28744f2449a8ebe07f79a8a
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c

--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,8 @@ repo_theme_light: default # https://github.com/stats-organization/github-stats-e
 repo_theme_dark: dark # https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md
 # Off by default: addresses are then split at build time so the HTML contains no
 # `user@host` and no `mailto:` for harvesters to scrape, and clicking one copies
-# it to the clipboard instead of opening a mail client. See docs/CUSTOMIZE.md.
+# it to the clipboard instead of opening a mail client.
+# See "Protecting email addresses from scrapers" in docs/CUSTOMIZE.md.
 protect_email: false
 
 # Off by default: the free public github-profile-trophy instance is disabled

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,11 @@ back_to_top: true # set to false to disable the back to top button
 # repo color theme
 repo_theme_light: default # https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md
 repo_theme_dark: dark # https://github.com/stats-organization/github-stats-extended/blob/master/packages/core/src/themes/README.md
+# Off by default: addresses are then split at build time so the HTML contains no
+# `user@host` and no `mailto:` for harvesters to scrape, and clicking one copies
+# it to the clipboard instead of opening a mail client. See docs/CUSTOMIZE.md.
+protect_email: false
+
 # Off by default: the free public github-profile-trophy instance is disabled
 # (its Vercel deployment answers HTTP 402 / DEPLOYMENT_DISABLED), so every trophy
 # image 404s. The project itself is still open source and free — self-host it and
@@ -292,6 +297,9 @@ plugins:
   - al_math
   - al_comments
   - al_newsletter
+  - al_email_protect
+  - al_marimo
+  - al_rtl
 
 # Sitemap settings
 defaults:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,23 +76,26 @@ What breaks the site is **blanking the baseurl out** — build with an empty bas
 
 `al_folio_core` is the hub: `_config.yml` sets `theme: al_folio_core`, and the gem ships every base `_layouts/*.liquid` and `_includes/*.liquid`, the base theme JS/CSS, the `details` and `file_exists` tags, and the `hideCustomBibtex` and `remove_accents` filters. Its `_includes/plugins/*.liquid` wrappers delegate to tags owned by sibling gems:
 
-| Wrapper / call site       | Liquid tag                                          | Owning gem                                                                     |
-| ------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
-| search assets             | `al_search_assets`                                  | `al_search` (Cmd-K ninja-keys palette; index built at build time from content) |
-| comments                  | `al_comments`                                       | `al_comments` (Giscus + Disqus, front-matter gated)                            |
-| cookie banner             | `al_cookie_styles` / `al_cookie_scripts`            | `al_cookie` (consent-mode gating of analytics)                                 |
-| icon `<link>`s            | `al_icons_styles`                                   | `al_icons` (FontAwesome/Academicons/Scholar Icons from CDN)                    |
-| analytics                 | `al_analytics_scripts`                              | `al_analytics` (GA/Cronitor/Pirsch/OpenPanel)                                  |
-| math                      | `al_math_styles` / `al_math_scripts`                | `al_math` (MathJax, pseudocode.js, TikZJax)                                    |
-| charts                    | `al_charts_scripts`                                 | `al_charts` (Mermaid/Chart.js/ECharts/Plotly/Vega/Leaflet/diff2html)           |
-| image tools               | `al_img_tools_styles` / `al_img_tools_scripts`      | `al_img_tools` (zoom, lightbox, sliders, galleries)                            |
-| newsletter                | `al_newsletter_form` / `al_newsletter_scripts`      | `al_newsletter` (Loops.so signup)                                              |
-| `layout: cv`              | `al_folio_cv_render`                                | `al_folio_cv` (RenderCV YAML + JSONResume)                                     |
-| `layout: distill`         | `al_folio_distill_render`                           | `al_folio_distill` (vendored, hash-pinned distillpub runtime)                  |
-| citation badges           | `google_scholar_citations` / `inspirehep_citations` | `al_citations`                                                                 |
-| external posts            | (generator, no tag)                                 | `al_ext_posts` (RSS/URL ingestion into synthetic posts)                        |
-| legacy Bootstrap behavior | (opt-in assets)                                     | `al_folio_bootstrap_compat`                                                    |
-| upgrade/audit CLI         | `bundle exec al-folio …`                            | `al_folio_upgrade`                                                             |
+| Wrapper / call site       | Liquid tag                                                   | Owning gem                                                                     |
+| ------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| search assets             | `al_search_assets`                                           | `al_search` (Cmd-K ninja-keys palette; index built at build time from content) |
+| comments                  | `al_comments`                                                | `al_comments` (Giscus + Disqus, front-matter gated)                            |
+| cookie banner             | `al_cookie_styles` / `al_cookie_scripts`                     | `al_cookie` (consent-mode gating of analytics)                                 |
+| icon `<link>`s            | `al_icons_styles`                                            | `al_icons` (FontAwesome/Academicons/Scholar Icons from CDN)                    |
+| analytics                 | `al_analytics_scripts`                                       | `al_analytics` (GA/Cronitor/Pirsch/OpenPanel)                                  |
+| math                      | `al_math_styles` / `al_math_scripts`                         | `al_math` (MathJax, pseudocode.js, TikZJax)                                    |
+| charts                    | `al_charts_scripts`                                          | `al_charts` (Mermaid/Chart.js/ECharts/Plotly/Vega/Leaflet/diff2html)           |
+| image tools               | `al_img_tools_styles` / `al_img_tools_scripts`               | `al_img_tools` (zoom, lightbox, sliders, galleries)                            |
+| newsletter                | `al_newsletter_form` / `al_newsletter_scripts`               | `al_newsletter` (Loops.so signup)                                              |
+| `<html>` attributes       | `al_rtl_html_attrs` / `al_rtl_styles`                        | `al_rtl` (page `lang` in an RTL script; `al_rtl.langs` overrides the set)      |
+| email addresses           | `al_email_protect_styles` / `al_email_protect_scripts`       | `al_email_protect` (site `protect_email: true`)                                |
+| marimo notebooks          | `al_marimo_styles` / `al_marimo_scripts` / `al_marimo_embed` | `al_marimo` (page `marimo: true`)                                              |
+| `layout: cv`              | `al_folio_cv_render`                                         | `al_folio_cv` (RenderCV YAML + JSONResume)                                     |
+| `layout: distill`         | `al_folio_distill_render`                                    | `al_folio_distill` (vendored, hash-pinned distillpub runtime)                  |
+| citation badges           | `google_scholar_citations` / `inspirehep_citations`          | `al_citations`                                                                 |
+| external posts            | (generator, no tag)                                          | `al_ext_posts` (RSS/URL ingestion into synthetic posts)                        |
+| legacy Bootstrap behavior | (opt-in assets)                                              | `al_folio_bootstrap_compat`                                                    |
+| upgrade/audit CLI         | `bundle exec al-folio …`                                     | `al_folio_upgrade`                                                             |
 
 ## How feature gems ship their assets
 

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -36,6 +36,9 @@ Use this table before opening or reviewing a PR:
 | Math/TikZ runtime integration                                                                                         | `al-org-dev/al-math` / `al_math`                                     |
 | Chart runtime integration                                                                                             | `al-org-dev/al-charts` / `al_charts`                                 |
 | Newsletter form integration                                                                                           | `al-org-dev/al-newsletter` / `al_newsletter`                         |
+| Right-to-left languages: document direction, RTL styling                                                              | `al-org-dev/al-rtl` / `al_rtl`                                       |
+| Email obfuscation and click-to-copy addresses                                                                         | `al-org-dev/al-email-protect` / `al_email_protect`                   |
+| marimo notebook embeds and runnable Python snippets                                                                   | `al-org-dev/al-marimo` / `al_marimo`                                 |
 
 Local site overrides are still valid **in your own site**. A site created from this template may define `_layouts/<name>.liquid`, `_includes/<path>.liquid`, `_sass/*.scss`, or site-specific plugins when the customization is only for that site. Shared runtime fixes should be ported to the owning plugin instead.
 

--- a/docs/CUSTOMIZE.md
+++ b/docs/CUSTOMIZE.md
@@ -29,6 +29,7 @@ Here we will give you some tips on how to customize the website. One important t
     - [Automatic PDF Generation (RenderCV only)](#automatic-pdf-generation-rendercv-only)
   - [Modifying the user and repository information](#modifying-the-user-and-repository-information)
     - [Configuring external service URLs](#configuring-external-service-urls)
+    - [Protecting email addresses from scrapers](#protecting-email-addresses-from-scrapers)
     - [Why trophies are off by default](#why-trophies-are-off-by-default)
       - [Migrating from github-readme-stats](#migrating-from-github-readme-stats)
   - [Creating new pages](#creating-new-pages)
@@ -409,6 +410,40 @@ The repository page uses external services to display GitHub statistics and trop
 
 - `github-stats-extended.vercel.app` for user stats and repository cards — **on by default**
 - `github-profile-trophy.vercel.app` for GitHub profile trophies — **off by default**
+
+### Protecting email addresses from scrapers
+
+Set `protect_email: true` in `_config.yml` (default `false`, provided by the `al_email_protect` plugin):
+
+```yaml
+protect_email: true
+```
+
+With it on, addresses are **never emitted as addresses**. The built HTML contains no `user@host` string and no
+`mailto:` target — the two halves are carried in separate attributes and rejoined by the browser when a visitor clicks,
+which copies the address to the clipboard and shows a brief confirmation instead of opening a mail client.
+
+The build-time part is the point. An implementation that ships the plaintext and rewrites it after `DOMContentLoaded`
+protects nobody, because harvesters parse markup and do not run your JavaScript.
+
+Two behaviours worth knowing:
+
+- A value that is not a usable address (no dot in the domain, for instance) renders as an ordinary `mailto:` link
+  rather than being mangled — publishing a broken contact address is worse than publishing an unprotected one.
+- `navigator.clipboard` is unavailable outside a secure context, so over plain HTTP the runtime falls back to a hidden
+  textarea copy, and if that fails too it shows the address so it can be copied by hand.
+
+In your own layouts:
+
+```liquid
+{% al_email_protect_link site.data.socials.email %}
+```
+
+renders a click-to-copy element when enabled and a plain `mailto:` link when disabled, so it is safe to call
+unconditionally. For an address shown as text rather than a link, `{{ cv.email | al_email_obfuscate }}` gives
+`someone [at] example [dot] com`.
+
+See [al-org-dev/al-email-protect](https://github.com/al-org-dev/al-email-protect) for the full reference.
 
 ### Why trophies are off by default
 


### PR DESCRIPTION
Wires up the three plugins built for the standing proposals — [#3544](https://github.com/alshedivat/al-folio/issues/3544) `al_rtl`, [#3540](https://github.com/alshedivat/al-folio/issues/3540) `al_email_protect`, [#3541](https://github.com/alshedivat/al-folio/issues/3541) `al_marimo` — now published at 1.0.0.

Also picks up two releases:

| gem | | why |
| --- | --- | --- |
| `al_folio_core` | 1.0.13 → **1.0.14** | the plugin invocation hooks; without these the three gems load but their tags are never called |
| `al_cookie` | 1.0.0 → **1.0.1** | its runtime was published to `/lib/assets/…` while the script tag pointed at `/assets/…`, so it **404'd on every site with cookie consent enabled**. Hidden by the feature being off by default. |

Both lists are edited — the `Gemfile` group *and* `_config.yml`'s `plugins:` — since a plugin present in only one of them is inert.

## All three ship off

- **`al_rtl`** — activates only on a page whose `lang` is a right-to-left script. No config needed; `al_rtl.langs` overrides the default set.
- **`al_marimo`** — only on a page with `marimo: true` in front matter.
- **`al_email_protect`** — only under the new `protect_email` key, defaulting to `false`.

Verified against a real build of this site: `<html lang="en">` unchanged, `mailto:` links untouched, and **zero** references to any of the three in the output. Bundling them costs nothing until a page opts in.

## On the lockfile

`Gemfile.lock` checksums were verified against the **published** `.gem` artifacts, not the local builds — all five match byte-for-byte. Worth stating because an earlier release in this series shipped a lock whose `CHECKSUMS` lacked `sha256=`: Bundler had reused a locally installed copy instead of downloading, which fails every CI job at "Setup Ruby" with no obvious cause.

## What is deliberately not here

No demo content. Each plugin's upstream PR shipped example posts, and those are worth having so the features are discoverable and so CI actually renders them — but that is a content change with its own review surface, and I would rather it not ride along with a dependency bump. Happy to follow up, and I think it should gate a v1.2 tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_