### PR TITLE
deps: adopt al_folio_core 1.0.15 (theme-switch flicker fix)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 # Gems for al-folio plugins
 group :al_folio_plugins do
-    gem 'al_folio_core', '= 1.0.14'
+    gem 'al_folio_core', '= 1.0.15'
     gem 'al_icons', '= 1.0.0'
     gem 'al_folio_cv', '= 1.0.2'
     gem 'al_folio_distill', '= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     al_folio_bootstrap_compat (1.0.0)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
-    al_folio_core (1.0.14)
+    al_folio_core (1.0.15)
       jekyll (>= 3.9, < 5.0)
       liquid (>= 4.0, < 6.0)
     al_folio_cv (1.0.2)
@@ -362,7 +362,7 @@ DEPENDENCIES
   al_email_protect (= 1.0.0)
   al_ext_posts (= 1.0.3)
   al_folio_bootstrap_compat (= 1.0.0)
-  al_folio_core (= 1.0.14)
+  al_folio_core (= 1.0.15)
   al_folio_cv (= 1.0.2)
   al_folio_distill (= 1.0.3)
   al_folio_upgrade (= 1.0.3)
@@ -410,7 +410,7 @@ CHECKSUMS
   al_email_protect (1.0.0) sha256=539c483657e35ee0b49197b7149df2584ee02fd2282efbf5ac190bf78bb78f26
   al_ext_posts (1.0.3) sha256=c4956d36071958d30de14f6c368863d3e4190dfe312dba08ff79aa685292420d
   al_folio_bootstrap_compat (1.0.0) sha256=c210ff3087f17344dc864fa9594c737e947b23c6cae9fab3dbd37a87090b98a8
-  al_folio_core (1.0.14) sha256=22c9b53563c33556697dddc55952bc000eb51f554a651140d0a9b9ac99b39c68
+  al_folio_core (1.0.15) sha256=eee5d0afefab5d3e8747b615890d760ed0ab01a1210991118709c4e969ad1326
   al_folio_cv (1.0.2) sha256=d9b8d3624c0c707a04deaa41972fa88395fa164419bccc44e2dc2488400022fa
   al_folio_distill (1.0.3) sha256=3feb669dd669effec127e1be5385158c5f98062c510980b5c9c802227ec2c247
   al_folio_upgrade (1.0.3) sha256=434ffddb27705852eae0bcaa01a8d007e0ef65472a989d1a33ae759f910f4709


### PR DESCRIPTION
Picks up [al-folio-core#39](https://github.com/al-org-dev/al-folio-core/pull/39) — the theme-switch flicker fix — now published as 1.0.15.

Without this the fix is merged in core but invisible here, since the `Gemfile` pins an exact release.

**What it fixes:** `color`, `fill` and `stroke` are inherited properties but were transitioned on `html.transition *`, so every inheriting element ran its own 240ms ease toward a parent still animating — text converged in waves, deeper elements landing last, then snapping. Measured on the about page: an `h2 > a` at `rgb(50,50,50)` while the paragraph beside it was already at `rgb(130,130,130)`. Also fixes a `transition-delay: 0` the CSS parser was silently dropping (`<time>` needs a unit even for zero), and widens the 20ms margin that let a slow frame truncate the transition into a snap.

`Gemfile.lock` checksum verified against the published `.gem`, and I confirmed the installed gem actually carries all three changes rather than trusting the version number.

`prettier` and `lint:style-contract` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5uhLakE68MtxJhRxpYL7C)_